### PR TITLE
Critical JS error in Classic Editor if API Key and Project ID are empty.

### DIFF
--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -265,9 +265,16 @@ class Core
 
     /**
      * Enqueue Core (built & minified) JS for Block Editor.
+     *
+     * @since 3.0.0
+     * @since 4.5.1 Disable plugin features if we don't have valid API settings.
      */
     public function enqueueBlockEditorAssets()
     {
+        if (! SettingsUtils::hasApiSettings()) {
+            return;
+        }
+
         if (CoreUtils::isGutenbergPage()) {
             $postType = get_post_type();
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -65,48 +65,57 @@ class Plugin
 
     /**
      * Constructor.
+     *
+     * @since 3.0.0
+     * @since 4.5.1 Disable plugin features if we don't have valid API settings.
      */
     public function init()
     {
-        // First, run plugin update checks
+        // Run plugin update checks before anything else
         (new Updater())->run();
 
-        // Elementor
+        // Elementor compatibility
         (new Elementor())->init();
 
-        // 1. Core
+        // Core
         $this->core = new Core($this->apiClient);
         $this->core->init();
 
-        // 2. Player
+        // Site health
+        (new SiteHealth())->init();
+
+        // Player
         if (SettingsUtils::useLegacyPlayer()) {
             (new LegacyPlayer())->init();
         } else {
             (new Player())->init();
         }
 
-        // 3. Settings
+        // Settings
         (new Settings($this->apiClient))->init();
 
-        // 4. Posts screen
-        (new Column())->init();
-        (new BulkEdit())->init();
-        (new BulkEditNotices())->init();
+        /**
+         * To prevent browser JS errors we skip adding admin UI components until
+         * we have a valid REST API connection.
+         */
+        if (SettingsUtils::hasApiSettings()) {
+            // Posts screen
+            (new BulkEdit())->init();
+            (new BulkEditNotices())->init();
+            (new Column())->init();
 
-        // 5. Post screen
-        (new AddPlayer())->init();
-        (new BlockAttributes())->init();
-        (new ErrorNotice())->init();
-        (new Inspect())->init();
+            // Post screen
+            (new AddPlayer())->init();
+            (new BlockAttributes())->init();
+            (new ErrorNotice())->init();
+            (new Inspect())->init();
 
-        // 6. Post screen Metabox
-        (new GenerateAudio())->init();
-        (new DisplayPlayer())->init();
-        (new SelectVoice($this->apiClient))->init();
-        (new PlayerStyle())->init();
-        (new Metabox($this->apiClient))->init();
-
-        // 7. Site Health
-        (new SiteHealth())->init();
+            // Post screen metabox
+            (new GenerateAudio())->init();
+            (new DisplayPlayer())->init();
+            (new SelectVoice($this->apiClient))->init();
+            (new PlayerStyle())->init();
+            (new Metabox($this->apiClient))->init();
+        }
     }
 }

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -142,9 +142,27 @@ class CoreTest extends WP_UnitTestCase
 
         $this->assertNotContains('beyondwords-block-js', $wp_scripts->queue);
 
+        /**
+         * Enqueuing without a valid API connection should do nothing
+         */
+        $core->enqueueBlockEditorAssets();
+
+        $this->assertNotContains('beyondwords-block-js', $wp_scripts->queue);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(DATE_ISO8601));
+
+        /**
+         * Enqueuing with a valid API connection should succeed
+         */
         $core->enqueueBlockEditorAssets();
 
         $this->assertContains('beyondwords-block-js', $wp_scripts->queue);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         wp_delete_post($post->ID, true);
     }


### PR DESCRIPTION
If a user installs the plugin and attempts to add a post in the Classic Editor without setting the **API Key** and **Project ID** in the plugin settings, then there is a critical JS error.

This happens because without valid API creds we currently attempt to make API calls for voices and languages with invalid (empty) REST API creds on post edit screens.

We should only really add UI components on post edit screens if we have a valid API connection.