### PR TITLE
Stop saving beyondwords_podcast_id post_meta in WordPress

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,12 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 == Changelog ==
 
+= 4.8.0 =
+
+Release date: TBC
+
+* Stop saving `beyondwords_podcast_id`. Plugin downgrades from `v4.8.0` or later to versions before `v4.0.0` are no longer supported.
+
 = 4.7.0 =
 
 Release date: 2nd May 2024

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -226,6 +226,7 @@ class Core
      * @since 3.7.0 Stop saving response.access_key, we don't currently use it.
      * @since 4.0.0 Replace Podcast IDs with Content IDs
      * @since 4.5.0 Save response.preview_token to support post scheduling.
+     * @since 4.8.0 Stop saving `beyondwords_podcast_id`.
      */
     public function processResponse($response, $projectId, $postId)
     {
@@ -239,9 +240,6 @@ class Core
 
             // Save Content ID
             update_post_meta($postId, 'beyondwords_content_id', $response['id']);
-
-            // Temporarily save into Podcast ID field to support downgrades to < 4.0.0
-            update_post_meta($postId, 'beyondwords_podcast_id', $response['id']);
 
             if (array_key_exists('preview_token', $response)) {
                 // Save Preview Key


### PR DESCRIPTION
Plugin downgrades from `v4.8.0` or later to versions before `v4.0.0` are no longer supported.