### PR TITLE
List compatible/incompatible post types in site health

### DIFF
--- a/src/Component/Post/DisplayPlayer/DisplayPlayer.php
+++ b/src/Component/Post/DisplayPlayer/DisplayPlayer.php
@@ -30,7 +30,7 @@ class DisplayPlayer
     public function init()
     {
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {

--- a/src/Component/Post/GenerateAudio/GenerateAudio.php
+++ b/src/Component/Post/GenerateAudio/GenerateAudio.php
@@ -31,7 +31,7 @@ class GenerateAudio
     public function init()
     {
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {

--- a/src/Component/Post/Metabox/Metabox.php
+++ b/src/Component/Post/Metabox/Metabox.php
@@ -77,7 +77,7 @@ class Metabox
      */
     public function addMetaBox($postType)
     {
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (is_array($postTypes) && ! in_array($postType, $postTypes)) {
             return;

--- a/src/Component/Post/Panel/Inspect/Inspect.php
+++ b/src/Component/Post/Panel/Inspect/Inspect.php
@@ -33,7 +33,7 @@ class Inspect
         add_filter('default_hidden_meta_boxes', array($this, 'hideMetaBox'));
 
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {
@@ -90,7 +90,7 @@ class Inspect
      */
     public function addMetaBox($postType)
     {
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (is_array($postTypes) && ! in_array($postType, $postTypes)) {
             return;

--- a/src/Component/Post/PlayerStyle/PlayerStyle.php
+++ b/src/Component/Post/PlayerStyle/PlayerStyle.php
@@ -35,7 +35,7 @@ class PlayerStyle
         add_action('rest_api_init', array($this, 'restApiInit'));
 
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {

--- a/src/Component/Post/SelectVoice/SelectVoice.php
+++ b/src/Component/Post/SelectVoice/SelectVoice.php
@@ -54,7 +54,7 @@ class SelectVoice
         add_action('admin_enqueue_scripts', array($this, 'adminEnqueueScripts'));
 
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {

--- a/src/Component/Post/Sidebar/Sidebar.php
+++ b/src/Component/Post/Sidebar/Sidebar.php
@@ -40,7 +40,7 @@ class Sidebar
         if (CoreUtils::isGutenbergPage()) {
             $postType = get_post_type();
 
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (in_array($postType, $postTypes)) {
                 // Register the Block Editor "Sidebar" CSS

--- a/src/Component/Posts/BulkEdit/BulkEdit.php
+++ b/src/Component/Posts/BulkEdit/BulkEdit.php
@@ -38,7 +38,7 @@ class BulkEdit
         add_action('wp_ajax_save_bulk_edit_beyondwords', array($this, 'saveBulkEdit'));
 
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {
@@ -59,7 +59,7 @@ class BulkEdit
             return;
         }
 
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (! in_array($postType, $postTypes)) {
             return;

--- a/src/Component/Posts/Column/Column.php
+++ b/src/Component/Posts/Column/Column.php
@@ -38,7 +38,7 @@ class Column
     public function init()
     {
         add_action('wp_loaded', function () {
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (is_array($postTypes)) {
                 foreach ($postTypes as $postType) {
@@ -81,7 +81,7 @@ class Column
             return;
         }
 
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (empty($postTypes)) {
             return;

--- a/src/Component/Settings/Preselect/Preselect.php
+++ b/src/Component/Settings/Preselect/Preselect.php
@@ -87,7 +87,7 @@ class Preselect
      **/
     public function render()
     {
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (! is_array($postTypes) || count($postTypes) === 0) :
             ?>

--- a/src/Component/SiteHealth/SiteHealth.php
+++ b/src/Component/SiteHealth/SiteHealth.php
@@ -127,15 +127,14 @@ class SiteHealth
             'value' => wp_json_encode(get_option('beyondwords_preselect')),
         ];
 
-        // translators: Tab heading for Site Health navigation.
-        $info['beyondwords']['fields']['allowed-post-types'] = [
-            'label' => __('Allowed post types', 'speechkit'),
-            'value' => implode(', ', SettingsUtils::getAllowedPostTypes()),
+        $info['beyondwords']['fields']['compatible-post-types'] = [
+            'label' => __('Compatible post types', 'speechkit'),
+            'value' => implode(', ', SettingsUtils::getCompatiblePostTypes()),
         ];
 
-        $info['beyondwords']['fields']['supported-post-types'] = [
-            'label' => __('Supported post types', 'speechkit'),
-            'value' => implode(', ', SettingsUtils::getSupportedPostTypes()),
+        $info['beyondwords']['fields']['incompatible-post-types'] = [
+            'label' => __('Incompatible post types', 'speechkit'),
+            'value' => implode(', ', SettingsUtils::getIncompatiblePostTypes()),
         ];
 
         $info['beyondwords']['fields']['beyondwords_settings_updated'] = [

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -265,7 +265,7 @@ class Core
         if (CoreUtils::isGutenbergPage()) {
             $postType = get_post_type();
 
-            $postTypes = SettingsUtils::getSupportedPostTypes();
+            $postTypes = SettingsUtils::getCompatiblePostTypes();
 
             if (in_array($postType, $postTypes, true)) {
                 $assetFile = include BEYONDWORDS__PLUGIN_DIR . 'build/index.asset.php';
@@ -307,7 +307,7 @@ class Core
      **/
     public function registerMeta()
     {
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         if (is_array($postTypes)) {
             $keys = CoreUtils::getPostMetaKeys('all');
@@ -511,7 +511,7 @@ class Core
             ],
         ]);
 
-        $beyondwordsPostTypes = SettingsUtils::getSupportedPostTypes();
+        $beyondwordsPostTypes = SettingsUtils::getCompatiblePostTypes();
 
         $graphqlPostTypes = \WPGraphQL::get_allowed_post_types();
 

--- a/tests/phpunit/Component/SiteHealthTest.php
+++ b/tests/phpunit/Component/SiteHealthTest.php
@@ -66,8 +66,8 @@ class SiteHealthTest extends WP_UnitTestCase
         $this->assertArrayHasKey('beyondwords_preselect', $info['beyondwords']['fields']);
         $this->assertArrayHasKey('beyondwords_settings_updated', $info['beyondwords']['fields']);
 
-        $this->assertArrayHasKey('allowed-post-types', $info['beyondwords']['fields']);
-        $this->assertArrayHasKey('supported-post-types', $info['beyondwords']['fields']);
+        $this->assertArrayHasKey('compatible-post-types', $info['beyondwords']['fields']);
+        $this->assertArrayHasKey('incompatible-post-types', $info['beyondwords']['fields']);
 
         $this->assertArrayHasKey('registered-filters', $info['beyondwords']['fields']);
         $this->assertArrayHasKey('registered-deprecated-filters', $info['beyondwords']['fields']);

--- a/tests/phpunit/Settings/SettingsUtilsTest.php
+++ b/tests/phpunit/Settings/SettingsUtilsTest.php
@@ -41,9 +41,13 @@ class SettingsUtilsTest extends WP_UnitTestCase
         $this->assertContains('attachment', $postTypes);
         $this->assertContains('revision', $postTypes);
 
-        // Set the filter to only return array key 1 ("page")
+        // Set the filter
         $filter = function($supportedPostTypes) {
-            return [$supportedPostTypes[1], 'attachment'];
+            return [
+                $supportedPostTypes[1],
+                $supportedPostTypes[0],
+                'another-post-type',
+            ];
         };
 
         add_filter('beyondwords_settings_post_types', $filter);
@@ -52,6 +56,6 @@ class SettingsUtilsTest extends WP_UnitTestCase
 
         remove_filter('beyondwords_settings_post_types', $filter);
 
-        $this->assertSame(['page'], $postTypes);
+        $this->assertSame(['page', 'post', 'another-post-type'], $postTypes);
     }
 }

--- a/tests/phpunit/Settings/SettingsUtilsTest.php
+++ b/tests/phpunit/Settings/SettingsUtilsTest.php
@@ -32,7 +32,7 @@ class SettingsUtilsTest extends WP_UnitTestCase
     /**
      * @test
      */
-    public function getSupportedPostTypesFilter()
+    public function getCompatiblePostTypesFilter()
     {
         $postTypes = array_values(get_post_types());
 
@@ -48,7 +48,7 @@ class SettingsUtilsTest extends WP_UnitTestCase
 
         add_filter('beyondwords_settings_post_types', $filter);
 
-        $postTypes = SettingsUtils::getSupportedPostTypes();
+        $postTypes = SettingsUtils::getCompatiblePostTypes();
 
         remove_filter('beyondwords_settings_post_types', $filter);
 


### PR DESCRIPTION
In Site Health we have renamed some labels so that they are simpler to understand. Associated PHP functions have been renamed too.

We now use the labels:

- Compatible post types
- Incompatible post types

Anyone attempting to use our plugin with an incompatible post type should first check whether the post type supports custom fields, and add support if it doesn't.