### PR TITLE
Prepend custom plugin links instead of appending them

### DIFF
--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -261,11 +261,20 @@ class Settings
         <?php
     }
 
+    /**
+     * Add "Settings" link to plugin page.
+     *
+     * @since 3.0.0
+     * @since 4.7.0 Prepend custom links instead of appending them.
+     */
     public function addSettingsLinkToPluginPage($links)
     {
-        $links[] = '<a href="' .
+        $customLinks[] = '<a href="' .
             esc_url(admin_url('options-general.php?page=beyondwords')) .
             '">' . __('Settings', 'speechkit') . '</a>';
+
+        array_unshift($links, $customLinks);
+
         return $links;
     }
 

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -269,11 +269,11 @@ class Settings
      */
     public function addSettingsLinkToPluginPage($links)
     {
-        $customLinks[] = '<a href="' .
+        $settingsLink = '<a href="' .
             esc_url(admin_url('options-general.php?page=beyondwords')) .
             '">' . __('Settings', 'speechkit') . '</a>';
 
-        array_unshift($links, $customLinks);
+        array_unshift($links, $settingsLink);
 
         return $links;
     }

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -10,7 +10,7 @@ use \Symfony\Component\DomCrawler\Crawler;
 class SettingsTest extends WP_UnitTestCase
 {
     /**
-     * @var \Beyondwords\Wordpress\Component\Settings\ProjectId\ProjectId
+     * @var \Beyondwords\Wordpress\Component\Settings\Settings
      * @static
      */
     private $_instance;
@@ -83,16 +83,16 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function addSettingsLinkToPluginPage()
     {
-        $existingLinks = ['Test'];
+        $existingLink = '<a href="#">Test</a>';
 
-        $links = $this->_instance->addSettingsLinkToPluginPage($existingLinks);
+        $links = $this->_instance->addSettingsLinkToPluginPage([$existingLink]);
 
-        $this->assertEquals('Test', $links[0]);
-
-        $expectedUrl = '<a href="' .
+        $expectedLink = '<a href="' .
             esc_url(admin_url('options-general.php?page=beyondwords')) .
             '">' . __('Settings', 'speechkit') . '</a>';
-        $this->assertEquals($expectedUrl, $links[1]);
+
+        $this->assertEquals($expectedLink, $links[0]);
+        $this->assertEquals($existingLink, $links[1]);
     }
 
     /**

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -83,16 +83,18 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function addSettingsLinkToPluginPage()
     {
-        $existingLink = '<a href="#">Test</a>';
+        $links = [
+            '<a href="#">Deactivate</a>'
+        ];
 
-        $links = $this->_instance->addSettingsLinkToPluginPage([$existingLink]);
-
-        $expectedLink = '<a href="' .
+        $expected = '<a href="' .
             esc_url(admin_url('options-general.php?page=beyondwords')) .
             '">' . __('Settings', 'speechkit') . '</a>';
 
-        $this->assertEquals($expectedLink, $links[0]);
-        $this->assertEquals($existingLink, $links[1]);
+        $newLinks = $this->_instance->addSettingsLinkToPluginPage($links);
+
+        $this->assertEquals($newLinks[0], $expected);
+        $this->assertEquals($newLinks[1], $links[0]);
     }
 
     /**


### PR DESCRIPTION
Other plugins prepend their custom links, instead of appending them like we have.

Placing the "Deactivate" last is preferable, so we will append our links too.