### PR TITLE
Critical JS error in Block Editor if API calls fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "sort-packages": true
     },
     "scripts": {
-        "test:coverage-check": "./vendor/bin/coverage-check ./tests/phpunit/_output/clover.xml 65",
+        "test:coverage-check": "./vendor/bin/coverage-check ./tests/phpunit/_output/clover.xml 70",
         "test:phpunit": [
             "yarn wp-env run tests-cli --env-cwd=wp-content/plugins/speechkit ./vendor/bin/phpunit -c phpunit.xml",
             "@test:coverage-check"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "4.5.1-rc1",
+  "version": "4.5.1",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text to speech, text to audio, tts, speech synthesis, podcast, audio
-Stable tag: 4.5.0
+Stable tag: 4.5.1
 Requires PHP: 7.4
 Tested up to: 6.4
 License: GPLv2 or later
@@ -80,17 +80,22 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 == Changelog ==
 
-= 4.5.1-rc1 =
+= 4.5.1 =
 
 Release date: 14th March 2024
 
 **Enhancements**
 
-* Make BeyondWords column in WP admin sortable.
+* Make the BeyondWords column in WP admin sortable.
 
 **Fixes**
 
-* Fix a critical JS error in Classic Editor that was occurring when API requests for languages and voices were failing. We now handle failed REST API calls and only render plugin components on the Post edit screens if the REST API creds have been validated.
+* We now only render plugin components on the Post edit screens if the REST API credentials have been validated.
+* Improved handling for REST API calls that fail while editing posts. This fixes the following issues:
+    * The block editor crashed if the API Key and/or Project ID had not been entered in the plugin settings.
+    * The block editor crashed if REST API calls failed for other reasons e.g. network problems.
+    * The classic editor would display empty select boxes for related failed API calls.
+* Removed a console log intended for debugging.
 
 = 4.5.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -82,11 +82,15 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 = 4.5.1-rc1 =
 
-Release date: 7th March 2024
+Release date: 14th March 2024
 
 **Enhancements**
 
 * Make BeyondWords column in WP admin sortable.
+
+**Fixes**
+
+* Fix a critical JS error in Classic Editor that was occurring when API requests for languages and voices were failing. We now handle failed REST API calls and only render plugin components on the Post edit screens if the REST API creds have been validated.
 
 = 4.5.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,6 @@ Release date: 14th March 2024
 * Improved handling for REST API calls that fail while editing posts. This fixes the following issues:
     * The block editor crashed if the API Key and/or Project ID had not been entered in the plugin settings.
     * The block editor crashed if REST API calls failed for other reasons e.g. network problems.
-    * The classic editor would display empty select boxes for related failed API calls.
 * Removed a console log intended for debugging.
 
 = 4.5.0 =

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           4.5.1-rc1
+ * Version:           4.5.1
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '4.5.1-rc1');
+define('BEYONDWORDS__PLUGIN_VERSION', '4.5.1');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/Post/BlockAttributes/addControls.js
+++ b/src/Component/Post/BlockAttributes/addControls.js
@@ -38,7 +38,6 @@ const withBeyondwordsBlockControls = createHigherOrderComponent(
 			const { attributes, setAttributes } = props;
 
 			useEffect( () => {
-				console.log('!!! useEffect');
 				setAttributes( {
 					beyondwordsMarker: getBlockMarkerAttribute( attributes )
 				} );

--- a/src/Component/Post/PlayerStyle/PlayerStyle.php
+++ b/src/Component/Post/PlayerStyle/PlayerStyle.php
@@ -42,7 +42,14 @@ class PlayerStyle
     }
 
     /**
+     * HTML output for this component.
+     *
      * @since 4.1.0
+     * @since 4.5.1 Hide element if no language data exists.
+     *
+     * @param WP_Post $post The post object.
+     *
+     * @return string|null
      */
     public function element($post)
     {
@@ -50,6 +57,10 @@ class PlayerStyle
 
         $playerStyle = PostMetaUtils::getPlayerStyle($post->ID);
         $allPlayerStyles = PlayerStyleSetting::getCachedPlayerStyles($projectId);
+
+        if (! is_array($allPlayerStyles) || ! count($allPlayerStyles)) {
+            return;
+        }
 
         wp_nonce_field('beyondwords_player_style', 'beyondwords_player_style_nonce');
         ?>
@@ -68,7 +79,7 @@ class PlayerStyle
                     '<option value="%s" %s %s>%s</option>',
                     esc_attr($item['value']),
                     selected(strval($item['value']), $playerStyle),
-                    disabled($item['disabled'], true),
+                    disabled($item['disabled'] ?? false, true),
                     esc_html($item['label'])
                 );
             }

--- a/src/Component/Post/PlayerStyle/index.js
+++ b/src/Component/Post/PlayerStyle/index.js
@@ -42,6 +42,10 @@ export function PlayerStyle( { wrapper } ) {
 		} );
 	};
 
+	if (! playerStyles.length) {
+		return false;
+	}
+
 	return (
 		<Wrapper>
 			<Flex>

--- a/src/Component/Post/SelectVoice/SelectVoice.php
+++ b/src/Component/Post/SelectVoice/SelectVoice.php
@@ -86,13 +86,9 @@ class SelectVoice
             return;
         }
 
-        $voices = [];
+        $voices = $this->apiClient->getVoices($currentLanguageId);
 
-        if ($currentLanguageId) {
-            $voices = $this->apiClient->getVoices($currentLanguageId);
-        }
-
-        if (! is_array($voices) || ! count($voices)) {
+        if (! is_array($voices)) {
             $voices = [];
         }
 

--- a/src/Component/Post/SelectVoice/SelectVoice.php
+++ b/src/Component/Post/SelectVoice/SelectVoice.php
@@ -62,7 +62,14 @@ class SelectVoice
     }
 
     /**
+     * HTML output for this component.
+     *
      * @since 4.0.0
+     * @since 4.5.1 Hide element if no language data exists.
+     *
+     * @param WP_Post $post The post object.
+     *
+     * @return string|null
      */
     public function element($post)
     {
@@ -74,10 +81,19 @@ class SelectVoice
         $currentVoiceId = get_post_meta($post->ID, 'beyondwords_body_voice_id', true);
 
         $languages = $this->getFilteredLanguages();
+
+        if (! is_array($languages) || ! count($languages)) {
+            return;
+        }
+
         $voices = [];
 
         if ($currentLanguageId) {
             $voices = $this->apiClient->getVoices($currentLanguageId);
+        }
+
+        if (! is_array($voices) || ! count($voices)) {
+            $voices = [];
         }
 
         wp_nonce_field('beyondwords_select_voice', 'beyondwords_select_voice_nonce');

--- a/src/Component/Post/SelectVoice/SelectVoice.php
+++ b/src/Component/Post/SelectVoice/SelectVoice.php
@@ -77,16 +77,11 @@ class SelectVoice
             return;
         }
 
+        $languages         = $this->getFilteredLanguages();
         $currentLanguageId = get_post_meta($post->ID, 'beyondwords_language_id', true);
+
+        $voices         = $this->apiClient->getVoices($currentLanguageId);
         $currentVoiceId = get_post_meta($post->ID, 'beyondwords_body_voice_id', true);
-
-        $languages = $this->getFilteredLanguages();
-
-        if (! is_array($languages) || ! count($languages)) {
-            return;
-        }
-
-        $voices = $this->apiClient->getVoices($currentLanguageId);
 
         if (! is_array($voices)) {
             $voices = [];
@@ -231,12 +226,18 @@ class SelectVoice
      * Get languages from BeyondWords API and filter by "Languages" plugin setting.
      *
      * @since 4.0.0
+     * @since 4.5.1 Exit early with an empty array if language API call fails.
      *
      * @return array Array of languages
      */
     public function getFilteredLanguages()
     {
-        $languages        = $this->apiClient->getLanguages();
+        $languages = $this->apiClient->getLanguages();
+
+        if (! is_array($languages)) {
+            return [];
+        }
+
         $languagesSetting = get_option('beyondwords_languages', Languages::DEFAULT_LANGUAGES);
 
         // Filter languages according to "Languages" plugin setting

--- a/src/Component/Post/SelectVoice/index.js
+++ b/src/Component/Post/SelectVoice/index.js
@@ -72,6 +72,10 @@ export function SelectVoice( { wrapper } ) {
 		} );
 	}, [ voices ] );
 
+	if (! languageOptions.length) {
+		return false;
+	}
+
 	return (
 		<SelectVoiceCheck>
 			<Wrapper>

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -199,6 +199,7 @@ class ApiClient
      *
      * @since 4.0.0 Introduced
      * @since 4.0.2 Prefix endpoint with /organization
+     * @since 4.5.1 Check the $languageId param is numeric.
      *
      * @param int $languageId BeyondWords Language ID
      *
@@ -206,6 +207,10 @@ class ApiClient
      **/
     public function getVoices($languageId)
     {
+        if (! is_numeric($languageId)) {
+            return [];
+        }
+
         $url = sprintf('%s/organization/voices?filter[language.id]=%s', Environment::getApiUrl(), urlencode(strval($languageId))); // phpcs:ignore Generic.Files.LineLength.TooLong
 
         $request = new Request('GET', $url);

--- a/src/Core/Settings/store/reducer.js
+++ b/src/Core/Settings/store/reducer.js
@@ -13,22 +13,22 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case 'SET_LANGUAGES':
 			return {
 				...state,
-				languages: action.value,
+				languages: action.value || [],
 			};
 		case 'SET_PLAYER_STYLES':
 			return {
 				...state,
-				playerStyles: action.value,
+				playerStyles: action.value || [],
 			};
 		case 'SET_SETTINGS':
 			return {
 				...state,
-				settings: action.value,
+				settings: action.value || {},
 			};
 		case 'SET_VOICES':
 			return {
 				...state,
-				voices: action.value,
+				voices: action.value || [],
 			};
 	}
 

--- a/tests/phpunit/Component/Post/DisplayPlayer/DisplayPlayerTest.php
+++ b/tests/phpunit/Component/Post/DisplayPlayer/DisplayPlayerTest.php
@@ -100,8 +100,6 @@ class DisplayPlayerTest extends WP_UnitTestCase
 
         $crawler = new Crawler($html);
 
-        fwrite(STDERR, print_r($html, true));
-
         $this->assertCount(1, $crawler->filter('p#beyondwords-metabox-display-player'));
 
         $input = $crawler->filter('p#beyondwords-metabox-display-player input');

--- a/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * BeyondWords Player Style element.
+ *
+ * Text Domain: speechkit
+ *
+ * @package Beyondwords\Wordpress
+ * @author  Stuart McAlpine <stu@beyondwords.io>
+ * @since   4.5.2
+ */
+
+use Beyondwords\Wordpress\Component\Post\PlayerStyle\PlayerStyle;
+use \Symfony\Component\DomCrawler\Crawler;
+
+class PostPlayerStyleTest extends WP_UnitTestCase
+{
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(DATE_ISO8601));
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
+
+        // Then...
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function init()
+    {
+        $playerStyle = new PlayerStyle();
+        $playerStyle->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('rest_api_init', array($playerStyle, 'restApiInit')));
+        $this->assertEquals(10, has_action('save_post_page', array($playerStyle, 'save')));
+        $this->assertEquals(10, has_action('save_post_post', array($playerStyle, 'save')));
+    }
+
+    /**
+     * @test
+     */
+    public function element()
+    {
+        $playerStyle = new PlayerStyle();
+
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'PostPlayerStyleTest::element',
+        ]);
+
+        $transientName = sprintf('beyondwords_player_styles[%s]', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        /**
+         * Each player style is an associative array with the following keys:
+         * - string  `label`    The option label e.g. "Standard"
+         * - string  `value`    The option value e.g. "standard"
+         * - boolean `disabled` (Optional) Is this option disabled?
+         * - boolean `default`  (Optional) Is this the default player style, assigned in the plugin settings?
+        */
+        set_transient($transientName, [
+            [
+                'label' => 'Foo',
+                'value' => 'foo',
+            ],
+            [
+                'label' => 'Bar',
+                'value' => 'bar',
+            ],
+            [
+                'label' => 'Baz',
+                'value' => 'baz',
+            ],
+        ]);
+
+        $playerStyle->element($post);
+
+        $html = $this->getActualOutput();
+
+        $crawler = new Crawler($html);
+
+        $this->assertCount(1, $crawler->filter('p#beyondwords-metabox-player-style'));
+
+        $select = $crawler->filter('#beyondwords_player_style');
+        $this->assertCount(1, $select);
+
+        $this->assertSame('foo', $select->filter('option:nth-child(1)')->attr('value'));
+        $this->assertSame('Foo', $select->filter('option:nth-child(1)')->text());
+
+        $this->assertSame('bar', $select->filter('option:nth-child(2)')->attr('value'));
+        $this->assertSame('Bar', $select->filter('option:nth-child(2)')->text());
+
+        $this->assertSame('baz', $select->filter('option:nth-child(3)')->attr('value'));
+        $this->assertSame('Baz', $select->filter('option:nth-child(3)')->text());
+
+        $label = $crawler->filter('p#beyondwords-metabox-player-style');
+
+        $this->assertEquals('Player style', $label->text());
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     */
+    public function save()
+    {
+        $_POST['beyondwords_player_style_nonce'] = wp_create_nonce('beyondwords_player_style');
+
+        $playerStyle = new PlayerStyle();
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'PlayerStyleTest::save',
+        ]);
+
+        $playerStyle->save($postId);
+
+        $this->assertEquals('', get_post_meta($postId, 'beyondwords_player_style', true));
+
+        $_POST['beyondwords_player_style'] = 'video';
+
+        $playerStyle->save($postId);
+
+        $this->assertEquals('video', get_post_meta($postId, 'beyondwords_player_style', true));
+
+        unset($_POST['beyondwords_player_style']);
+
+        $playerStyle->save($postId);
+
+        $this->assertEquals('video', get_post_meta($postId, 'beyondwords_player_style', true));
+
+        wp_delete_post($postId, true);
+    }
+}

--- a/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
+++ b/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * BeyondWords Select Voice element.
+ *
+ * Text Domain: speechkit
+ *
+ * @package Beyondwords\Wordpress
+ * @author  Stuart McAlpine <stu@beyondwords.io>
+ * @since   4.5.2
+ */
+
+use Beyondwords\Wordpress\Component\Post\SelectVoice\SelectVoice;
+use Beyondwords\Wordpress\Core\ApiClient;
+use \Symfony\Component\DomCrawler\Crawler;
+
+class SelectVoiceTest extends WP_UnitTestCase
+{
+    /**
+     * @var ApiClient
+     */
+    private $apiClient;
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+        $this->apiClient = new ApiClient();
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(DATE_ISO8601));
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+        $this->apiClient = null;
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
+
+        // Then...
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function init()
+    {
+        $selectVoice = new SelectVoice($this->apiClient);
+        $selectVoice->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('rest_api_init', array($selectVoice, 'restApiInit')));
+        $this->assertEquals(10, has_action('admin_enqueue_scripts', array($selectVoice, 'adminEnqueueScripts')));
+        $this->assertEquals(10, has_action('save_post_page', array($selectVoice, 'save')));
+        $this->assertEquals(10, has_action('save_post_post', array($selectVoice, 'save')));
+    }
+
+    /**
+     * @test
+     */
+    public function element()
+    {
+        update_option('beyondwords_languages', ['1', '2', '3']);
+
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'PostSelectVoiceTest::element',
+            'meta_input' => [
+                // Set Language ID so we see the "Voice" <select>
+                'beyondwords_language_id' => '1',
+            ],
+        ]);
+
+        $selectVoice = new SelectVoice($this->apiClient);
+
+        $selectVoice->element($post);
+
+        $html = $this->getActualOutput();
+
+        $crawler = new Crawler($html);
+
+        $languageLabel = $crawler->filter('p#beyondwords-metabox-select-voice--language-id');
+        $this->assertEquals('Language', $languageLabel->text());
+
+        $languageSelect = $crawler->filter('#beyondwords_language_id');
+        $this->assertCount(1, $languageSelect);
+
+        $this->assertSame('', $languageSelect->filter('option:nth-child(1)')->attr('value'));
+        $this->assertSame('Project default', $languageSelect->filter('option:nth-child(1)')->text());
+
+        $this->assertSame('1', $languageSelect->filter('option:nth-child(2)')->attr('value'));
+        $this->assertSame('Language 1', $languageSelect->filter('option:nth-child(2)')->text());
+
+        $this->assertSame('2', $languageSelect->filter('option:nth-child(3)')->attr('value'));
+        $this->assertSame('Language 2', $languageSelect->filter('option:nth-child(3)')->text());
+
+        $this->assertSame('3', $languageSelect->filter('option:nth-child(4)')->attr('value'));
+        $this->assertSame('Language 3', $languageSelect->filter('option:nth-child(4)')->text());
+
+        $voiceLabel = $crawler->filter('p#beyondwords-metabox-select-voice--voice-id');
+        $this->assertEquals('Voice', $voiceLabel->text());
+
+        $voiceSelect = $crawler->filter('#beyondwords_voice_id');
+        $this->assertCount(1, $voiceSelect);
+
+        $this->assertSame('1', $voiceSelect->filter('option:nth-child(2)')->attr('value'));
+        $this->assertSame('Voice 1-a', $voiceSelect->filter('option:nth-child(2)')->text());
+
+        $this->assertSame('2', $voiceSelect->filter('option:nth-child(3)')->attr('value'));
+        $this->assertSame('Voice 1-b', $voiceSelect->filter('option:nth-child(3)')->text());
+
+        $this->assertSame('3', $voiceSelect->filter('option:nth-child(4)')->attr('value'));
+        $this->assertSame('Voice 1-c', $voiceSelect->filter('option:nth-child(4)')->text());
+
+        wp_delete_post($post->ID, true);
+
+        delete_option('beyondwords_languages');
+    }
+
+    /**
+     * @test
+     */
+    public function save()
+    {
+        $_POST['beyondwords_select_voice_nonce'] = wp_create_nonce('beyondwords_select_voice');
+
+        $selectVoice = new SelectVoice($this->apiClient);
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'SelectVoiceTest::save',
+        ]);
+
+        $selectVoice->save($postId);
+
+        $this->assertEquals('', get_post_meta($postId, 'beyondwords_body_voice_id', true));
+
+        $_POST['beyondwords_voice_id'] = '1';
+
+        $selectVoice->save($postId);
+
+        $this->assertEquals('', get_post_meta($postId, 'beyondwords_body_voice_id', true));
+
+        $_POST['beyondwords_language_id'] = '1';
+        $_POST['beyondwords_voice_id'] = '1';
+
+        $selectVoice->save($postId);
+
+        $this->assertEquals('1', get_post_meta($postId, 'beyondwords_body_voice_id', true));
+
+        unset($_POST['beyondwords_voice_id']);
+
+        $selectVoice->save($postId);
+
+        $this->assertEquals('1', get_post_meta($postId, 'beyondwords_body_voice_id', true));
+
+        wp_delete_post($postId, true);
+    }
+}

--- a/tests/phpunit/Component/Settings/SettingsUpdatedTest.php
+++ b/tests/phpunit/Component/Settings/SettingsUpdatedTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Beyondwords\Wordpress\Component\Settings\SettingsUpdated\SettingsUpdated;
+
+final class SettingsUpdatedTest extends WP_UnitTestCase
+{
+    /**
+     * @var \Beyondwords\Wordpress\Component\Posts\BulkEdit\BulkEdit
+     */
+    private $_instance;
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+        unset($_POST, $_REQUEST);
+
+        // Your set up methods here.
+        $this->_instance = new SettingsUpdated();
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+        unset($_POST, $_REQUEST);
+
+        $this->_instance = null;
+
+        // Then...
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function init()
+    {
+        $settingsUpdated = new SettingsUpdated();
+        $settingsUpdated->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($settingsUpdated, 'addSettingsField')));
+    }
+
+    /**
+     * @test
+     */
+    public function addSettingsField()
+    {
+        global $wp_settings_fields;
+
+        $settingsUpdated = new SettingsUpdated();
+        $settingsUpdated->addSettingsField();
+
+        // Check for add_settings_field() result
+        $this->assertArrayHasKey('beyondwords-settings-updated', $wp_settings_fields['beyondwords']['basic']);
+
+        $field = $wp_settings_fields['beyondwords']['basic']['beyondwords-settings-updated'];
+
+        $this->assertSame('beyondwords-settings-updated', $field['id']);
+        $this->assertSame('Settings Updated', $field['title']);
+        $this->assertSame(array($settingsUpdated, 'render'), $field['callback']);
+        $this->assertSame(['class' => 'hidden'], $field['args']);
+    }
+}

--- a/tests/phpunit/Core/ApiClientTest.php
+++ b/tests/phpunit/Core/ApiClientTest.php
@@ -130,10 +130,17 @@ class ApiClientTest extends WP_UnitTestCase
      */
     public function deleteAudio()
     {
+        $postId = self::factory()->post->create([
+            'post_title' => 'ApiClientTest::deleteAudio::1',
+        ]);
+
+        $response = $this->_instance->deleteAudio($postId);
+        $this->assertFalse($response);
+
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
 
         $postId = self::factory()->post->create([
-            'post_title' => 'ApiClientTest::deleteAudio',
+            'post_title' => 'ApiClientTest::deleteAudio::2',
             'meta_input' => [
                 'beyondwords_project_id' => BEYONDWORDS_TESTS_PROJECT_ID,
                 'beyondwords_podcast_id' => BEYONDWORDS_TESTS_CONTENT_ID,
@@ -148,6 +155,130 @@ class ApiClientTest extends WP_UnitTestCase
         wp_delete_post($postId, true);
 
         delete_option('beyondwords_api_key');
+    }
+
+    /**
+     * @test
+     * @group voices
+     */
+    public function getLanguages()
+    {
+        $response = $this->_instance->getLanguages();
+        $this->assertFalse($response);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+
+        $response = $this->_instance->getLanguages();
+
+        $this->assertSame($response, [
+            ['id' => 1, 'name' => 'Language 1'],
+            ['id' => 2, 'name' => 'Language 2'],
+            ['id' => 3, 'name' => 'Language 3'],
+        ]);
+
+        delete_option('beyondwords_api_key');
+    }
+
+    /**
+     * @test
+     * @group voices
+     */
+    public function getVoices()
+    {
+        $response = $this->_instance->getVoices('2');
+        $this->assertFalse($response);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+
+        $response = $this->_instance->getVoices('2');
+
+        $this->assertSame($response, [
+            ['id' => 1, 'name' => 'Voice 2-a'],
+            ['id' => 2, 'name' => 'Voice 2-b'],
+            ['id' => 3, 'name' => 'Voice 2-c'],
+        ]);
+
+        delete_option('beyondwords_api_key');
+    }
+
+    /**
+     * @test
+     * @group settings
+     */
+    public function getProject()
+    {
+        $response = $this->_instance->getProject();
+        $this->assertFalse($response);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $response = $this->_instance->getProject();
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('name', $response);
+        $this->assertArrayHasKey('language', $response);
+        $this->assertArrayHasKey('auto_publish_enabled', $response);
+        $this->assertArrayHasKey('time_zone', $response);
+        $this->assertArrayHasKey('created', $response);
+        $this->assertArrayHasKey('updated', $response);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
+     * @group settings
+     */
+    public function getPlayerSettings()
+    {
+        $response = $this->_instance->getPlayerSettings();
+        $this->assertFalse($response);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $response = $this->_instance->getPlayerSettings();
+
+        $this->assertArrayHasKey('player_version', $response);
+        $this->assertArrayHasKey('player_style', $response);
+        $this->assertArrayHasKey('player_title', $response);
+        $this->assertArrayHasKey('call_to_action', $response);
+        $this->assertArrayHasKey('image_url', $response);
+        $this->assertArrayHasKey('theme', $response);
+        $this->assertArrayHasKey('updated', $response);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
+     * @group settings
+     */
+    public function getVideoSettings()
+    {
+        $response = $this->_instance->getVideoSettings();
+        $this->assertFalse($response);
+
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $response = $this->_instance->getVideoSettings();
+
+        $this->assertArrayHasKey('enabled', $response);
+        $this->assertArrayHasKey('logo_image_url', $response);
+        $this->assertArrayHasKey('logo_image_position', $response);
+        $this->assertArrayHasKey('background_color', $response);
+        $this->assertArrayHasKey('text_background_color', $response);
+        $this->assertArrayHasKey('text_color', $response);
+        $this->assertArrayHasKey('text_highlight_color', $response);
+        $this->assertArrayHasKey('waveform_color', $response);
+        $this->assertArrayHasKey('content_image_enabled', $response);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
     }
 
     /**

--- a/tests/phpunit/Settings/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Settings/PlayerStyle/PlayerStyleTest.php
@@ -6,7 +6,7 @@ use Beyondwords\Wordpress\Component\Settings\PlayerStyle\PlayerStyle;
 use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
-class PlayerStyleTest extends WP_UnitTestCase
+class SettingsPlayerStyleTest extends WP_UnitTestCase
 {
     /**
      * @var \Beyondwords\Wordpress\Component\Settings\PlayerStyle\PlayerStyle


### PR DESCRIPTION
As well as handling empty creds in #371 we also need to handle:

- Invalid/revoked creds
- Network server errors

It's not common for API creds to be invalid or missing, or for REST API calls to fail, but this issue has been reported to us before.

We should adjust the calls to the REST API to handle these cases.