### PR TITLE
Regenerate audio for all post statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 5.0.1
+Stable tag: 5.1.0
 Requires PHP: 8.0
 Tested up to: 6.6
 License: GPLv2 or later
@@ -80,15 +80,17 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 == Changelog ==
 
-= 5.0.1 =
+= 5.1.0 =
 
-Release date: 28th October 2024
+Release date: 29th October 2024
 
 **Fixes**
 
 * [#404](https://github.com/beyondwords-io/wordpress-plugin/pull/404) Bring auto-publish setting into WordPress to fix auto-publishing.
     * In some cases WordPress was publishing audio regardless of the auto-publish setting in the dashboard.
     * After this update any content created with the WordPress plugin will need to be published in the BeyondWords dashboard.
+* If a post has a content ID for audio then we now always make PUT requests to the BeyondWords REST API when the post is updated.
+    * This fixes an issue where the `published` property of audio was not set to `false` when WordPress posts were moved back to `draft` status.
 
 = 5.0.0 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           5.0.1
+ * Version:           5.1.0
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '5.0.1');
+define('BEYONDWORDS__PLUGIN_VERSION', '5.1.0');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
+++ b/src/Component/Settings/Fields/AutoPublish/AutoPublish.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * @package Beyondwords\Wordpress
  * @author  Stuart McAlpine <stu@beyondwords.io>
- * @since   5.0.1
+ * @since   5.1.0
  */
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\AutoPublish;
@@ -17,7 +17,7 @@ use Beyondwords\Wordpress\Component\Settings\Sync;
 /**
  * AutoPublish
  *
- * @since 5.0.1
+ * @since 5.1.0
  */
 class AutoPublish
 {
@@ -38,7 +38,7 @@ class AutoPublish
     /**
      * Init.
      *
-     * @since 5.0.1
+     * @since 5.1.0
      */
     public function init()
     {
@@ -53,7 +53,7 @@ class AutoPublish
     /**
      * Init setting.
      *
-     * @since 5.0.1
+     * @since 5.1.0
      *
      * @return void
      */
@@ -81,7 +81,7 @@ class AutoPublish
     /**
      * Render setting field.
      *
-     * @since 5.0.1
+     * @since 5.1.0
      *
      * @return void
      **/

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -486,6 +486,10 @@ class CoreTest extends WP_UnitTestCase
      */
     public function onUntrashPost($expectedResponse)
     {
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::untrashingPostWillUpdateAudio',
             'post_status' => 'trash',


### PR DESCRIPTION
- If a post has a content ID for audio then we now always make PUT requests to the BeyondWords REST API when the post is updated.
- This fixes an issue where the `published` property of audio was not set to `false` when WordPress posts were moved back to `draft` status.
