### PR TITLE
Generate Audio checkbox in Classic Editor doesn't reflect the "Preselect" setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,8 @@ Release date: 29th October 2024
 * [#407](https://github.com/beyondwords-io/wordpress-plugin/pull/407) Regenerate audio for all post statuses
     * If a post has a content ID for audio then we now *always* make PUT requests to the BeyondWords REST API when the post is updated.
     * This fixes an issue where the `published` property of audio was not set to `false` when WordPress posts were moved back to `draft` status.
+* [#408](https://github.com/beyondwords-io/wordpress-plugin/pull/408) Generate Audio checkbox in Classic Editor doesn't reflect the "Preselect" setting
+    * A change in the `v5.0` update meant the "Preselect generate audio" JS script was no longer being enqueued. This should now be fixed.
 
 = 5.0.0 =
 

--- a/src/Component/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudio.php
+++ b/src/Component/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudio.php
@@ -41,6 +41,7 @@ class PreselectGenerateAudio
     public function init()
     {
         add_action('admin_init', array($this, 'addSetting'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueueScripts'));
     }
 
     /**

--- a/tests/phpunit/Component/Post/GenerateAudio/GenerateAudioTest.php
+++ b/tests/phpunit/Component/Post/GenerateAudio/GenerateAudioTest.php
@@ -33,6 +33,20 @@ class GenerateAudioTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $generateAudio = new GenerateAudio();
+        $generateAudio->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('save_post_post', array($generateAudio, 'save')));
+        $this->assertEquals(10, has_action('save_post_page', array($generateAudio, 'save')));
+    }
+
+    /**
+     * @test
+     */
     public function saveWithoutNonce()
     {
         $post = self::factory()->post->create_and_get([

--- a/tests/phpunit/Component/Post/Metabox/MetaboxTest.php
+++ b/tests/phpunit/Component/Post/Metabox/MetaboxTest.php
@@ -44,6 +44,7 @@ class MetaboxTest extends WP_UnitTestCase
         do_action('wp_loaded');
 
         $this->assertEquals(10, has_action('admin_enqueue_scripts', array($this->_instance, 'adminEnqueueScripts')));
+        $this->assertEquals(10, has_action('add_meta_boxes', array($this->_instance, 'addMetaBox')));
     }
 
     /**

--- a/tests/phpunit/Component/Posts/Column/ColumnTest.php
+++ b/tests/phpunit/Component/Posts/Column/ColumnTest.php
@@ -39,13 +39,16 @@ class ColumnTest extends WP_UnitTestCase
 
         // Post type: post
         $this->assertEquals(10, has_filter('manage_post_posts_columns', array($column, 'renderColumnsHead')));
-        $this->assertEquals(10, has_filter('manage_post_posts_custom_column', array($column, 'renderColumnsContent')));
+        $this->assertEquals(10, has_action('manage_post_posts_custom_column', array($column, 'renderColumnsContent')));
+        $this->assertEquals(10, has_filter('manage_edit-post_sortable_columns', array($column, 'makeColumnSortable')));
 
         // Post type: page
         $this->assertEquals(10, has_filter('manage_page_posts_columns', array($column, 'renderColumnsHead')));
-        $this->assertEquals(10, has_filter('manage_page_posts_custom_column', array($column, 'renderColumnsContent')));
+        $this->assertEquals(10, has_action('manage_page_posts_custom_column', array($column, 'renderColumnsContent')));
+        $this->assertEquals(10, has_filter('manage_edit-page_sortable_columns', array($column, 'makeColumnSortable')));
 
-        // todo test custom post types
+        // @todo set CoreUtils::isEditScreen() to true for this assertion
+        // $this->assertEquals(10, has_filter('pre_get_posts', array($column, 'setSortQuery')));
     }
 
     public function testRenderColumnsHead()

--- a/tests/phpunit/Core/ApiClientTest.php
+++ b/tests/phpunit/Core/ApiClientTest.php
@@ -46,6 +46,19 @@ class ApiClientTest extends WP_UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function init()
+    {
+        $apiClient = new ApiClient();
+        $apiClient->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_notices', array($apiClient, 'adminNotices')));
+    }
+
+    /**
      * Helper function to check that an API 200 OK response is the structure we expect.
      *
      * We only use the id (UUID) for now.

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -44,6 +44,8 @@ class CoreTest extends WP_UnitTestCase
         $this->assertEquals(10, has_action('before_delete_post', array($core, 'onTrashOrDeletePost')));
         $this->assertEquals(10, has_action('trashed_post', array($core, 'onTrashOrDeletePost')));
         $this->assertEquals(10, has_action('untrashed_post', array($core, 'onUntrashPost')));
+
+        $this->assertEquals(10, has_action('is_protected_meta', array($core, 'isProtectedMeta')));
     }
 
     /**

--- a/tests/phpunit/Core/CoreUtilsTest.php
+++ b/tests/phpunit/Core/CoreUtilsTest.php
@@ -6,15 +6,6 @@ use Beyondwords\Wordpress\Core\CoreUtils;
 
 class CoreUtilsTest extends WP_UnitTestCase
 {
-    /**
-     * Sample data from the custom field `speechkit_info`.
-     *
-     * This was exported from a test site running plugin v2.7.10.
-     *
-     * @var string
-     */
-    private $sampleSpeechkitInfo = 'a:16:{s:2:"id";s:2:"49";s:10:"podcast_id";i:9969567;s:3:"url";s:53:"https://speechkit.pressingspace.com/post-from-2-7-10/";s:5:"title";s:16:"Post from 2.7.10";s:6:"author";s:13:"pressingspace";s:7:"summary";s:0:"";s:5:"image";s:1:"f";s:12:"published_at";s:24:"2021-11-17T17:44:58.000Z";s:5:"state";s:9:"processed";s:9:"share_url";s:25:"https://spkt.io/a/9969567";s:13:"share_version";s:2:"v2";s:5:"media";a:2:{i:0;a:10:{s:2:"id";i:11542939;s:4:"role";s:4:"body";s:12:"content_type";s:21:"application/x-mpegURL";s:3:"url";s:118:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh.m3u8";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:03.211Z";s:10:"updated_at";s:24:"2021-11-17T17:45:03.211Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}i:1;a:10:{s:2:"id";i:11542938;s:4:"role";s:4:"body";s:12:"content_type";s:10:"audio/mpeg";s:3:"url";s:126:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh_compiled.mp3";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:02.078Z";s:10:"updated_at";s:24:"2021-11-17T17:45:02.078Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}}s:11:"player_type";s:14:"EmbeddedPlayer";s:24:"next_content_external_id";N;s:11:"ad_disabled";b:0;s:10:"project_id";i:9969;}';
-
     public function setUp(): void
     {
         // Before...

--- a/tests/phpunit/Core/PlayerTest.php
+++ b/tests/phpunit/Core/PlayerTest.php
@@ -34,6 +34,25 @@ class PlayerTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $player = new Player();
+        $player->init();
+
+        do_action('wp_loaded');
+
+        // Actions
+        $this->assertEquals(10, has_action('init', array($player, 'registerShortcodes')));
+        $this->assertEquals(10, has_action('wp_enqueue_scripts', array($player, 'enqueueScripts')));
+
+        // Filters
+        $this->assertEquals(1000000, has_filter('the_content', array($player, 'autoPrependPlayer')));
+        $this->assertEquals(10, has_filter('newsstand_the_content', array($player, 'autoPrependPlayer')));
+    }
+
+    /**
+     * @test
+     */
     public function addShortcode()
     {
         global $post;

--- a/tests/phpunit/Core/PostMetaUtilsTest.php
+++ b/tests/phpunit/Core/PostMetaUtilsTest.php
@@ -11,15 +11,6 @@ class PostMetaUtilsTest extends WP_UnitTestCase
      */
     protected $tester;
 
-    /**
-     * Sample data from the custom field `speechkit_info`.
-     *
-     * This was exported from a test site running plugin v2.7.10.
-     *
-     * @var string
-     */
-    private $sampleSpeechkitInfo = 'a:16:{s:2:"id";s:2:"49";s:10:"podcast_id";i:9969567;s:3:"url";s:53:"https://speechkit.pressingspace.com/post-from-2-7-10/";s:5:"title";s:16:"Post from 2.7.10";s:6:"author";s:13:"pressingspace";s:7:"summary";s:0:"";s:5:"image";s:1:"f";s:12:"published_at";s:24:"2021-11-17T17:44:58.000Z";s:5:"state";s:9:"processed";s:9:"share_url";s:25:"https://spkt.io/a/9969567";s:13:"share_version";s:2:"v2";s:5:"media";a:2:{i:0;a:10:{s:2:"id";i:11542939;s:4:"role";s:4:"body";s:12:"content_type";s:21:"application/x-mpegURL";s:3:"url";s:118:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh.m3u8";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:03.211Z";s:10:"updated_at";s:24:"2021-11-17T17:45:03.211Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}i:1;a:10:{s:2:"id";i:11542938;s:4:"role";s:4:"body";s:12:"content_type";s:10:"audio/mpeg";s:3:"url";s:126:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh_compiled.mp3";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:02.078Z";s:10:"updated_at";s:24:"2021-11-17T17:45:02.078Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}}s:11:"player_type";s:14:"EmbeddedPlayer";s:24:"next_content_external_id";N;s:11:"ad_disabled";b:0;s:10:"project_id";i:9969;}';
-
     public function setUp(): void
     {
         // Before...

--- a/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
+++ b/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
@@ -44,6 +44,19 @@ class ApiKeyTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $apiKey = new ApiKey();
+        $apiKey->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($apiKey, 'addSetting')));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
+++ b/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
@@ -44,6 +44,20 @@ class IncludeExcerptTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $includeExcerpt = new IncludeExcerpt();
+        $includeExcerpt->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($includeExcerpt, 'addSetting')));
+        $this->assertEquals(10, has_action('option_beyondwords_prepend_excerpt', 'rest_sanitize_boolean'));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
+++ b/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
@@ -47,6 +47,20 @@ class LanguagesTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $apiClient = new ApiClient();
+        $languages = new Languages($apiClient);
+        $languages->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($languages, 'addSetting')));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
@@ -47,6 +47,21 @@ class SettingsPlayerStyleTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $apiClient = new ApiClient();
+        $playerStyle = new PlayerStyle($apiClient);
+        $playerStyle->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($playerStyle, 'addSetting')));
+        $this->assertTrue(has_action('pre_update_option_beyondwords_player_style'));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
+++ b/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
@@ -45,6 +45,20 @@ class PlayerUITest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $playerUi = new PlayerUI();
+        $playerUi->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($playerUi, 'addSetting')));
+        $this->assertTrue(has_action('pre_update_option_beyondwords_player_ui'));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
+++ b/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
@@ -44,6 +44,20 @@ class PreselectGenerateAudioTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $preselectGenerateAudio = new PreselectGenerateAudio();
+        $preselectGenerateAudio->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($preselectGenerateAudio, 'addSetting')));
+        $this->assertEquals(10, has_action('admin_enqueue_scripts', array($preselectGenerateAudio, 'enqueueScripts')));
+    }
+
+    /**
+     * @test
+     */
     public function addSetting()
     {
         global $wp_settings_fields;

--- a/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
+++ b/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
@@ -46,6 +46,19 @@ class ProjectIdTest extends WP_UnitTestCase
      */
     public function init()
     {
+        $projectId = new ProjectId();
+        $projectId->init();
+
+        do_action('wp_loaded');
+
+        $this->assertEquals(10, has_action('admin_init', array($projectId, 'addSetting')));
+    }
+
+    /**
+     * @test
+     */
+    public function addSetting()
+    {
         global $wp_settings_fields;
 
         $this->_instance->addSetting();

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -39,6 +39,27 @@ class SettingsTest extends WP_UnitTestCase
     /**
      * @test
      */
+    public function init()
+    {
+        $apiClient = new ApiClient();
+        $settings = new Settings($apiClient);
+        $settings->init();
+
+        do_action('wp_loaded');
+
+        // Actions
+        $this->assertEquals(1, has_action('admin_menu', array($settings, 'addOptionsPage')));
+        $this->assertEquals(100, has_action('admin_notices', array($settings, 'printPluginAdminNotices')));
+        $this->assertEquals(10, has_action('admin_enqueue_scripts', array($settings, 'enqueueScripts')));
+        $this->assertEquals(10, has_action('rest_api_init', array($settings, 'restApiInit')));
+
+        // Filters
+        $this->assertEquals(10, has_filter('plugin_action_links_speechkit/speechkit.php', array($settings, 'addSettingsLinkToPluginPage')));
+    }
+
+    /**
+     * @test
+     */
     public function addSettingsLinkToPluginPage()
     {
         $links = [

--- a/tests/phpunit/Settings/SettingsUtilsTest.php
+++ b/tests/phpunit/Settings/SettingsUtilsTest.php
@@ -6,15 +6,6 @@ use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
 
 class SettingsUtilsTest extends WP_UnitTestCase
 {
-    /**
-     * Sample data from the custom field `speechkit_info`.
-     *
-     * This was exported from a test site running plugin v2.7.10.
-     *
-     * @var string
-     */
-    private $sampleSpeechkitInfo = 'a:16:{s:2:"id";s:2:"49";s:10:"podcast_id";i:9969567;s:3:"url";s:53:"https://speechkit.pressingspace.com/post-from-2-7-10/";s:5:"title";s:16:"Post from 2.7.10";s:6:"author";s:13:"pressingspace";s:7:"summary";s:0:"";s:5:"image";s:1:"f";s:12:"published_at";s:24:"2021-11-17T17:44:58.000Z";s:5:"state";s:9:"processed";s:9:"share_url";s:25:"https://spkt.io/a/9969567";s:13:"share_version";s:2:"v2";s:5:"media";a:2:{i:0;a:10:{s:2:"id";i:11542939;s:4:"role";s:4:"body";s:12:"content_type";s:21:"application/x-mpegURL";s:3:"url";s:118:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh.m3u8";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:03.211Z";s:10:"updated_at";s:24:"2021-11-17T17:45:03.211Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}i:1;a:10:{s:2:"id";i:11542938;s:4:"role";s:4:"body";s:12:"content_type";s:10:"audio/mpeg";s:3:"url";s:126:"https://abcdefghabcdef.cloudfront.net/audio/projects/9969/contents/9969567/media/abcdefghabcdefghabcdefghabcdefgh_compiled.mp3";s:12:"download_url";N;s:10:"created_at";s:24:"2021-11-17T17:45:02.078Z";s:10:"updated_at";s:24:"2021-11-17T17:45:02.078Z";s:5:"state";s:9:"processed";s:8:"duration";i:4;s:5:"voice";N;}}s:11:"player_type";s:14:"EmbeddedPlayer";s:24:"next_content_external_id";N;s:11:"ad_disabled";b:0;s:10:"project_id";i:9969;}';
-
     public function setUp(): void
     {
         // Before...


### PR DESCRIPTION
A change in the v5.0 update meant the "Preselect generate audio" JS script was no longer being enqueued.

This PR fixes that, and adds some missing unit tests for many components to help prevent problems like this in the future.