### PR TITLE
Bring auto-publish setting into WordPress to fix auto-publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 5.0.0
+Stable tag: 5.0.1
 Requires PHP: 8.0
 Tested up to: 6.6
 License: GPLv2 or later
@@ -79,6 +79,16 @@ You can even leverage your listenership through audio advertising. Use our self-
 Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&utm_medium=referral&utm_campaign=&utm_content=plugin) or email <hello@beyondwords.io>.
 
 == Changelog ==
+
+= 5.0.1 =
+
+Release date: 28th October 2024
+
+**Fixes**
+
+* [#404](https://github.com/beyondwords-io/wordpress-plugin/pull/404) Bring auto-publish setting into WordPress to fix auto-publishing.
+    * In some cases WordPress was publishing audio regardless of the auto-publish setting in the dashboard.
+    * After this update any content created with the WordPress plugin will need to be published in the BeyondWords dashboard.
 
 = 5.0.0 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           5.0.0
+ * Version:           5.0.1
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '5.0.0');
+define('BEYONDWORDS__PLUGIN_VERSION', '5.0.1');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
+++ b/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * @package Beyondwords\Wordpress
  * @author  Stuart McAlpine <stu@beyondwords.io>
- * @since   5.1.0
+ * @since   5.0.1
  */
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\AutoPublish;
@@ -17,7 +17,7 @@ use Beyondwords\Wordpress\Component\Settings\Sync;
 /**
  * AutoPublish
  *
- * @since 5.1.0
+ * @since 5.0.1
  */
 class AutoPublish
 {
@@ -38,7 +38,7 @@ class AutoPublish
     /**
      * Init.
      *
-     * @since 5.1.0
+     * @since 5.0.1
      */
     public function init()
     {
@@ -53,7 +53,7 @@ class AutoPublish
     /**
      * Init setting.
      *
-     * @since 5.1.0
+     * @since 5.0.1
      *
      * @return void
      */
@@ -81,7 +81,7 @@ class AutoPublish
     /**
      * Render setting field.
      *
-     * @since 5.1.0
+     * @since 5.0.1
      *
      * @return void
      **/

--- a/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
+++ b/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
@@ -99,7 +99,12 @@ class AutoPublish
                     value="1"
                     <?php checked($value); ?>
                 />
-                <?php esc_html_e('Auto-publish audio', 'speechkit'); ?>
+                <?php 
+                esc_html_e(
+                    'When auto-publish is disabled all audio content created in WordPress will need to be manually published in the BeyondWords dashboard.',  // phpcs:ignore Generic.Files.LineLength.TooLong
+                    'speechkit'
+                ); 
+                ?>
             </label>
         </div>
         <?php

--- a/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
+++ b/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Setting: Auto-publish
+ *
+ * @package Beyondwords\Wordpress
+ * @author  Stuart McAlpine <stu@beyondwords.io>
+ * @since   5.1.0
+ */
+
+namespace Beyondwords\Wordpress\Component\Settings\Fields\AutoPublish;
+
+use Beyondwords\Wordpress\Component\Settings\Sync;
+
+/**
+ * AutoPublish
+ *
+ * @since 5.1.0
+ */
+class AutoPublish
+{
+    /**
+     * Default value.
+     *
+     * @var string
+     */
+    public const DEFAULT_VALUE = true;
+
+    /**
+     * Option name.
+     *
+     * @var string
+     */
+    public const OPTION_NAME = 'beyondwords_project_auto_publish_enabled';
+
+    /**
+     * Init.
+     *
+     * @since 5.1.0
+     */
+    public function init()
+    {
+        add_action('admin_init', array($this, 'addSetting'));
+        add_action('pre_update_option_' . self::OPTION_NAME, function ($value) {
+            Sync::syncOptionToDashboard(self::OPTION_NAME);
+            return $value;
+        });
+        add_filter('option_' . self::OPTION_NAME, 'rest_sanitize_boolean');
+    }
+
+    /**
+     * Init setting.
+     *
+     * @since 5.1.0
+     *
+     * @return void
+     */
+    public function addSetting()
+    {
+        register_setting(
+            'beyondwords_content_settings',
+            self::OPTION_NAME,
+            [
+                'type'              => 'boolean',
+                'sanitize_callback' => 'rest_sanitize_boolean',
+                'default'           => self::DEFAULT_VALUE,
+            ]
+        );
+
+        add_settings_field(
+            'beyondwords-auto-publish',
+            __('Auto-publish', 'speechkit'),
+            array($this, 'render'),
+            'beyondwords_content',
+            'content'
+        );
+    }
+
+    /**
+     * Render setting field.
+     *
+     * @since 5.1.0
+     *
+     * @return void
+     **/
+    public function render()
+    {
+        $value = get_option(self::OPTION_NAME);
+        ?>
+        <div>
+            <label>
+                <input type="hidden" name="<?php echo esc_attr(self::OPTION_NAME); ?>" value="" />
+                <input
+                    type="checkbox"
+                    id="<?php echo esc_attr(self::OPTION_NAME); ?>"
+                    name="<?php echo esc_attr(self::OPTION_NAME); ?>"
+                    value="1"
+                    <?php checked($value); ?>
+                />
+                <?php esc_html_e('Auto-publish audio', 'speechkit'); ?>
+            </label>
+        </div>
+        <?php
+    }
+}

--- a/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
+++ b/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
@@ -101,7 +101,7 @@ class AutoPublish
                 />
                 <?php 
                 esc_html_e(
-                    'When auto-publish is disabled all audio content created in WordPress will need to be manually published in the BeyondWords dashboard.',  // phpcs:ignore Generic.Files.LineLength.TooLong
+                    'When auto-publish is disabled all audio content created in WordPress will need to be manually published in the BeyondWords dashboard',  // phpcs:ignore Generic.Files.LineLength.TooLong
                     'speechkit'
                 ); 
                 ?>

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -43,6 +43,7 @@ class Sync
         'beyondwords_player_skip_button_style'  => '[player_settings][skip_button_style]',
         'beyondwords_player_clickable_sections' => '[player_settings][segment_playback_enabled]',
         // Project
+        'beyondwords_project_auto_publish_enabled'      => '[project][auto_publish_enabled]',
         'beyondwords_project_language_code'             => '[project][language]',
         'beyondwords_project_language_id'               => '[project][language_id]',
         'beyondwords_project_body_voice_id'             => '[project][body][voice][id]',

--- a/src/Component/Settings/Tabs/Content/Content.php
+++ b/src/Component/Settings/Tabs/Content/Content.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Beyondwords\Wordpress\Component\Settings\Tabs\Content;
 
+use Beyondwords\Wordpress\Component\Settings\Fields\AutoPublish\AutoPublish;
 use Beyondwords\Wordpress\Component\Settings\Fields\IncludeExcerpt\IncludeExcerpt;
 use Beyondwords\Wordpress\Component\Settings\Fields\IncludeTitle\IncludeTitle;
 use Beyondwords\Wordpress\Component\Settings\Fields\PreselectGenerateAudio\PreselectGenerateAudio;
@@ -33,6 +34,7 @@ class Content
     public function init()
     {
         (new IncludeTitle())->init();
+        (new AutoPublish())->init();
         (new IncludeExcerpt())->init();
         (new PreselectGenerateAudio())->init();
 

--- a/src/Component/SiteHealth/SiteHealth.php
+++ b/src/Component/SiteHealth/SiteHealth.php
@@ -124,7 +124,7 @@ class SiteHealth
 
         $info['beyondwords']['fields']['beyondwords_languages'] = [
             'label' => __('Multiple languages', 'speechkit'),
-            'value' => ! empty($languages) ? wp_json_encode($languages, JSON_PRETTY_PRINT) : '',
+            'value' => ! empty($languages) ? wp_json_encode($languages, JSON_PRETTY_PRINT) : '', // phpcs:ignore Generic.Files.LineLength.TooLong
         ];
 
         $this->addFilters($info);
@@ -148,13 +148,19 @@ class SiteHealth
     {
         $info['beyondwords']['fields']['beyondwords_project_title_enabled'] = [
             'label' => __('Include title in audio', 'speechkit'),
-            'value' => get_option('beyondwords_project_title_enabled') ? __('Yes', 'speechkit') : __('No', 'speechkit'),
+            'value' => get_option('beyondwords_project_title_enabled') ? __('Yes', 'speechkit') : __('No', 'speechkit'), // phpcs:ignore Generic.Files.LineLength.TooLong
             'debug' => get_option('beyondwords_project_title_enabled') ? 'yes' : 'no',
+        ];
+
+        $info['beyondwords']['fields']['beyondwords_project_auto_publish_enabled'] = [
+            'label' => __('Auto-publish audio', 'speechkit'),
+            'value' => get_option('beyondwords_project_auto_publish_enabled') ? __('Yes', 'speechkit') : __('No', 'speechkit'), // phpcs:ignore Generic.Files.LineLength.TooLong
+            'debug' => get_option('beyondwords_project_auto_publish_enabled') ? 'yes' : 'no',
         ];
 
         $info['beyondwords']['fields']['beyondwords_prepend_excerpt'] = [
             'label' => __('Include excerpts in audio', 'speechkit'),
-            'value' => get_option('beyondwords_prepend_excerpt') ? __('Yes', 'speechkit') : __('No', 'speechkit'),
+            'value' => get_option('beyondwords_prepend_excerpt') ? __('Yes', 'speechkit') : __('No', 'speechkit'), // phpcs:ignore Generic.Files.LineLength.TooLong
             'debug' => get_option('beyondwords_prepend_excerpt') ? 'yes' : 'no',
         ];
 

--- a/src/Core/CoreUtils.php
+++ b/src/Core/CoreUtils.php
@@ -160,7 +160,7 @@ class CoreUtils
     public static function getOptions($type = 'current')
     {
         $current = [
-            // v4.x
+            // v5.x
             'beyondwords_player_call_to_action',
             'beyondwords_player_clickable_sections',
             'beyondwords_player_highlight_sections',
@@ -171,6 +171,7 @@ class CoreUtils
             'beyondwords_player_theme_video',
             'beyondwords_player_widget_position',
             'beyondwords_player_widget_style',
+            'beyondwords_project_auto_publish_enabled',
             'beyondwords_project_body_voice_id',
             'beyondwords_project_body_voice_speaking_rate',
             'beyondwords_project_language_code',

--- a/tests/cypress/e2e/settings/content/content.cy.js
+++ b/tests/cypress/e2e/settings/content/content.cy.js
@@ -14,11 +14,13 @@ context( 'Settings > Content',  () => {
 
     cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=content' )
     cy.get( '#beyondwords_project_title_enabled' ).should( 'be.checked' )
+    cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'be.checked' )
     cy.get( '#beyondwords_prepend_excerpt' ).should( 'not.be.checked' )
     cy.get( 'input[name="beyondwords_preselect[post]"]' ).should( 'be.checked' )
     cy.get( 'input[name="beyondwords_preselect[page]"]' ).should( 'be.checked' )
 
     cy.get( '#beyondwords_project_title_enabled' ).uncheck()
+    cy.get( '#beyondwords_project_auto_publish_enabled' ).uncheck()
     cy.get( '#beyondwords_prepend_excerpt' ).check()
     cy.get( 'input[name="beyondwords_preselect[post]"]' ).check()
     cy.get( 'input[name="beyondwords_preselect[page]"]' ).uncheck()
@@ -27,12 +29,14 @@ context( 'Settings > Content',  () => {
 
     // @todo skipping because this fails now we auto-sync the API with WordPress
     // cy.get( '#beyondwords_project_title_enabled' ).should( 'not.be.checked' )
+    // cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'not.be.checked' )
     // cy.get( '#beyondwords_prepend_excerpt' ).should( 'be.checked' )
     // cy.get( 'input[name="beyondwords_preselect[post]"]' ).should( 'be.checked' )
     // cy.get( 'input[name="beyondwords_preselect[page]"]' ).should( 'not.be.checked' )
 
     // cy.visit( '/wp-admin/options.php' )
     // cy.get( '#beyondwords_project_title_enabled' ).should( 'exist' )
+    // cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'exist' )
     // cy.get( '#beyondwords_prepend_excerpt' ).should( 'exist' )
     // cy.get( '#beyondwords_preselect' ).should( 'exist' )
   } )

--- a/tests/cypress/e2e/site-health.cy.js
+++ b/tests/cypress/e2e/site-health.cy.js
@@ -63,126 +63,131 @@ context( 'Site Health', () => {
         } )
         // Include excerpts in audio
         cy.get( 'tr' ).eq( 8 ).within( () => {
+          cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Auto-publish audio' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Yes' )
+        } )
+        // Include excerpts in audio
+        cy.get( 'tr' ).eq( 9 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Include excerpts in audio' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'No' )
         } )
         // Preselect ‘Generate audio’
-        cy.get( 'tr' ).eq( 9 ).within( () => {
+        cy.get( 'tr' ).eq( 10 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Preselect ‘Generate audio’' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "post": "1",\n    "page": "1",\n    "cpt_active": "1"\n}' )
         } )
         // Default language code
-        cy.get( 'tr' ).eq( 10 ).within( () => {
+        cy.get( 'tr' ).eq( 11 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Default language code' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'bb_BB' )
         } )
         // Default language ID
-        cy.get( 'tr' ).eq( 11 ).within( () => {
+        cy.get( 'tr' ).eq( 12 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Default language ID' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '2' )
         } )
         // Title voice ID
-        cy.get( 'tr' ).eq( 12 ).within( () => {
+        cy.get( 'tr' ).eq( 13 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Title voice ID' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '2' )
         } )
         // Title voice speaking rate
-        cy.get( 'tr' ).eq( 13 ).within( () => {
+        cy.get( 'tr' ).eq( 14 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Title voice speaking rate' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '90' )
         } )
         // Body voice ID
-        cy.get( 'tr' ).eq( 14 ).within( () => {
+        cy.get( 'tr' ).eq( 15 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Body voice ID' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '3' )
         } )
         // Body voice speaking rate
-        cy.get( 'tr' ).eq( 15 ).within( () => {
+        cy.get( 'tr' ).eq( 16 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Body voice speaking rate' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '110' )
         } )
         // Player UI
-        cy.get( 'tr' ).eq( 16 ).within( () => {
+        cy.get( 'tr' ).eq( 17 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Player UI' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'enabled' )
         } )
         // Player style
-        cy.get( 'tr' ).eq( 17 ).within( () => {
+        cy.get( 'tr' ).eq( 18 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Player style' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'standard' )
         } )
         // Player theme
-        cy.get( 'tr' ).eq( 18 ).within( () => {
+        cy.get( 'tr' ).eq( 19 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Player theme' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'light' )
         } )
         // Light theme
-        cy.get( 'tr' ).eq( 19 ).within( () => {
+        cy.get( 'tr' ).eq( 20 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Light theme' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#f5f5f5",\n    "icon_color": "#000",\n    "text_color": "#111",\n    "highlight_color": "#eee"\n}' )
         } )
         // Dark theme
-        cy.get( 'tr' ).eq( 20 ).within( () => {
+        cy.get( 'tr' ).eq( 21 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Dark theme' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "transparent",\n    "icon_color": "#fff",\n    "text_color": "#fff",\n    "highlight_color": "#444"\n}' )
         } )
         // Video theme
-        cy.get( 'tr' ).eq( 21 ).within( () => {
+        cy.get( 'tr' ).eq( 22 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Video theme' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#f5f5f5",\n    "icon_color": "#000",\n    "text_color": "#111"\n}' )
         } )
         // Call-to-action
-        cy.get( 'tr' ).eq( 22 ).within( () => {
+        cy.get( 'tr' ).eq( 23 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Call-to-action' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Listen to this article' )
         } )
         // Text highlighting
-        cy.get( 'tr' ).eq( 23 ).within( () => {
+        cy.get( 'tr' ).eq( 24 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Text highlighting' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'No' )
         } )
         // Playback from segments
-        cy.get( 'tr' ).eq( 24 ).within( () => {
+        cy.get( 'tr' ).eq( 25 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Playback from segments' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Yes' )
         } )
         // Widget style
-        cy.get( 'tr' ).eq( 25 ).within( () => {
+        cy.get( 'tr' ).eq( 26 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Widget style' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'standard' )
         } )
         // Widget position
-        cy.get( 'tr' ).eq( 26 ).within( () => {
+        cy.get( 'tr' ).eq( 27 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Widget position' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'auto' )
         } )
         // Skip button style
-        cy.get( 'tr' ).eq( 27 ).within( () => {
+        cy.get( 'tr' ).eq( 28 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Skip button style' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'auto' )
         } )
         // Multiple languages
-        cy.get( 'tr' ).eq( 28 ).within( () => {
+        cy.get( 'tr' ).eq( 29 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Multiple languages' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', '' )
         } )
         // Registered filters
-        cy.get( 'tr' ).eq( 29 ).within( () => {
+        cy.get( 'tr' ).eq( 30 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Registered filters' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'None' )
         } )
         // Registered deprecated filters
-        cy.get( 'tr' ).eq( 30 ).within( () => {
+        cy.get( 'tr' ).eq( 31 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Registered deprecated filters' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'None' )
         } )
         // BEYONDWORDS_AUTO_SYNC_SETTINGS
-        cy.get( 'tr' ).eq( 31 ).within( () => {
+        cy.get( 'tr' ).eq( 32 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'BEYONDWORDS_AUTO_SYNC_SETTINGS' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'False' )
         } )
         // BEYONDWORDS_AUTOREGENERATE
-        cy.get( 'tr' ).eq( 32 ).within( () => {
+        cy.get( 'tr' ).eq( 33 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'BEYONDWORDS_AUTOREGENERATE' )
           cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Undefined' )
         } )


### PR DESCRIPTION
In some cases WordPress was publishing audio regardless of the auto-publish setting in the dashboard.

This PR makes WordPress compatible with auto-publish.

After this update any content created with the WordPress plugin will need to be published in the BeyondWords dashboard.