### PR TITLE
Unskip e2e tests

### DIFF
--- a/tests/cypress/e2e/block-editor/player-style.cy.js
+++ b/tests/cypress/e2e/block-editor/player-style.cy.js
@@ -14,7 +14,7 @@ context( 'Block Editor: Player Style', () => {
   // Only test priority post types
   postTypes.filter( x => x.priority ).forEach( postType => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
+    it( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
       cy.visit( `/wp-admin/post-new.php?post_type=${postType.slug}` ).wait( 500 )
 
       cy.closeWelcomeToBlockEditorTips()

--- a/tests/cypress/e2e/classic-editor/player-style.cy.js
+++ b/tests/cypress/e2e/classic-editor/player-style.cy.js
@@ -18,7 +18,7 @@ context( 'Classic Editor: Player Style', () => {
 
   postTypes.filter( x => x.priority ).forEach( postType => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
+    it( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
       cy.visit( `/wp-admin/post-new.php?post_type=${postType.slug}` ).wait( 500 )
 
       cy.get( 'select#beyondwords_player_style' ).find( 'option' ).should( $els => {

--- a/tests/cypress/e2e/settings/player/call-to-action.cy.js
+++ b/tests/cypress/e2e/settings/player/call-to-action.cy.js
@@ -16,7 +16,7 @@ context( 'Settings > Player > Call-to-action',  () => {
 
   values.forEach( value => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `sets "${value}"`, () => {
+    it( `sets "${value}"`, () => {
       cy.saveMinimalPluginSettings()
 
       cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/playback-from-segments.cy.js
+++ b/tests/cypress/e2e/settings/player/playback-from-segments.cy.js
@@ -10,7 +10,7 @@ context( 'Settings > Player > Playback from segments',  () => {
   } )
 
   // @todo skipping because this fails now we auto-sync the API with WordPress
-  it.skip( `sets "Playback from segments"`, () => {
+  it( `sets "Playback from segments"`, () => {
     cy.saveMinimalPluginSettings()
 
     // Check

--- a/tests/cypress/e2e/settings/player/player-colors.cy.js
+++ b/tests/cypress/e2e/settings/player/player-colors.cy.js
@@ -30,7 +30,7 @@ context( 'Settings > Player > Player colors',  () => {
   };
 
   // @todo skipping because this fails now we auto-sync the API with WordPress
-  it.skip( `sets Player colors"`, () => {
+  it( `sets Player colors"`, () => {
     cy.saveMinimalPluginSettings()
 
     cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/player-theme.cy.js
+++ b/tests/cypress/e2e/settings/player/player-theme.cy.js
@@ -26,7 +26,7 @@ context( 'Settings > Player > Player theme',  () => {
 
   themes.forEach( theme => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `sets "${theme.label}"`, () => {
+    it( `sets "${theme.label}"`, () => {
       cy.saveMinimalPluginSettings()
 
       cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/player-ui.cy.js
+++ b/tests/cypress/e2e/settings/player/player-ui.cy.js
@@ -10,7 +10,7 @@ context( 'Settings > Player UI',  () => {
   } )
 
   // @todo skipping because this fails now we auto-sync the API with WordPress
-  it.skip( 'uses "Enabled" Player UI setting', () => {
+  it( 'uses "Enabled" Player UI setting', () => {
     cy.saveMinimalPluginSettings()
 
     cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/skip-button-style.cy.js
+++ b/tests/cypress/e2e/settings/player/skip-button-style.cy.js
@@ -16,7 +16,7 @@ context( 'Settings > Player > Skip button style',  () => {
 
   values.forEach( value => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `sets "${value}"`, () => {
+    it( `sets "${value}"`, () => {
       cy.saveMinimalPluginSettings()
 
       cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/text-highlighting.cy.js
+++ b/tests/cypress/e2e/settings/player/text-highlighting.cy.js
@@ -10,7 +10,7 @@ context( 'Settings > Player > Text highlighting',  () => {
   } )
 
   // @todo skipping because this fails now we auto-sync the API with WordPress
-  it.skip( `sets "Text highlighting"`, () => {
+  it( `sets "Text highlighting"`, () => {
     cy.saveMinimalPluginSettings()
 
     // Check

--- a/tests/cypress/e2e/settings/player/widget-position.cy.js
+++ b/tests/cypress/e2e/settings/player/widget-position.cy.js
@@ -31,7 +31,7 @@ context( 'Settings > Player > Widget position',  () => {
 
   options.forEach( option => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `sets "${option.label}"`, () => {
+    it( `sets "${option.label}"`, () => {
       cy.saveMinimalPluginSettings()
 
       cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/player/widget-style.cy.js
+++ b/tests/cypress/e2e/settings/player/widget-style.cy.js
@@ -34,7 +34,7 @@ context( 'Settings > Player > Widget style',  () => {
 
   options.forEach( option => {
     // @todo skipping because this fails now we auto-sync the API with WordPress
-    it.skip( `sets "${option.label}"`, () => {
+    it( `sets "${option.label}"`, () => {
       cy.saveMinimalPluginSettings()
 
       cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -39,7 +39,7 @@ context( 'Settings',  () => {
   } )
 
   // Skip this test in CI because auto-syncing settings is not supported in CI
-  it.skip( 'syncs the settings from the Dashboard to WordPress', () => {
+  it( 'syncs the settings from the Dashboard to WordPress', () => {
     cy.saveAllPluginSettings()
 
     cy.visit( '/wp-admin/options.php' )


### PR DESCRIPTION
Some e2e tests were skipped because the auto-sync with the REST API broke them. This PR will unskip as many as possible for the version 5.0 release.