### PR TITLE
Refactor API calls to prevent "invalid creds" messages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,10 +411,6 @@ jobs:
         run: |
           wp config set BEYONDWORDS_API_URL http://localhost:3000/v1
 
-      - name: Disable BEYONDWORDS_AUTO_SYNC_SETTINGS
-        run: |
-          wp config set BEYONDWORDS_AUTO_SYNC_SETTINGS false --raw
-
       - name: Set WordPress core config values
         run: |
           wp config set AUTOMATIC_UPDATER_DISABLED true --raw

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,6 +411,10 @@ jobs:
         run: |
           wp config set BEYONDWORDS_API_URL http://localhost:3000/v1
 
+      - name: Keep BEYONDWORDS_AUTO_SYNC_SETTINGS
+        run: |
+          wp config set BEYONDWORDS_AUTO_SYNC_SETTINGS false --raw
+
       - name: Set WordPress core config values
         run: |
           wp config set AUTOMATIC_UPDATER_DISABLED true --raw

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           wp config set BEYONDWORDS_API_URL http://localhost:3000/v1
 
-      - name: Keep BEYONDWORDS_AUTO_SYNC_SETTINGS
+      - name: Disable BEYONDWORDS_AUTO_SYNC_SETTINGS
         run: |
           wp config set BEYONDWORDS_AUTO_SYNC_SETTINGS false --raw
 

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -34,7 +34,8 @@
     "env": {
         "tests": {
             "config": {
-                "BEYONDWORDS_API_URL": "http://host.docker.internal:3000/v1"
+                "BEYONDWORDS_API_URL": "http://host.docker.internal:3000/v1",
+                "BEYONDWORDS_AUTO_SYNC_SETTINGS": false
             }
         }
     }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -34,8 +34,7 @@
     "env": {
         "tests": {
             "config": {
-                "BEYONDWORDS_API_URL": "http://host.docker.internal:3000/v1",
-                "BEYONDWORDS_AUTO_SYNC_SETTINGS": false
+                "BEYONDWORDS_API_URL": "http://host.docker.internal:3000/v1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0-beta.2",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 5.2.0-beta.1
+Stable tag: 5.2.0-beta.2
 Requires PHP: 8.0
 Tested up to: 6.7
 License: GPLv2 or later
@@ -128,15 +128,15 @@ Release date: 15th October 2024
 **Breaking changes**
 
 * Legacy audio player support has been removed.
-    * The legacy BeyondWords player is no longer natively supported in the WordPress plugin. 
+    * The legacy BeyondWords player is no longer natively supported in the WordPress plugin.
     * The standard [BeyondWords Player](https://docs.beyondwords.io/docs-and-guides/player/overview) is now the only built-in option for the audio player.
 * Remove built-in Elementor compatibility.
     * Basic support for audio generation and auto-player embeds should still work for posts that are created with Elementor, although you will be unable to see a BeyondWords player in the Elementor post edit screens. To view our player in WordPress admin you can temporarily switch to the Block or Classic editors.
     * Refer to our [WordPress filters](https://docs.beyondwords.io/docs-and-guides/content/connect-cms/wordpress/wordpress-filters) docs and the [Elementor hooks](https://developers.elementor.com/docs/hooks/) docs if you wish to add Elementor support to your site.
-* Stop saving the legacy `beyondwords_podcast_id` param. 
-    * This change means that posts generated with versions `v5.0.0` and later will not play audio if the plugin is downgraded to `v3.x` or below. 
+* Stop saving the legacy `beyondwords_podcast_id` param.
+    * This change means that posts generated with versions `v5.0.0` and later will not play audio if the plugin is downgraded to `v3.x` or below.
     * If you need to downgrade to `v3.x` after using `v5.x` please contact us for support.
-* Remove deprecated filters. 
+* Remove deprecated filters.
     * A number of deprecated filters have now been removed from the source code.
     * Refer to our [WordPress Filters](https://docs.beyondwords.io/docs-and-guides/content/connect-cms/wordpress/wordpress-filters) documentation to view the current filters we provide.
 

--- a/readme.txt
+++ b/readme.txt
@@ -95,9 +95,9 @@ Release date: 19th November 2024
 
 **Fixes**
 
-* [#411](https://github.com/beyondwords-io/wordpress-plugin/pull/411) Remove `beyondwords_valid_api_connection` check.
-    * Since upgrading to version 5 a few publishers have reported problems with their valid API credentials being flagged as invalid, so the checks we had in place to validate the API Key and Project ID have been removed.
-    * API calls to create/update BeyondWords content can now be made with potentially invalid credentials. If this happens (fe.g. if your API Key has been revoked) the 401 Unauthorized error code and error message will be stored for your requests and visible in WordPress admin.
+* [#413](https://github.com/beyondwords-io/wordpress-plugin/pull/413) Refactor API calls to prevent "invalid creds" messages
+    * Since upgrading to version 5 a few publishers have reported problems with their valid API credentials being flagged as invalid, so the checks we had in place to validate the API Key and Project ID have been updated.
+    * API calls to create/update BeyondWords content can now be made with potentially invalid credentials. If this happens (e.g. if your API Key has been revoked) the 401 Unauthorized error code and error message will be stored for your requests and visible in WordPress admin.
 
 = 5.1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -82,9 +82,9 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 = 5.2.0 =
 
-Release date: TBC
+Release date: 19th November 2024
 
-**Experimental**
+**Enhancements**
 
 * [#409](https://github.com/beyondwords-io/wordpress-plugin/pull/409) Support the recommended inline script tag method to embed players.
     * ***This opt-in feature is experimental and may change, or be removed, in the near future***.
@@ -92,6 +92,12 @@ Release date: TBC
     * This was added because the recent removal of the deprecated `beyondwords_content_id` filter caused problems for a publisher who had been using it to display an audio player from another post on their homepage.
     * After opting-in, audio players that are auto-prepended to the post body should now use the `beyondwords_content_id` and `beyondwords_project_id` from the associated post being queried within The Loop.
     * A known-issue is the current implementation is currently incompatible with both the *BeyondWords shortcode* and the *BeyondWords player block*. Compatibility will be ensured before this experimental opt-in feature is shipped to all users. In the meantime players added using either the shortcode or player block are unlikely to appear when the `BEYONDWORDS_PLAYER_INLINE_SCRIPT_TAG` is `true`.
+
+**Fixes**
+
+* [#411](https://github.com/beyondwords-io/wordpress-plugin/pull/411) Remove `beyondwords_valid_api_connection` check.
+    * Since upgrading to version 5 a few publishers have reported problems with their valid API credentials being flagged as invalid, so the checks we had in place to validate the API Key and Project ID have been removed.
+    * API calls to create/update BeyondWords content can now be made with potentially invalid credentials. If this happens (fe.g. if your API Key has been revoked) the 401 Unauthorized error code and error message will be stored for your requests and visible in WordPress admin.
 
 = 5.1.0 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           5.2.0-beta.1
+ * Version:           5.2.0-beta.2
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '5.2.0-beta.1');
+define('BEYONDWORDS__PLUGIN_VERSION', '5.2.0-beta.2');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/Post/Metabox/Metabox.php
+++ b/src/Component/Post/Metabox/Metabox.php
@@ -28,21 +28,6 @@ use Beyondwords\Wordpress\Core\Environment;
 class Metabox
 {
     /**
-     * @var \Beyondwords\Wordpress\Core\ApiClient
-     */
-    private $apiClient;
-
-    /**
-     * Init.
-     *
-     * @since 4.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Init.
      *
      * @since 4.0.0
@@ -135,7 +120,7 @@ class Metabox
         }
 
         // Enable these components for posts with/without audio
-        (new SelectVoice($this->apiClient))->element($post);
+        (new SelectVoice())->element($post);
         (new PlayerStyle())->element($post);
 
         echo '<hr />';

--- a/src/Component/Post/PostContentUtils.php
+++ b/src/Component/Post/PostContentUtils.php
@@ -302,7 +302,7 @@ class PostContentUtils
      * @static
      * @param int $postId WordPress Post ID.
      *
-     * @return Response
+     * @return string JSON endoded params.
      **/
     public static function getContentParams($postId)
     {
@@ -321,8 +321,8 @@ class PostContentUtils
         $status = get_post_status($postId);
 
         /*
-         * If the post status is draft/pending then we explicity send 
-         * { published: false } to the BeyondWords API, to prevent the 
+         * If the post status is draft/pending then we explicity send
+         * { published: false } to the BeyondWords API, to prevent the
          * generated audio from being published in playlists.
          *
          * We also omit { publish_date } because get_post_time() returns `false`

--- a/src/Component/Post/PostMetaUtils.php
+++ b/src/Component/Post/PostMetaUtils.php
@@ -195,14 +195,6 @@ class PostMetaUtils
             return intval($matches[1]);
         }
 
-        // It may also be found by parsing post_meta.speechkit_response
-        $speechkit_response = static::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response');
-        preg_match('/"podcast_id":(")?(\d+)(?(1)\1|)/', (string)$speechkit_response, $matches);
-        // $matches[2] is the Podcast ID (response.podcast_id)
-        if ($matches && $matches[2]) {
-            return intval($matches[2]);
-        }
-
         /**
          * It may also be found by parsing post_meta.speechkit_info
          *
@@ -307,16 +299,6 @@ class PostMetaUtils
     {
         // Check custom fields
         $projectId = intval(PostMetaUtils::getRenamedPostMeta($postId, 'project_id'));
-
-        if (! $projectId) {
-            // It may also be found by parsing post_meta.speechkit_response
-            $speechkit_response = static::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response');
-            preg_match('/"project_id":(")?(\d+)(?(1)\1|)/', (string)$speechkit_response, $matches);
-            // $matches[2] is the Project ID (response.project_id)
-            if ($matches && $matches[2]) {
-                $projectId = intval($matches[2]);
-            }
-        }
 
         // If we still don't have an ID then use the default from the plugin settings
         if (! $projectId) {
@@ -444,38 +426,5 @@ class PostMetaUtils
     public static function getDisabled($postId)
     {
         return PostMetaUtils::getRenamedPostMeta($postId, 'disabled');
-    }
-
-    /**
-     * Get HTTP response body from post meta.
-     *
-     * The data may have been saved as a WordPress HTTP response array. If it was,
-     * then return the 'body' key of the HTTP response instead of the raw post meta.
-     *
-     * The data may also have been saved as a WordPress WP_Error instance. If it was,
-     * then return a string containing the WP_Error code and message.
-     *
-     * @since 3.0.3
-     * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils
-     * @since 3.6.1 Handle responses saved as object of class WP_Error
-     *
-     * @param int    $postId   Post ID.
-     * @param string $metaName Post Meta name.
-     *
-     * @return string
-     */
-    public static function getHttpResponseBodyFromPostMeta($postId, $metaName)
-    {
-        $postMeta = get_post_meta($postId, $metaName, true);
-
-        if (is_array($postMeta)) {
-            return (string)wp_remote_retrieve_body($postMeta);
-        }
-
-        if (is_wp_error($postMeta)) {
-            return sprintf(PostMetaUtils::WP_ERROR_FORMAT, $postMeta->get_error_code(), $postMeta->get_error_message());
-        }
-
-        return (string)$postMeta;
     }
 }

--- a/src/Component/Post/PostMetaUtils.php
+++ b/src/Component/Post/PostMetaUtils.php
@@ -195,6 +195,14 @@ class PostMetaUtils
             return intval($matches[1]);
         }
 
+        // It may also be found by parsing post_meta.speechkit_response
+        $speechkit_response = static::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response');
+        preg_match('/"podcast_id":(")?(\d+)(?(1)\1|)/', (string)$speechkit_response, $matches);
+        // $matches[2] is the Podcast ID (response.podcast_id)
+        if ($matches && $matches[2]) {
+            return intval($matches[2]);
+        }
+
         /**
          * It may also be found by parsing post_meta.speechkit_info
          *
@@ -299,6 +307,16 @@ class PostMetaUtils
     {
         // Check custom fields
         $projectId = intval(PostMetaUtils::getRenamedPostMeta($postId, 'project_id'));
+
+        if (! $projectId) {
+            // It may also be found by parsing post_meta.speechkit_response
+            $speechkit_response = static::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response');
+            preg_match('/"project_id":(")?(\d+)(?(1)\1|)/', (string)$speechkit_response, $matches);
+            // $matches[2] is the Project ID (response.project_id)
+            if ($matches && $matches[2]) {
+                $projectId = intval($matches[2]);
+            }
+        }
 
         // If we still don't have an ID then use the default from the plugin settings
         if (! $projectId) {
@@ -426,5 +444,38 @@ class PostMetaUtils
     public static function getDisabled($postId)
     {
         return PostMetaUtils::getRenamedPostMeta($postId, 'disabled');
+    }
+
+    /**
+     * Get HTTP response body from post meta.
+     *
+     * The data may have been saved as a WordPress HTTP response array. If it was,
+     * then return the 'body' key of the HTTP response instead of the raw post meta.
+     *
+     * The data may also have been saved as a WordPress WP_Error instance. If it was,
+     * then return a string containing the WP_Error code and message.
+     *
+     * @since 3.0.3
+     * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils
+     * @since 3.6.1 Handle responses saved as object of class WP_Error
+     *
+     * @param int    $postId   Post ID.
+     * @param string $metaName Post Meta name.
+     *
+     * @return string
+     */
+    public static function getHttpResponseBodyFromPostMeta($postId, $metaName)
+    {
+        $postMeta = get_post_meta($postId, $metaName, true);
+
+        if (is_array($postMeta)) {
+            return (string)wp_remote_retrieve_body($postMeta);
+        }
+
+        if (is_wp_error($postMeta)) {
+            return sprintf(PostMetaUtils::WP_ERROR_FORMAT, $postMeta->get_error_code(), $postMeta->get_error_message());
+        }
+
+        return (string)$postMeta;
     }
 }

--- a/src/Component/Post/SelectVoice/SelectVoice.php
+++ b/src/Component/Post/SelectVoice/SelectVoice.php
@@ -15,6 +15,7 @@ namespace Beyondwords\Wordpress\Component\Post\SelectVoice;
 use Beyondwords\Wordpress\Core\CoreUtils;
 use Beyondwords\Wordpress\Component\Settings\Fields\Languages\Languages;
 use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
+use Beyondwords\Wordpress\Core\ApiClient;
 
 /**
  * SelectVoice
@@ -23,23 +24,6 @@ use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
  */
 class SelectVoice
 {
-    /**
-     * API Client.
-     *
-     * @since 3.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 3.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
     /**
      * Init.
      *
@@ -80,7 +64,7 @@ class SelectVoice
         $languages         = $this->getFilteredLanguages();
         $currentLanguageId = get_post_meta($post->ID, 'beyondwords_language_id', true);
 
-        $voices         = $this->apiClient->getVoices($currentLanguageId);
+        $voices         = ApiClient::getVoices($currentLanguageId);
         $currentVoiceId = get_post_meta($post->ID, 'beyondwords_body_voice_id', true);
 
         if (! is_array($voices)) {
@@ -232,7 +216,7 @@ class SelectVoice
      */
     public function getFilteredLanguages()
     {
-        $languages = $this->apiClient->getLanguages();
+        $languages = ApiClient::getLanguages();
 
         if (! is_array($languages)) {
             return [];
@@ -306,7 +290,7 @@ class SelectVoice
     {
         $params = $data->get_url_params();
 
-        $voices = $this->apiClient->getVoices($params['languageId']);
+        $voices = ApiClient::getVoices($params['languageId']);
 
         return new \WP_REST_Response($voices);
     }

--- a/src/Component/Settings/Fields/ApiKey/ApiKey.php
+++ b/src/Component/Settings/Fields/ApiKey/ApiKey.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\ApiKey;
 
+use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
+
 /**
  * ApiKey
  *
@@ -96,18 +98,14 @@ class ApiKey
      **/
     public function sanitize($value)
     {
-        $errors = get_transient('beyondwords_settings_errors');
-
-        if (empty($errors)) {
-            $errors = [];
-        }
-
         if (empty($value)) {
-            $errors['Settings/ApiKey'] = __(
-                'Please enter the BeyondWords API key. This can be found in your project settings.',
-                'speechkit'
+            SettingsUtils::addSettingsErrorMessage(
+                __(
+                    'Please enter the BeyondWords API key. This can be found in your project settings.',
+                    'speechkit'
+                ),
+                'Settings/ApiKey'
             );
-            set_transient('beyondwords_settings_errors', $errors);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ApiKey/ApiKey.php
+++ b/src/Component/Settings/Fields/ApiKey/ApiKey.php
@@ -90,7 +90,7 @@ class ApiKey
      * Sanitise the setting value.
      *
      * @since 3.0.0
-     * @since 5.2.0 Replace API creds validation with attempted sync.
+     * @since 5.2.0 Remove creds validation from here.
      *
      * @param array $value The submitted value.
      *

--- a/src/Component/Settings/Fields/ApiKey/ApiKey.php
+++ b/src/Component/Settings/Fields/ApiKey/ApiKey.php
@@ -109,7 +109,7 @@ class ApiKey
             );
             set_transient('beyondwords_settings_errors', $errors);
         } else {
-            set_transient('beyondwords_validate_api_connection', true);
+            set_transient('beyondwords_validate_api_connection', true, 60);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ApiKey/ApiKey.php
+++ b/src/Component/Settings/Fields/ApiKey/ApiKey.php
@@ -87,15 +87,15 @@ class ApiKey
     /**
      * Sanitise the setting value.
      *
-     * @since  3.0.0
-     * @param  array $value The submitted value.
+     * @since 3.0.0
+     * @since 5.2.0 Replace API creds validation with attempted sync.
+     *
+     * @param array $value The submitted value.
      *
      * @return void
      **/
     public function sanitize($value)
     {
-        set_transient('beyondwords_validate_api_connection', true, 30);
-
         $errors = get_transient('beyondwords_settings_errors');
 
         if (empty($errors)) {
@@ -108,6 +108,8 @@ class ApiKey
                 'speechkit'
             );
             set_transient('beyondwords_settings_errors', $errors);
+        } else {
+            set_transient('beyondwords_validate_api_connection', true);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ApiKey/ApiKey.php
+++ b/src/Component/Settings/Fields/ApiKey/ApiKey.php
@@ -108,8 +108,6 @@ class ApiKey
                 'speechkit'
             );
             set_transient('beyondwords_settings_errors', $errors);
-        } else {
-            set_transient('beyondwords_validate_api_connection', true, 60);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/Language/Language.php
+++ b/src/Component/Settings/Fields/Language/Language.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Beyondwords\Wordpress\Component\Settings\Fields\Language;
 
 use Beyondwords\Wordpress\Component\Settings\Sync;
+use Beyondwords\Wordpress\Core\ApiClient;
 
 /**
  * Language
@@ -30,23 +31,6 @@ class Language
      * Option name.
      */
     public const OPTION_NAME_CODE = 'beyondwords_project_language_code';
-
-    /**
-     * API Client.
-     *
-     * @since 5.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
 
     /**
      * Constructor
@@ -145,7 +129,7 @@ class Language
      **/
     public function getOptions()
     {
-        $languages = $this->apiClient->getLanguages();
+        $languages = ApiClient::getLanguages();
 
         if (! is_array($languages)) {
             $languages = [];
@@ -177,7 +161,7 @@ class Language
             return;
         }
 
-        $languages = $this->apiClient->getLanguages();
+        $languages = ApiClient::getLanguages();
 
         if (! is_array($languages)) {
             return;

--- a/src/Component/Settings/Fields/Languages/Languages.php
+++ b/src/Component/Settings/Fields/Languages/Languages.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\Languages;
 
+use Beyondwords\Wordpress\Core\ApiClient;
+
 /**
  * Languages
  *
@@ -32,23 +34,6 @@ class Languages
      * @since 3.0.0
      */
     public const DEFAULT_LANGUAGES = [];
-
-    /**
-     * API Client.
-     *
-     * @since 3.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 3.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
 
     /**
      * Init.
@@ -96,7 +81,7 @@ class Languages
      **/
     public function render()
     {
-        $allLanguages = $this->apiClient->getLanguages();
+        $allLanguages = ApiClient::getLanguages();
 
         if (! is_array($allLanguages)) {
             $allLanguages = [];

--- a/src/Component/Settings/Fields/PlayerStyle/PlayerStyle.php
+++ b/src/Component/Settings/Fields/PlayerStyle/PlayerStyle.php
@@ -35,23 +35,6 @@ class PlayerStyle
     public const VIDEO = 'video';
 
     /**
-     * API Client.
-     *
-     * @since 5.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Constructor
      */
     public function init()

--- a/src/Component/Settings/Fields/ProjectId/ProjectId.php
+++ b/src/Component/Settings/Fields/ProjectId/ProjectId.php
@@ -87,15 +87,15 @@ class ProjectId
     /**
      * Sanitise the setting value.
      *
-     * @since  3.0.0
-     * @param  array $value The submitted value.
+     * @since 3.0.0
+     * @since 5.2.0 Replace API creds validation with attempted sync.
+     *
+     * @param array $value The submitted value.
      *
      * @return void
      **/
     public function sanitize($value)
     {
-        set_transient('beyondwords_validate_api_connection', true, 30);
-
         $errors = get_transient('beyondwords_settings_errors');
 
         if (empty($errors)) {
@@ -108,6 +108,8 @@ class ProjectId
                 'speechkit'
             );
             set_transient('beyondwords_settings_errors', $errors);
+        } else {
+            set_transient('beyondwords_validate_api_connection', true);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ProjectId/ProjectId.php
+++ b/src/Component/Settings/Fields/ProjectId/ProjectId.php
@@ -108,8 +108,6 @@ class ProjectId
                 'speechkit'
             );
             set_transient('beyondwords_settings_errors', $errors);
-        } else {
-            set_transient('beyondwords_validate_api_connection', true, 60);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ProjectId/ProjectId.php
+++ b/src/Component/Settings/Fields/ProjectId/ProjectId.php
@@ -109,7 +109,7 @@ class ProjectId
             );
             set_transient('beyondwords_settings_errors', $errors);
         } else {
-            set_transient('beyondwords_validate_api_connection', true);
+            set_transient('beyondwords_validate_api_connection', true, 60);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/ProjectId/ProjectId.php
+++ b/src/Component/Settings/Fields/ProjectId/ProjectId.php
@@ -90,7 +90,7 @@ class ProjectId
      * Sanitise the setting value.
      *
      * @since 3.0.0
-     * @since 5.2.0 Replace API creds validation with attempted sync.
+     * @since 5.2.0 Remove creds validation from here.
      *
      * @param array $value The submitted value.
      *

--- a/src/Component/Settings/Fields/ProjectId/ProjectId.php
+++ b/src/Component/Settings/Fields/ProjectId/ProjectId.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\ProjectId;
 
+use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
+
 /**
  * ProjectId
  *
@@ -96,18 +98,14 @@ class ProjectId
      **/
     public function sanitize($value)
     {
-        $errors = get_transient('beyondwords_settings_errors');
-
-        if (empty($errors)) {
-            $errors = [];
-        }
-
         if (empty($value)) {
-            $errors['Settings/ProjectId'] = __(
-                'Please enter your BeyondWords project ID. This can be found in your project settings.',
-                'speechkit'
+            SettingsUtils::addSettingsErrorMessage(
+                __(
+                    'Please enter your BeyondWords project ID. This can be found in your project settings.',
+                    'speechkit'
+                ),
+                'Settings/ProjectId'
             );
-            set_transient('beyondwords_settings_errors', $errors);
         }
 
         return $value;

--- a/src/Component/Settings/Fields/Voice/Voice.php
+++ b/src/Component/Settings/Fields/Voice/Voice.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Beyondwords\Wordpress\Component\Settings\Fields\Voice;
 
+use Beyondwords\Wordpress\Core\ApiClient;
+
 /**
  * Voice
  *
@@ -19,23 +21,6 @@ namespace Beyondwords\Wordpress\Component\Settings\Fields\Voice;
  */
 abstract class Voice
 {
-    /**
-     * API Client.
-     *
-     * @since 3.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 3.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
     /**
      * Get all options for the current component.
      *
@@ -46,7 +31,7 @@ abstract class Voice
     public function getOptions()
     {
         $languageId = get_option('beyondwords_project_language_id');
-        $voices     = $this->apiClient->getVoices($languageId);
+        $voices     = ApiClient::getVoices($languageId);
 
         if (! $voices) {
             return [];

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -60,7 +60,7 @@ class Settings
         (new Credentials())->init();
         (new Sync($this->apiClient))->init();
 
-        if (SettingsUtils::hasApiSettings()) {
+        if (SettingsUtils::hasApiCreds()) {
             (new Voices($this->apiClient))->init();
             (new Content())->init();
             (new Player($this->apiClient))->init();
@@ -153,7 +153,7 @@ class Settings
 
                 // Pronunciations currently has no fields to submit
                 if ($activeTab !== 'pronunciations') {
-                    if (SettingsUtils::hasApiSettings()) {
+                    if (SettingsUtils::hasApiCreds()) {
                         submit_button('Save changes');
                     } else {
                         submit_button('Continue setup');
@@ -198,7 +198,7 @@ class Settings
             'advanced'       => __('Advanced', 'speechkit'),
         );
 
-        if (! SettingsUtils::hasApiSettings()) {
+        if (! SettingsUtils::hasApiCreds()) {
             $tabs = array_splice($tabs, 0, 1);
         }
 
@@ -240,7 +240,7 @@ class Settings
      */
     public function printPluginAdminNotices()
     {
-        $hasApiSettings = SettingsUtils::hasApiSettings();
+        $hasApiSettings = SettingsUtils::hasApiCreds();
         $settingsErrors = get_transient('beyondwords_settings_errors');
 
         if (is_array($settingsErrors) && count($settingsErrors)) :

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -38,8 +38,6 @@ class Settings
      */
     public function init()
     {
-        delete_transient('beyondwords_settings_errors');
-
         (new Credentials())->init();
         (new Sync())->init();
 
@@ -220,7 +218,9 @@ class Settings
     public function printPluginAdminNotices()
     {
         $hasValidConnection = SettingsUtils::hasValidApiConnection();
-        $settingsErrors        = get_transient('beyondwords_settings_errors');
+        $settingsErrors     = get_transient('beyondwords_settings_errors');
+
+        delete_transient('beyondwords_settings_errors');
 
         if (is_array($settingsErrors) && count($settingsErrors)) :
             ?>
@@ -251,7 +251,6 @@ class Settings
                     ?>
                 </ul>
             </div>
-
             <?php
         elseif (false === $hasValidConnection) :
             ?>

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -34,23 +34,6 @@ use Beyondwords\Wordpress\Core\Environment;
 class Settings
 {
     /**
-     * API Client.
-     *
-     * @since 3.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 3.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Init
      */
     public function init()
@@ -58,14 +41,14 @@ class Settings
         delete_transient('beyondwords_settings_errors');
 
         (new Credentials())->init();
-        (new Sync($this->apiClient))->init();
+        (new Sync())->init();
 
         if (SettingsUtils::hasApiCreds()) {
-            (new Voices($this->apiClient))->init();
+            (new Voices())->init();
             (new Content())->init();
-            (new Player($this->apiClient))->init();
+            (new Player())->init();
             (new Pronunciations())->init();
-            (new Advanced($this->apiClient))->init();
+            (new Advanced())->init();
         }
 
         add_action('admin_menu', array($this, 'addOptionsPage'), 1);
@@ -148,6 +131,11 @@ class Settings
                 <hr class="wp-header-end">
 
                 <?php
+                if ($activeTab === 'credentials') {
+                    Sync::validateApiConnection();
+                }
+
+                settings_errors('beyondwords_messages');
                 settings_fields("beyondwords_{$activeTab}_settings");
                 do_settings_sections("beyondwords_{$activeTab}");
 

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -53,7 +53,7 @@ class Settings
         add_action('admin_notices', array($this, 'printMissingApiCredsWarning'), 100);
         add_action('admin_notices', array($this, 'printSettingsErrors'), 200);
         add_action('admin_enqueue_scripts', array($this, 'enqueueScripts'));
-        add_action('load-settings_page_beyondwords', array($this, 'validateApiCreds'), 40);
+        add_action('load-settings_page_beyondwords', array($this, 'validateApiCreds'));
 
         add_action('rest_api_init', array($this, 'restApiInit'));
 
@@ -86,31 +86,21 @@ class Settings
      */
     public function validateApiCreds()
     {
-        $tabs = $this->getTabs();
-
-        if (! count($tabs)) {
-            return;
-        }
-
-        $activeTab = $this->getActiveTab($tabs);
+        $activeTab = self::getActiveTab();
 
         if ($activeTab === 'credentials') {
             SettingsUtils::validateApiConnection();
         }
     }
+
     /**
      * @since 3.0.0
      * @since 4.7.0 Added tabs.
      */
     public function createAdminInterface()
     {
-        $tabs = $this->getTabs();
-
-        if (! count($tabs)) {
-            return;
-        }
-
-        $activeTab = $this->getActiveTab($tabs);
+        $tabs      = self::getTabs();
+        $activeTab = self::getActiveTab();
         ?>
         <div class="wrap">
             <h1>
@@ -184,8 +174,11 @@ class Settings
      * Get tabs.
      *
      * @since 4.7.0
+     * @since 5.2.0 Make static.
+     *
+     * @return array Tabs
      */
-    public function getTabs()
+    public static function getTabs()
     {
         $tabs = array(
             'credentials'    => __('Credentials', 'speechkit'),
@@ -207,9 +200,18 @@ class Settings
      * Get active tab.
      *
      * @since 4.7.0
+     * @since 5.2.0 Make static.
+     *
+     * @return string Active tab
      */
-    public function getActiveTab($tabs)
+    public static function getActiveTab()
     {
+        $tabs = self::getTabs();
+
+        if (! count($tabs)) {
+            return '';
+        }
+
         $defaultTab = array_key_first($tabs);
 
         // phpcs:disable WordPress.Security.NonceVerification.Recommended

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -135,7 +135,6 @@ class Settings
                     Sync::validateApiConnection();
                 }
 
-                settings_errors('beyondwords_messages');
                 settings_fields("beyondwords_{$activeTab}_settings");
                 do_settings_sections("beyondwords_{$activeTab}");
 

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -43,7 +43,7 @@ class Settings
         (new Credentials())->init();
         (new Sync())->init();
 
-        if (SettingsUtils::hasApiCreds()) {
+        if (SettingsUtils::hasValidApiConnection()) {
             (new Voices())->init();
             (new Content())->init();
             (new Player())->init();
@@ -131,20 +131,12 @@ class Settings
                 <hr class="wp-header-end">
 
                 <?php
-                if ($activeTab === 'credentials') {
-                    Sync::validateApiConnection();
-                }
-
                 settings_fields("beyondwords_{$activeTab}_settings");
                 do_settings_sections("beyondwords_{$activeTab}");
 
                 // Pronunciations currently has no fields to submit
                 if ($activeTab !== 'pronunciations') {
-                    if (SettingsUtils::hasApiCreds()) {
-                        submit_button('Save changes');
-                    } else {
-                        submit_button('Continue setup');
-                    }
+                    submit_button('Save changes');
                 }
                 ?>
             </form>
@@ -185,7 +177,7 @@ class Settings
             'advanced'       => __('Advanced', 'speechkit'),
         );
 
-        if (! SettingsUtils::hasApiCreds()) {
+        if (! SettingsUtils::hasValidApiConnection()) {
             $tabs = array_splice($tabs, 0, 1);
         }
 
@@ -227,27 +219,12 @@ class Settings
      */
     public function printPluginAdminNotices()
     {
-        $hasApiSettings = SettingsUtils::hasApiCreds();
-        $settingsErrors = get_transient('beyondwords_settings_errors');
+        $hasValidConnection = SettingsUtils::hasValidApiConnection();
+        $settingsErrors        = get_transient('beyondwords_settings_errors');
 
         if (is_array($settingsErrors) && count($settingsErrors)) :
             ?>
             <div class="notice notice-error">
-                <p>
-                    <strong>
-                        <?php
-                        printf(
-                            /* translators: %s is replaced with a "plugin settings" link */
-                            esc_html__('To use BeyondWords, please update the %s.', 'speechkit'),
-                            sprintf(
-                                '<a href="%s">%s</a>',
-                                esc_url(admin_url('options-general.php?page=beyondwords')),
-                                esc_html__('plugin settings', 'speechkit')
-                            )
-                        );
-                        ?>
-                    </strong>
-                </p>
                 <ul class="ul-disc">
                     <?php
                     foreach ($settingsErrors as $error) {
@@ -265,6 +242,8 @@ class Settings
                                     'strong' => array(),
                                     'i' => array(),
                                     'em' => array(),
+                                    'br' => array(),
+                                    'code' => array(),
                                 )
                             )
                         );
@@ -274,7 +253,7 @@ class Settings
             </div>
 
             <?php
-        elseif (false === $hasApiSettings) :
+        elseif (false === $hasValidConnection) :
             ?>
             <div class="notice notice-info">
                 <p>

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -130,22 +130,20 @@ class SettingsUtils
     }
 
     /**
-     * Do we have creds for the BeyondWords REST API?
+     * Do we have a valid REST API connection for the BeyondWords REST API?
      * 
-     * Note that this does not check whether the creds are valid, only that 
-     * they exist and are non-empty.
+     * Note that this only whether a valid REST API connection was made when 
+     * the API Key was supplied. The API connection may be invalidated at a later
+     * date e.g. if the API Key is revoked.
      *
      * @since  5.2.0
      * @static
      *
      * @return boolean
      */
-    public static function hasApiCreds()
+    public static function hasValidApiConnection()
     {
-        $apiKey    = trim(strval(get_option('beyondwords_api_key')));
-        $projectId = trim(strval(get_option('beyondwords_project_id')));
-    
-        return (strlen($apiKey) > 0) && (strlen($projectId) > 0);
+        return boolval(get_option('beyondwords_valid_api_connection'));
     }
 
     /**

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -130,17 +130,22 @@ class SettingsUtils
     }
 
     /**
-     * Do we have a valid API connection to call the BeyondWords REST API?
+     * Do we have creds for the BeyondWords REST API?
+     * 
+     * Note that this does not check whether the creds are valid, only that 
+     * they exist and are non-empty.
      *
-     * @since  3.0.0
-     * @since  4.0.0 Moved from Settings to SettingsUtils
+     * @since  5.2.0
      * @static
      *
      * @return boolean
      */
-    public static function hasApiSettings()
+    public static function hasApiCreds()
     {
-        return boolval(get_option('beyondwords_valid_api_connection'));
+        $apiKey    = trim(strval(get_option('beyondwords_api_key')));
+        $projectId = trim(strval(get_option('beyondwords_project_id')));
+    
+        return (strlen($apiKey) > 0) && (strlen($projectId) > 0);
     }
 
     /**

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -199,31 +199,25 @@ class SettingsUtils
 
         if ($validConnection) {
             update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
-            delete_transient('beyondwords_settings_errors');
             set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
+            delete_transient('beyondwords_settings_errors');
             return true;
         }
 
         // Cancel any syncs
         delete_transient('beyondwords_sync_to_wordpress');
 
-        // Set errors
-        $errors = get_transient('beyondwords_settings_errors');
-
-        if (empty($errors)) {
-            $errors = [];
-        }
-
-        $errors['Settings/ValidApiConnection'] = sprintf(
-            /* translators: %s is replaced with the JSON encoded REST API response body */
-            __(
-                'We were unable to validate your BeyondWords REST API connection.<br />Please check your project ID and API key, save changes, and contact us for support if this message remains.<br /><br />BeyondWords REST API Response:<br /><code>%s</code>', // phpcs:ignore Generic.Files.LineLength.TooLong
-                'speechkit'
+        self::addSettingsErrorMessage(
+            sprintf(
+                /* translators: %s is replaced with the JSON encoded REST API response body */
+                __(
+                    'We were unable to validate your BeyondWords REST API connection.<br />Please check your project ID and API key, save changes, and contact us for support if this message remains.<br /><br />BeyondWords REST API Response:<br /><code>%s</code>', // phpcs:ignore Generic.Files.LineLength.TooLong
+                    'speechkit'
+                ),
+                wp_json_encode($project)
             ),
-            wp_json_encode($project)
+            'Settings/ValidApiConnection'
         );
-
-        set_transient('beyondwords_settings_errors', $errors);
 
         return false;
     }
@@ -260,5 +254,33 @@ class SettingsUtils
             />
         </div>
         <?php
+    }
+
+    /**
+     * Add settings error message.
+     *
+     * @since 5.2.0
+     * @static
+     *
+     * @param string $message The error message.
+     * @param string $errorId The error ID.
+     *
+     * @return void
+     **/
+    public static function addSettingsErrorMessage($message, $errorId = '')
+    {
+        $errors = get_transient('beyondwords_settings_errors');
+
+        if (empty($errors)) {
+            $errors = [];
+        }
+
+        if (empty($errorId)) {
+            $errorId = bin2hex(random_bytes(8));
+        }
+
+        $errors[$errorId] = $message;
+
+        set_transient('beyondwords_settings_errors', $errors);
     }
 }

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -131,8 +131,8 @@ class SettingsUtils
 
     /**
      * Do we have a valid REST API connection for the BeyondWords REST API?
-     * 
-     * Note that this only whether a valid REST API connection was made when 
+     *
+     * Note that this only whether a valid REST API connection was made when
      * the API Key was supplied. The API connection may be invalidated at a later
      * date e.g. if the API Key is revoked.
      *

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -85,7 +85,7 @@ class Sync
      */
     public function init()
     {
-        add_action('load-settings_page_beyondwords', array($this, 'syncToWordPress'), 40);
+        add_action('load-settings_page_beyondwords', array($this, 'syncToWordPress'), 30);
 
         if (Environment::hasAutoSyncSettings()) {
             add_action('load-settings_page_beyondwords', array($this, 'scheduleSyncs'), 20);
@@ -103,14 +103,12 @@ class Sync
      */
     public function scheduleSyncs()
     {
-        // phpcs:disable WordPress.Security.NonceVerification.Recommended
-        $tab = null;
-        if (isset($_GET['tab'])) {
-            $tab = sanitize_key($_GET['tab']);
-        }
-        // phpcs:enable WordPress.Security.NonceVerification.Recommended
+        $tab = Settings::getActiveTab();
 
         switch ($tab) {
+            case 'credentials':
+                set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
+                break;
             case 'content':
                 set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
                 break;

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -149,9 +149,6 @@ class Sync
             return;
         }
 
-        // Assume invalid connection
-        delete_option('beyondwords_valid_api_connection');
-
         $projectId = get_option('beyondwords_project_id');
         $apiKey    = get_option('beyondwords_api_key');
 
@@ -169,7 +166,6 @@ class Sync
         );
 
         if ($validConnection) {
-            update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
             set_transient('beyondwords_sync_to_wordpress', ['all'], 30);
             return true;
         }

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Beyondwords\Wordpress\Component\Settings;
 
 use Beyondwords\Wordpress\Core\ApiClient;
+use Beyondwords\Wordpress\Core\Environment;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -86,7 +87,7 @@ class Sync
     {
         add_action('load-settings_page_beyondwords', array($this, 'syncToWordPress'), 40);
 
-        if (! defined('BEYONDWORDS_AUTO_SYNC_SETTINGS') || false != BEYONDWORDS_AUTO_SYNC_SETTINGS) {
+        if (Environment::hasAutoSyncSettings()) {
             add_action('load-settings_page_beyondwords', array($this, 'scheduleSyncs'), 20);
             add_action('load-settings_page_beyondwords', array(__CLASS__, 'validateApiConnection'), 30);
             add_action('shutdown', array($this, 'syncToDashboard'));
@@ -156,7 +157,7 @@ class Sync
         $validConnection = (
             is_array($project)
             && array_key_exists('id', $project)
-            && strval($project['id']) === $projectId
+            && strval($project['id']) === strval($projectId)
         );
 
         if ($validConnection) {

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -86,10 +86,10 @@ class Sync
     public function init()
     {
         add_action('load-settings_page_beyondwords', array($this, 'syncToWordPress'), 40);
+        add_action('load-settings_page_beyondwords', array(__CLASS__, 'validateApiConnection'), 30);
 
         if (Environment::hasAutoSyncSettings()) {
             add_action('load-settings_page_beyondwords', array($this, 'scheduleSyncs'), 20);
-            add_action('load-settings_page_beyondwords', array(__CLASS__, 'validateApiConnection'), 30);
             add_action('shutdown', array($this, 'syncToDashboard'));
         }
     }

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -106,9 +106,6 @@ class Sync
         $tab = Settings::getActiveTab();
 
         switch ($tab) {
-            case 'credentials':
-                set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
-                break;
             case 'content':
                 set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
                 break;

--- a/src/Component/Settings/Tabs/Advanced/Advanced.php
+++ b/src/Component/Settings/Tabs/Advanced/Advanced.php
@@ -24,30 +24,13 @@ use Beyondwords\Wordpress\Component\Settings\Fields\Languages\Languages;
 class Advanced
 {
     /**
-     * API client.
-     *
-     * @since 5.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Init
      *
      * @since 5.0.0
      */
     public function init()
     {
-        (new Languages($this->apiClient))->init();
+        (new Languages())->init();
 
         add_action('admin_init', array($this, 'addSettingsSection'), 5);
     }

--- a/src/Component/Settings/Tabs/Player/Player.php
+++ b/src/Component/Settings/Tabs/Player/Player.php
@@ -32,23 +32,6 @@ use Beyondwords\Wordpress\Component\Settings\Fields\TextHighlighting\TextHighlig
 class Player
 {
     /**
-     * API client.
-     *
-     * @since 5.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Init
      *
      * @since 5.0.0
@@ -56,7 +39,7 @@ class Player
     public function init()
     {
         (new PlayerUI())->init();
-        (new PlayerStyle($this->apiClient))->init();
+        (new PlayerStyle())->init();
         (new PlayerColors())->init();
         (new CallToAction())->init();
         (new WidgetStyle())->init();

--- a/src/Component/Settings/Tabs/Voices/Voices.php
+++ b/src/Component/Settings/Tabs/Voices/Voices.php
@@ -27,23 +27,6 @@ use Beyondwords\Wordpress\Component\Settings\Fields\Language\Language;
  */
 class Voices
 {
-     /**
-     * API Client.
-     *
-     * @since 5.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
     /**
      * Init
      *
@@ -51,10 +34,10 @@ class Voices
      */
     public function init()
     {
-        (new Language($this->apiClient))->init();
-        (new TitleVoice($this->apiClient))->init();
+        (new Language())->init();
+        (new TitleVoice())->init();
         (new TitleVoiceSpeakingRate())->init();
-        (new BodyVoice($this->apiClient))->init();
+        (new BodyVoice())->init();
         (new BodyVoiceSpeakingRate())->init();
 
         add_action('admin_init', array($this, 'addSettingsSection'), 5);

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -14,26 +14,26 @@ use Beyondwords\Wordpress\Component\Post\PostMetaUtils;
  **/
 class ApiClient
 {
-    public const ERROR_FORMAT = '#%s: %s';
-
     /**
-     * Init.
+     * Error format.
+     * 
+     * The error format used to display error messages in WordPress admin.
+     * 
+     * @var string
      */
-    public function init()
-    {
-        add_action('admin_notices', array($this, 'adminNotices'));
-    }
+    public const ERROR_FORMAT = '#%s: %s';
 
     /**
      * POST /projects/:id/content.
      *
      * @since 3.0.0
+     * @since 5.2.0 Make static.
      *
      * @param int $postId WordPress Post ID
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function createAudio($postId)
+    public static function createAudio($postId)
     {
         $projectId = PostMetaUtils::getProjectId($postId);
 
@@ -47,19 +47,20 @@ class ApiClient
 
         $request = new Request('POST', $url, $body);
 
-        return $this->callApi($request, $postId);
+        return self::callApi($request, $postId);
     }
 
     /**
      * PUT /projects/:id/content/:id.
      *
      * @since 3.0.0
+     * @since 5.2.0 Make static.
      *
      * @param int $postId WordPress Post ID
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function updateAudio($postId)
+    public static function updateAudio($postId)
     {
         $projectId = PostMetaUtils::getProjectId($postId);
         $contentId = PostMetaUtils::getContentId($postId);
@@ -74,19 +75,20 @@ class ApiClient
 
         $request = new Request('PUT', $url, $body);
 
-        return $this->callApi($request, $postId);
+        return self::callApi($request, $postId);
     }
 
     /**
      * DELETE /projects/:id/content/:id.
      *
      * @since 3.0.0
+     * @since 5.2.0 Make static.
      *
      * @param int $postId WordPress Post ID
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function deleteAudio($postId)
+    public static function deleteAudio($postId)
     {
         $projectId = PostMetaUtils::getProjectId($postId);
         $contentId = PostMetaUtils::getContentId($postId);
@@ -99,20 +101,21 @@ class ApiClient
 
         $request = new Request('DELETE', $url);
 
-        return $this->callApi($request, $postId);
+        return self::callApi($request, $postId);
     }
 
     /**
      * DELETE /projects/:id/content/:id.
      *
      * @since 4.1.0
+     * @since 5.2.0 Make static.
      *
      * @param int[] $postIds Array of WordPress Post IDs.
      *
      * @throws \Exception
-     * @return int[] The Post IDs with deleted audio.
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function batchDeleteAudio($postIds)
+    public static function batchDeleteAudio($postIds)
     {
         $contentIds = [];
         $updatedPostIds = [];
@@ -183,16 +186,17 @@ class ApiClient
      * @since 4.0.0 Introduced
      * @since 4.0.2 Prefix endpoint with /organization
      * @since 5.0.0 Cache response using transients
+     * @since 5.2.0 Make static.
      *
-     * @return array|object Array of voices or API error object.
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function getLanguages()
+    public static function getLanguages()
     {
         $url = sprintf('%s/organization/languages', Environment::getApiUrl());
 
         $request = new Request('GET', $url);
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
@@ -202,12 +206,13 @@ class ApiClient
      * @since 4.0.2 Prefix endpoint with /organization
      * @since 4.5.1 Check the $languageId param is numeric.
      * @since 5.0.0 Accept numeric language ID or string language code as param.
+     * @since 5.2.0 Make static.
      *
      * @param int|string $language BeyondWords Language code or numeric ID
      *
-     * @return array|object Array of voices or API error object.
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function getVoices($language)
+    public static function getVoices($language)
     {
         $field = 'language.code';
 
@@ -219,7 +224,7 @@ class ApiClient
 
         $request = new Request('GET', $url);
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
@@ -227,19 +232,20 @@ class ApiClient
      * GET /organization/voice is not available.
      *
      * @since 5.0.0
+     * @since 5.2.0 Make static.
      *
      * @param int       $voiceId  Voice ID.
      * @param int|false $language Language ID, optional.
      *
      * @return object|false Voice, or false if not found.
      **/
-    public function getVoice($voiceId, $languageId = false)
+    public static function getVoice($voiceId, $languageId = false)
     {
         if (! $languageId) {
             $languageId = get_option('beyondwords_project_language_id');
         }
 
-        $voices = $this->getVoices($languageId);
+        $voices = self::getVoices($languageId);
 
         if (empty($voices)) {
             return false;
@@ -252,12 +258,13 @@ class ApiClient
      * PUT /voices/:id.
      *
      * @since 5.0.0
+     * @since 5.2.0 Make static.
      *
      * @param array $settings Associative array of voice settings.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function updateVoice($voiceId, $settings)
+    public static function updateVoice($voiceId, $settings)
     {
         if (empty($voiceId)) {
             return false;
@@ -267,7 +274,7 @@ class ApiClient
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
@@ -275,10 +282,11 @@ class ApiClient
      *
      * @since 4.0.0
      * @since 5.0.0 Cache response using transients
+     * @since 5.2.0 Make static.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function getProject()
+    public static function getProject()
     {
         $projectId = get_option('beyondwords_project_id');
 
@@ -290,19 +298,20 @@ class ApiClient
 
         $request = new Request('GET', $url);
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
      * PUT /projects/:id.
      *
      * @since 5.0.0
+     * @since 5.2.0 Make static.
      *
      * @param array $settings Associative array of project settings.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function updateProject($settings)
+    public static function updateProject($settings)
     {
         $projectId = get_option('beyondwords_project_id');
 
@@ -314,17 +323,18 @@ class ApiClient
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
      * GET /projects/:id/player_settings.
      *
      * @since 4.0.0
+     * @since 5.2.0 Make static.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function getPlayerSettings()
+    public static function getPlayerSettings()
     {
         $projectId = get_option('beyondwords_project_id');
 
@@ -336,19 +346,20 @@ class ApiClient
 
         $request = new Request('GET', $url);
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
      * PUT /projects/:id/player_settings.
      *
      * @since 4.0.0
+     * @since 5.2.0 Make static.
      *
      * @param array $settings Associative array of player settings.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function updatePlayerSettings($settings)
+    public static function updatePlayerSettings($settings)
     {
         $projectId = get_option('beyondwords_project_id');
 
@@ -360,7 +371,7 @@ class ApiClient
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
@@ -368,12 +379,13 @@ class ApiClient
      *
      * @since 4.1.0
      * @since 5.0.0 Cache response using transients
+     * @since 5.2.0 Make static.
      *
      * @param int $projectId BeyondWords Project ID.
      *
-     * @return Response|false Response, or false
+     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function getVideoSettings($projectId = null)
+    public static function getVideoSettings($projectId = null)
     {
         if (! $projectId) {
             $projectId = get_option('beyondwords_project_id');
@@ -387,7 +399,7 @@ class ApiClient
 
         $request = new Request('GET', $url);
 
-        return $this->callApi($request);
+        return self::callApi($request);
     }
 
     /**
@@ -397,52 +409,40 @@ class ApiClient
      * @since 3.9.0 Stop saving the speechkit_status post meta - downgrades to plugin v2.x are no longer expected.
      * @since 4.0.0 Removed hash comparison.
      * @since 4.4.0 Handle 204 responses with no body.
+     * @since 5.2.0 Make static.
      *
      * @param Request $request Request.
      * @param int     $postId  WordPress Post ID
      *
      * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
      **/
-    public function callApi($request, $postId = false)
+    public static function callApi($request, $postId = false)
     {
-        // Pure
-        $args = $this->buildRequestArgs($request);
+        self::deleteErrors($postId);
 
-        if ($postId) {
-            // Side-effect: db write
-            $this->deleteErrors($postId);
+        $args = self::buildRequestArgs($request);
+        self::addRequestLogs($postId, $request, $args);
 
-            // Side-effect: db write
-            $this->addRequestLog($request, $args, $postId);
-        }
+        // Get response
+        $response = wp_remote_request($request->getUrl(), $args);
 
-        // WordPress core methods
-        $response        = wp_remote_request($request->getUrl(), $args);
-        $responseCode    = wp_remote_retrieve_response_code($response);
-        $responseMessage = wp_remote_retrieve_response_message($response);
-        $responseBody    = json_decode(wp_remote_retrieve_body($response), true);
+        // Get response details
+        $responseCode    = strval(wp_remote_retrieve_response_code($response));
+        $responseBodyRaw = wp_remote_retrieve_body($response);
+        $responseBody    = json_decode($responseBodyRaw, true);
 
         // 204 responses have no body
         if ($responseCode === 204) {
+            self::deleteLogs($postId);
+
             return null;
         }
 
         // Handle HTTP errors
         if (is_wp_error($response) || $responseCode > 299) {
-            // Prefer the response "message" field over the HTTP status message
-            if (is_array($responseBody) && array_key_exists('message', $responseBody)) {
-                $responseMessage = $responseBody['message'];
-            }
-        }
+            $message = self::errorMessageFromResponse($response);
 
-        $responseBodyJson = wp_remote_retrieve_body($response);
-        $responseBody     = json_decode($responseBodyJson, true);
-
-        // Response had a HTTP error code (3XX, 4XX, 5XX)
-        if ($responseCode > 299) {
-            $errorMessage = $this->errorMessageFromResponse($response);
-
-            $this->saveErrorMessage($postId, $responseMessage, $responseCode);
+            self::saveErrorMessage($postId, $message, $responseCode);
 
             return false;
         }
@@ -456,15 +456,12 @@ class ApiClient
                 wp_kses(json_last_error_msg(), [])
             );
 
-            $this->saveErrorMessage($postId, $errorMessage, 500);
+            self::saveErrorMessage($postId, $errorMessage, 500);
 
             return false;
         }
 
-        if ($postId) {
-            // Modifies db
-            $this->deleteRequestLog($postId);
-        }
+        self::deleteLogs($postId);
 
         return $responseBody;
     }
@@ -475,12 +472,13 @@ class ApiClient
      * @since 3.0.0
      * @since 4.0.0 Removed hash comparison and display 403 errors.
      * @since 4.1.0 Introduced.
+     * @since 5.2.0 Make static.
      *
      * @param Request $request BeyondWords Request.
      *
      * @return array WordPress HTTP Request arguments.
      */
-    public function buildRequestArgs($request)
+    public static function buildRequestArgs($request)
     {
         return [
             'blocking'    => true,
@@ -495,15 +493,18 @@ class ApiClient
      * Error message from BeyondWords REST API response.
      *
      * @since 4.1.0
+     * @since 5.2.0 Make static.
      *
      * @param mixed[] $response BeyondWords REST API response.
      *
      * @return string Error message.
      */
-    public function errorMessageFromResponse($response)
+    public static function errorMessageFromResponse($response)
     {
         $body = wp_remote_retrieve_body($response);
         $body = json_decode($body, true);
+
+        $message = wp_remote_retrieve_response_message($response);
 
         if (is_array($body) && array_key_exists('errors', $body)) {
             $messages = [];
@@ -515,8 +516,6 @@ class ApiClient
             $message = implode(", ", $messages);
         } elseif (is_array($body) && array_key_exists('message', $body)) {
             $message = $body['message'];
-        } else {
-            $message = wp_remote_retrieve_response_message($response);
         }
 
         return $message;
@@ -526,11 +525,18 @@ class ApiClient
      * Deletes errors for a post.
      *
      * @since 4.1.0 Introduced.
+     * @since 5.2.0 Make static.
      *
      * @param int $postId WordPress post ID.
+     *
+     * @return void
      */
-    public function deleteErrors($postId)
+    public static function deleteErrors($postId)
     {
+        if (! $postId) {
+            return;
+        }
+
         // Reset any existing errors before making this API call
         delete_post_meta($postId, 'speechkit_error_message');
         delete_post_meta($postId, 'beyondwords_error_message');
@@ -538,32 +544,44 @@ class ApiClient
 
     /**
      * Log the request details for a post.
+     * 
+     * Logs are removed later if the request was successful and retained if not.
      *
      * @since 4.1.0 Introduced.
+     * @since 5.2.0 Make static.
      *
-     * @param int    $postId   WordPress post ID.
+     * @param int     $postId  WordPress post ID.
      * @param Request $request BeyondWords Request.
+     * @param array   $args    BeyondWords Request args.
      *
-     * @param array WordPress HTTP Request arguments.
+     * @return void
      */
-    public function addRequestLog($request, $args, $postId)
+    public static function addRequestLogs($postId, $request, $args)
     {
-        // Log the request URL and args for debugging
-        // (these are removed for successful requests)
+        if (! $postId) {
+            return;
+        }
+
         update_post_meta($postId, 'beyondwords_request_url', $request->getUrl());
         update_post_meta($postId, 'beyondwords_request_args', var_export($args, true)); // phpcs:ignore
     }
 
     /**
-     * Deletes request details for a post.
+     * Deletes request/response logs for a post.
      *
      * @since 4.1.0 Introduced.
+     * @since 5.2.0 Make static.
      *
      * @param int $postId WordPress post ID.
+     *
+     * @return void
      */
-    public function deleteRequestLog($postId)
+    public static function deleteLogs($postId)
     {
-        // Success, so remove request URL and args log
+        if (! $postId) {
+            return;
+        }
+
         delete_post_meta($postId, 'beyondwords_request_url');
         delete_post_meta($postId, 'beyondwords_request_args');
     }
@@ -573,13 +591,20 @@ class ApiClient
      *
      * @since 4.1.0 Introduced.
      * @since 4.4.0 Rename from error() to saveErrorMessage().
+     * @since 5.2.0 Make static.
      *
      * @param int    $postId  WordPress post ID.
      * @param string $message Error message.
      * @param int    $code    Error code.
+     *
+     * @return void
      */
-    public function saveErrorMessage($postId, $message = '', $code = 500)
+    public static function saveErrorMessage($postId, $message = '', $code = 500)
     {
+        if (! $postId) {
+            return;
+        }
+
         if (! $message) {
             $message = sprintf(
                 /* translators: %s is replaced with the support email link */

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -16,9 +16,9 @@ class ApiClient
 {
     /**
      * Error format.
-     * 
+     *
      * The error format used to display error messages in WordPress admin.
-     * 
+     *
      * @var string
      */
     public const ERROR_FORMAT = '#%s: %s';
@@ -31,7 +31,7 @@ class ApiClient
      *
      * @param int $postId WordPress Post ID
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function createAudio($postId)
     {
@@ -45,9 +45,10 @@ class ApiClient
 
         $body = PostContentUtils::getContentParams($postId);
 
-        $request = new Request('POST', $url, $body);
+        $request  = new Request('POST', $url, $body);
+        $response = self::callApi($request, $postId);
 
-        return self::callApi($request, $postId);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -58,7 +59,7 @@ class ApiClient
      *
      * @param int $postId WordPress Post ID
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function updateAudio($postId)
     {
@@ -74,8 +75,9 @@ class ApiClient
         $body = PostContentUtils::getContentParams($postId);
 
         $request = new Request('PUT', $url, $body);
+        $response = self::callApi($request, $postId);
 
-        return self::callApi($request, $postId);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -86,7 +88,7 @@ class ApiClient
      *
      * @param int $postId WordPress Post ID
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function deleteAudio($postId)
     {
@@ -99,9 +101,16 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d/content/%s', Environment::getApiUrl(), $projectId, $contentId);
 
-        $request = new Request('DELETE', $url);
+        $request  = new Request('DELETE', $url);
+        $response = self::callApi($request, $postId);
+        $code     = wp_remote_retrieve_response_code($response);
 
-        return self::callApi($request, $postId);
+        // Expect 201 for deleted response
+        if ($code !== 204) {
+            return false;
+        }
+
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -113,7 +122,7 @@ class ApiClient
      * @param int[] $postIds Array of WordPress Post IDs.
      *
      * @throws \Exception
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function batchDeleteAudio($postIds)
     {
@@ -188,15 +197,16 @@ class ApiClient
      * @since 5.0.0 Cache response using transients
      * @since 5.2.0 Make static.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function getLanguages()
     {
         $url = sprintf('%s/organization/languages', Environment::getApiUrl());
 
         $request = new Request('GET', $url);
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -210,7 +220,7 @@ class ApiClient
      *
      * @param int|string $language BeyondWords Language code or numeric ID
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function getVoices($language)
     {
@@ -223,8 +233,9 @@ class ApiClient
         $url = sprintf('%s/organization/voices?filter[%s]=%s', Environment::getApiUrl(), $field, urlencode(strval($language))); // phpcs:ignore Generic.Files.LineLength.TooLong
 
         $request = new Request('GET', $url);
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -262,7 +273,7 @@ class ApiClient
      *
      * @param array $settings Associative array of voice settings.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function updateVoice($voiceId, $settings)
     {
@@ -273,8 +284,9 @@ class ApiClient
         $url = sprintf('%s/organization/voices/%d', Environment::getApiUrl(), $voiceId);
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -284,7 +296,7 @@ class ApiClient
      * @since 5.0.0 Cache response using transients
      * @since 5.2.0 Make static.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function getProject()
     {
@@ -297,8 +309,9 @@ class ApiClient
         $url = sprintf('%s/projects/%d', Environment::getApiUrl(), $projectId);
 
         $request = new Request('GET', $url);
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -309,7 +322,7 @@ class ApiClient
      *
      * @param array $settings Associative array of project settings.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function updateProject($settings)
     {
@@ -322,8 +335,9 @@ class ApiClient
         $url = sprintf('%s/projects/%d', Environment::getApiUrl(), $projectId);
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -332,7 +346,7 @@ class ApiClient
      * @since 4.0.0
      * @since 5.2.0 Make static.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function getPlayerSettings()
     {
@@ -345,8 +359,9 @@ class ApiClient
         $url = sprintf('%s/projects/%d/player_settings', Environment::getApiUrl(), $projectId);
 
         $request = new Request('GET', $url);
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -357,7 +372,7 @@ class ApiClient
      *
      * @param array $settings Associative array of player settings.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function updatePlayerSettings($settings)
     {
@@ -370,8 +385,9 @@ class ApiClient
         $url = sprintf('%s/projects/%d/player_settings', Environment::getApiUrl(), $projectId);
 
         $request = new Request('PUT', $url, wp_json_encode($settings));
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
@@ -383,7 +399,7 @@ class ApiClient
      *
      * @param int $projectId BeyondWords Project ID.
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return mixed JSON-decoded response body
      **/
     public static function getVideoSettings($projectId = null)
     {
@@ -398,72 +414,62 @@ class ApiClient
         $url = sprintf('%s/projects/%d/video_settings', Environment::getApiUrl(), (int)$projectId);
 
         $request = new Request('GET', $url);
+        $response = self::callApi($request);
 
-        return self::callApi($request);
+        return json_decode(wp_remote_retrieve_body($response));
     }
 
     /**
-     * Call the BeyondWords API backend.
+     * Call the BeyondWords API backend, logging any errors if the requests for a particular post.
+     *
+     * @todo investigate whether we can move the logging into a WordPress HTTP filter.
      *
      * @since 3.0.0
      * @since 3.9.0 Stop saving the speechkit_status post meta - downgrades to plugin v2.x are no longer expected.
      * @since 4.0.0 Removed hash comparison.
      * @since 4.4.0 Handle 204 responses with no body.
-     * @since 5.2.0 Make static.
+     * @since 5.2.0 Make static, return result from wp_remote_request.
      *
      * @param Request $request Request.
      * @param int     $postId  WordPress Post ID
      *
-     * @return array|null|false JSON-decoded response body, or null for 204, or false on failure
+     * @return array|WP_Error The response array or a WP_Error on failure. See WP_Http::request() for
+     *                        information on return value.
      **/
     public static function callApi($request, $postId = false)
     {
+        // By default we delete the request logs we temporarily store
+        $deleteRequestLogs = true;
+
         self::deleteErrors($postId);
 
         $args = self::buildRequestArgs($request);
+
         self::addRequestLogs($postId, $request, $args);
 
         // Get response
-        $response = wp_remote_request($request->getUrl(), $args);
+        $response     = wp_remote_request($request->getUrl(), $args);
+        $responseCode = wp_remote_retrieve_response_code($response);
 
-        // Get response details
-        $responseCode    = strval(wp_remote_retrieve_response_code($response));
-        $responseBodyRaw = wp_remote_retrieve_body($response);
-        $responseBody    = json_decode($responseBodyRaw, true);
-
-        // 204 responses have no body
-        if ($responseCode === 204) {
-            self::deleteLogs($postId);
-
-            return null;
+        // Mark API connection as invalid for 401 (API key may have been revoked)
+        if ($responseCode === 401) {
+            delete_option('beyondwords_valid_api_connection');
         }
 
-        // Handle HTTP errors
+        // Save error messages from WordPress HTTP errors and BeyondWords REST API error responses
         if (is_wp_error($response) || $responseCode > 299) {
+            $deleteRequestLogs = false;
+
             $message = self::errorMessageFromResponse($response);
 
             self::saveErrorMessage($postId, $message, $responseCode);
-
-            return false;
         }
 
-        // Handle invalid JSON
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            $errorMessage = sprintf(
-                /* translators: %s is replaced with the reason that JSON parsing failed */
-                __('Unable to parse JSON in BeyondWords API response. Reason: %s.', 'speechkit'),
-                // Don't allow any tags
-                wp_kses(json_last_error_msg(), [])
-            );
-
-            self::saveErrorMessage($postId, $errorMessage, 500);
-
-            return false;
+        if ($deleteRequestLogs) {
+            self::deleteLogs($postId);
         }
 
-        self::deleteLogs($postId);
-
-        return $responseBody;
+        return $response;
     }
 
     /**
@@ -506,16 +512,18 @@ class ApiClient
 
         $message = wp_remote_retrieve_response_message($response);
 
-        if (is_array($body) && array_key_exists('errors', $body)) {
-            $messages = [];
+        if (is_array($body)) {
+            if (array_key_exists('errors', $body)) {
+                $messages = [];
 
-            foreach ($body['errors'] as $error) {
-                $messages[] = implode(" ", array_values($error));
+                foreach ($body['errors'] as $error) {
+                    $messages[] = implode(' ', array_values($error));
+                }
+
+                $message = implode(', ', $messages);
+            } elseif (array_key_exists('message', $body)) {
+                $message = $body['message'];
             }
-
-            $message = implode(", ", $messages);
-        } elseif (is_array($body) && array_key_exists('message', $body)) {
-            $message = $body['message'];
         }
 
         return $message;
@@ -544,11 +552,11 @@ class ApiClient
 
     /**
      * Log the request details for a post.
-     * 
+     *
      * Logs are removed later if the request was successful and retained if not.
      *
      * @since 4.1.0 Introduced.
-     * @since 5.2.0 Make static.
+     * @since 5.2.0 Make static, use wp_json_encode(), don't save headers.
      *
      * @param int     $postId  WordPress post ID.
      * @param Request $request BeyondWords Request.
@@ -562,8 +570,11 @@ class ApiClient
             return;
         }
 
+        // Don't store headers in the logs
+        unset($args['headers']);
+
         update_post_meta($postId, 'beyondwords_request_url', $request->getUrl());
-        update_post_meta($postId, 'beyondwords_request_args', var_export($args, true)); // phpcs:ignore
+        update_post_meta($postId, 'beyondwords_request_args', wp_json_encode($args));
     }
 
     /**

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -105,7 +105,7 @@ class ApiClient
         $response = self::callApi($request, $postId);
         $code     = wp_remote_retrieve_response_code($response);
 
-        // Expect 201 for deleted response
+        // Expect 204 Deleted
         if ($code !== 204) {
             return false;
         }

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -48,7 +48,7 @@ class ApiClient
         $request  = new Request('POST', $url, $body);
         $response = self::callApi($request, $postId);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -74,10 +74,10 @@ class ApiClient
 
         $body = PostContentUtils::getContentParams($postId);
 
-        $request = new Request('PUT', $url, $body);
+        $request  = new Request('PUT', $url, $body);
         $response = self::callApi($request, $postId);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -110,7 +110,7 @@ class ApiClient
             return false;
         }
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -203,10 +203,10 @@ class ApiClient
     {
         $url = sprintf('%s/organization/languages', Environment::getApiUrl());
 
-        $request = new Request('GET', $url);
+        $request  = new Request('GET', $url);
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -232,10 +232,10 @@ class ApiClient
 
         $url = sprintf('%s/organization/voices?filter[%s]=%s', Environment::getApiUrl(), $field, urlencode(strval($language))); // phpcs:ignore Generic.Files.LineLength.TooLong
 
-        $request = new Request('GET', $url);
+        $request  = new Request('GET', $url);
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -283,10 +283,10 @@ class ApiClient
 
         $url = sprintf('%s/organization/voices/%d', Environment::getApiUrl(), $voiceId);
 
-        $request = new Request('PUT', $url, wp_json_encode($settings));
+        $request  = new Request('PUT', $url, wp_json_encode($settings));
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -308,10 +308,10 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d', Environment::getApiUrl(), $projectId);
 
-        $request = new Request('GET', $url);
+        $request  = new Request('GET', $url);
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -334,10 +334,10 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d', Environment::getApiUrl(), $projectId);
 
-        $request = new Request('PUT', $url, wp_json_encode($settings));
+        $request  = new Request('PUT', $url, wp_json_encode($settings));
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -358,10 +358,10 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d/player_settings', Environment::getApiUrl(), $projectId);
 
-        $request = new Request('GET', $url);
+        $request  = new Request('GET', $url);
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -384,10 +384,10 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d/player_settings', Environment::getApiUrl(), $projectId);
 
-        $request = new Request('PUT', $url, wp_json_encode($settings));
+        $request  = new Request('PUT', $url, wp_json_encode($settings));
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -413,10 +413,10 @@ class ApiClient
 
         $url = sprintf('%s/projects/%d/video_settings', Environment::getApiUrl(), (int)$projectId);
 
-        $request = new Request('GET', $url);
+        $request  = new Request('GET', $url);
         $response = self::callApi($request);
 
-        return json_decode(wp_remote_retrieve_body($response));
+        return json_decode(wp_remote_retrieve_body($response), true);
     }
 
     /**
@@ -441,10 +441,12 @@ class ApiClient
         // By default we delete the request logs we temporarily store
         $deleteRequestLogs = true;
 
+        // Delete existing errors before making this API call
         self::deleteErrors($postId);
 
         $args = self::buildRequestArgs($request);
 
+        // Log the request details
         self::addRequestLogs($postId, $request, $args);
 
         // Get response

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -14,26 +14,6 @@ use Beyondwords\Wordpress\Core\CoreUtils;
 class Core
 {
     /**
-     * API Client.
-     *
-     * @since 3.0.0
-     */
-    private $apiClient;
-
-    /**
-     * Constructor.
-     *
-     * @since 3.0.0
-     * @since 3.7.1 Remove the "X BeyondWords errors found" notice after a reported slow MySQL query.
-     * @since 3.9.0 Add actions for deleting/trashing/restoring posts.
-     * @since 4.0.0 Moved side-effects into init() method.
-     */
-    public function __construct($apiClient)
-    {
-        $this->apiClient = $apiClient;
-    }
-
-    /**
      * Init.
      *
      * @since 4.0.0
@@ -165,9 +145,9 @@ class Core
                 return false;
             }
 
-            $response = $this->apiClient->updateAudio($postId);
+            $response = ApiClient::updateAudio($postId);
         } else {
-            $response = $this->apiClient->createAudio($postId);
+            $response = ApiClient::createAudio($postId);
         }
 
         $projectId = PostMetaUtils::getProjectId($postId);
@@ -188,7 +168,7 @@ class Core
      */
     public function deleteAudioForPost($postId)
     {
-        return $this->apiClient->deleteAudio($postId);
+        return ApiClient::deleteAudio($postId);
     }
 
     /**
@@ -202,7 +182,7 @@ class Core
      */
     public function batchDeleteAudioForPosts($postIds)
     {
-        return $this->apiClient->batchDeleteAudio($postIds);
+        return ApiClient::batchDeleteAudio($postIds);
     }
 
     /**
@@ -357,7 +337,7 @@ class Core
             return false;
         }
 
-        $response = $this->apiClient->deleteAudio($postId);
+        $response = ApiClient::deleteAudio($postId);
 
         if (
             ! is_array($response) ||
@@ -399,7 +379,7 @@ class Core
             return false;
         }
 
-        $response = $this->apiClient->updateAudio($postId);
+        $response = ApiClient::updateAudio($postId);
 
         if (
             ! is_array($response) ||

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -224,7 +224,7 @@ class Core
      */
     public function enqueueBlockEditorAssets()
     {
-        if (! SettingsUtils::hasApiCreds()) {
+        if (! SettingsUtils::hasValidApiConnection()) {
             return;
         }
 

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -244,7 +244,7 @@ class Core
      */
     public function enqueueBlockEditorAssets()
     {
-        if (! SettingsUtils::hasApiSettings()) {
+        if (! SettingsUtils::hasApiCreds()) {
             return;
         }
 

--- a/src/Core/CoreUtils.php
+++ b/src/Core/CoreUtils.php
@@ -186,6 +186,7 @@ class CoreUtils
             'beyondwords_player_style',
             'beyondwords_player_version',
             'beyondwords_settings_updated',
+            'beyondwords_valid_api_connection',
             // v3.7.0 beyondwords_*
             'beyondwords_api_key',
             'beyondwords_prepend_excerpt',
@@ -195,8 +196,6 @@ class CoreUtils
         ];
 
         $deprecated = [
-            // v5.x
-            'beyondwords_valid_api_connection',
             // v3.0.0 speechkit_*
             'speechkit_api_key',
             'speechkit_prepend_excerpt',

--- a/src/Core/CoreUtils.php
+++ b/src/Core/CoreUtils.php
@@ -186,7 +186,6 @@ class CoreUtils
             'beyondwords_player_style',
             'beyondwords_player_version',
             'beyondwords_settings_updated',
-            'beyondwords_valid_api_connection',
             // v3.7.0 beyondwords_*
             'beyondwords_api_key',
             'beyondwords_prepend_excerpt',
@@ -196,6 +195,8 @@ class CoreUtils
         ];
 
         $deprecated = [
+            // v5.x
+            'beyondwords_valid_api_connection',
             // v3.0.0 speechkit_*
             'speechkit_api_key',
             'speechkit_prepend_excerpt',

--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -84,10 +84,18 @@ class Environment
      *
      * Override with BEYONDWORDS_PLAYER_INLINE_SCRIPT_TAG in wp-config.php.
      *
-     * @since  5.2.0-beta.1
+     * @since  5.2.0
      * @var    bool
      */
     public const BEYONDWORDS_PLAYER_INLINE_SCRIPT_TAG = false;
+
+    /**
+     * Auto-sync settings.
+     *
+     * @since  5.2.0
+     * @var    bool
+     */
+    public const BEYONDWORDS_AUTO_SYNC_SETTINGS = true;
 
     /**
      * @return string
@@ -176,6 +184,20 @@ class Environment
          * Filters whether the inline player script tag should be loaded.
          */
         $value = apply_filters('beyondwords_player_inline_script_tag', $value);
+
+        return $value;
+    }
+
+    /**
+     * @return bool
+     */
+    public static function hasAutoSyncSettings()
+    {
+        $value = static::BEYONDWORDS_AUTO_SYNC_SETTINGS;
+
+        if (defined('BEYONDWORDS_AUTO_SYNC_SETTINGS')) {
+            $value = (bool) BEYONDWORDS_AUTO_SYNC_SETTINGS;
+        }
 
         return $value;
     }

--- a/src/Core/Updater.php
+++ b/src/Core/Updater.php
@@ -29,7 +29,7 @@ class Updater
         $version = get_option('beyondwords_version', '1.0.0');
 
         if (version_compare($version, '5.0.0', '<') && get_option('beyondwords_api_key')) {
-            set_transient('beyondwords_sync_to_wordpress', ['all'], 30);
+            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
         }
 
         if (version_compare($version, '3.0.0', '<')) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -99,7 +99,7 @@ class Plugin
          * To prevent browser JS errors we skip adding admin UI components until
          * we have a valid REST API connection.
          */
-        if (SettingsUtils::hasApiSettings()) {
+        if (SettingsUtils::hasApiCreds()) {
             // Posts screen
             (new BulkEdit())->init();
             (new BulkEditNotices())->init();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Beyondwords\Wordpress;
 
 use Beyondwords\Wordpress\Compatibility\WPGraphQL\WPGraphQL;
-use Beyondwords\Wordpress\Core\ApiClient;
 use Beyondwords\Wordpress\Core\Core;
 use Beyondwords\Wordpress\Core\Environment;
 use Beyondwords\Wordpress\Core\Player\Player;
@@ -49,22 +48,6 @@ class Plugin
     public $player;
 
     /**
-     * The API client - this enables various components to access the API.
-     *
-     * @todo Consider switching from dependency injection to singleton or another
-     *       pattern so that components can perform API calls without DI.
-     */
-    public $apiClient;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->apiClient = new ApiClient();
-    }
-
-    /**
      * Constructor.
      *
      * @since 3.0.0
@@ -79,7 +62,7 @@ class Plugin
         (new WPGraphQL())->init();
 
         // Core
-        $this->core = new Core($this->apiClient);
+        $this->core = new Core();
         $this->core->init();
 
         // Site health
@@ -93,7 +76,7 @@ class Plugin
         }
 
         // Settings
-        (new Settings($this->apiClient))->init();
+        (new Settings())->init();
 
         /**
          * To prevent browser JS errors we skip adding admin UI components until
@@ -114,9 +97,9 @@ class Plugin
             // Post screen metabox
             (new GenerateAudio())->init();
             (new DisplayPlayer())->init();
-            (new SelectVoice($this->apiClient))->init();
+            (new SelectVoice())->init();
             (new PlayerStyle())->init();
-            (new Metabox($this->apiClient))->init();
+            (new Metabox())->init();
         }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,7 +82,7 @@ class Plugin
          * To prevent browser JS errors we skip adding admin UI components until
          * we have a valid REST API connection.
          */
-        if (SettingsUtils::hasApiCreds()) {
+        if (SettingsUtils::hasValidApiConnection()) {
             // Posts screen
             (new BulkEdit())->init();
             (new BulkEditNotices())->init();

--- a/tests/cypress/e2e/block-editor/player-style.cy.js
+++ b/tests/cypress/e2e/block-editor/player-style.cy.js
@@ -13,7 +13,6 @@ context( 'Block Editor: Player Style', () => {
 
   // Only test priority post types
   postTypes.filter( x => x.priority ).forEach( postType => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
       cy.visit( `/wp-admin/post-new.php?post_type=${postType.slug}` ).wait( 500 )
 

--- a/tests/cypress/e2e/classic-editor/player-style.cy.js
+++ b/tests/cypress/e2e/classic-editor/player-style.cy.js
@@ -17,7 +17,6 @@ context( 'Classic Editor: Player Style', () => {
   } )
 
   postTypes.filter( x => x.priority ).forEach( postType => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `uses the plugin setting as the default selected option for a ${postType.name}`, () => {
       cy.visit( `/wp-admin/post-new.php?post_type=${postType.slug}` ).wait( 500 )
 

--- a/tests/cypress/e2e/settings/content/content.cy.js
+++ b/tests/cypress/e2e/settings/content/content.cy.js
@@ -27,17 +27,16 @@ context( 'Settings > Content',  () => {
 
     cy.get( 'input[type="submit"]' ).click().wait( 1000 )
 
-    // @todo skipping because this fails now we auto-sync the API with WordPress
-    // cy.get( '#beyondwords_project_title_enabled' ).should( 'not.be.checked' )
-    // cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'not.be.checked' )
-    // cy.get( '#beyondwords_prepend_excerpt' ).should( 'be.checked' )
-    // cy.get( 'input[name="beyondwords_preselect[post]"]' ).should( 'be.checked' )
-    // cy.get( 'input[name="beyondwords_preselect[page]"]' ).should( 'not.be.checked' )
+    cy.get( '#beyondwords_project_title_enabled' ).should( 'not.be.checked' )
+    cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'not.be.checked' )
+    cy.get( '#beyondwords_prepend_excerpt' ).should( 'be.checked' )
+    cy.get( 'input[name="beyondwords_preselect[post]"]' ).should( 'be.checked' )
+    cy.get( 'input[name="beyondwords_preselect[page]"]' ).should( 'not.be.checked' )
 
-    // cy.visit( '/wp-admin/options.php' )
-    // cy.get( '#beyondwords_project_title_enabled' ).should( 'exist' )
-    // cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'exist' )
-    // cy.get( '#beyondwords_prepend_excerpt' ).should( 'exist' )
-    // cy.get( '#beyondwords_preselect' ).should( 'exist' )
+    cy.visit( '/wp-admin/options.php' )
+    cy.get( '#beyondwords_project_title_enabled' ).should( 'exist' )
+    cy.get( '#beyondwords_project_auto_publish_enabled' ).should( 'exist' )
+    cy.get( '#beyondwords_prepend_excerpt' ).should( 'exist' )
+    cy.get( '#beyondwords_preselect' ).should( 'exist' )
   } )
 } )

--- a/tests/cypress/e2e/settings/credentials/credentials.cy.js
+++ b/tests/cypress/e2e/settings/credentials/credentials.cy.js
@@ -4,7 +4,7 @@ context( 'Settings > Credentials',  () => {
     cy.login()
   } )
 
-  it.only( 'prompts for API credentials and hides other settings tabs until they are validated', () => {
+  it( 'prompts for API credentials and hides other settings tabs until they are validated', () => {
     cy.visit( '/wp-admin' )
 
     cy.showsPluginSettingsNotice()

--- a/tests/cypress/e2e/settings/credentials/credentials.cy.js
+++ b/tests/cypress/e2e/settings/credentials/credentials.cy.js
@@ -4,7 +4,7 @@ context( 'Settings > Credentials',  () => {
     cy.login()
   } )
 
-  it( 'prompts for API credentials and hides other settings tabs until they are supplied', () => {
+  it( 'prompts for API credentials and hides other settings tabs until they are validated', () => {
     cy.visit( '/wp-admin' )
 
     cy.showsPluginSettingsNotice()
@@ -32,14 +32,12 @@ context( 'Settings > Credentials',  () => {
     cy.showsPluginSettingsNotice()
     cy.showsOnlyCredentialsSettingsTab()
 
-    // Invalid creds (this used to show the invalid creds notice, but we don't validate creds anymore)
+    // Invalid creds
     cy.get( 'input[name="beyondwords_api_key"]' ).clear().type( Cypress.env( 'apiKey' ) )
     cy.get( 'input[name="beyondwords_project_id"]' ).clear().type( '401' ) // Project 401 triggers a 403 response in Mockoon
     cy.get( 'input[type="submit"]' ).click().wait( 1000 )
-    cy.showsAllSettingsTabs()
-
-    // No notices
-    cy.get( '.notice-error' ).should( 'not.exist' )
+    cy.showsInvalidApiCredsNotice()
+    cy.showsOnlyCredentialsSettingsTab()
 
     // Valid API Key & Project ID
     cy.get( 'input[name="beyondwords_api_key"]' ).clear().type( Cypress.env( 'apiKey' ) )
@@ -57,8 +55,9 @@ context( 'Settings > Credentials',  () => {
     cy.get( 'input[name="beyondwords_project_id"]' ).should( 'have.value', Cypress.env( 'projectId' ) )
 
     cy.visit( '/wp-admin/options.php' )
-    cy.get( '#beyondwords_api_key' ).should( 'exist' )
-    cy.get( '#beyondwords_project_id' ).should( 'exist' )
+    cy.get( '#beyondwords_api_key' ).should( 'have.value', Cypress.env( 'apiKey' ) );
+    cy.get( '#beyondwords_project_id' ).should( 'have.value', Cypress.env( 'projectId' ) );
+    cy.get( '#beyondwords_valid_api_connection' ).should( 'exist' )
     cy.get( '#beyondwords_version' ).should( 'exist' )
   } )
 } )

--- a/tests/cypress/e2e/settings/credentials/credentials.cy.js
+++ b/tests/cypress/e2e/settings/credentials/credentials.cy.js
@@ -4,7 +4,7 @@ context( 'Settings > Credentials',  () => {
     cy.login()
   } )
 
-  it( 'prompts for API credentials and hides other settings tabs until they are valid', () => {
+  it( 'prompts for API credentials and hides other settings tabs until they are supplied', () => {
     cy.visit( '/wp-admin' )
 
     cy.showsPluginSettingsNotice()
@@ -32,12 +32,14 @@ context( 'Settings > Credentials',  () => {
     cy.showsPluginSettingsNotice()
     cy.showsOnlyCredentialsSettingsTab()
 
-    // Invalid creds
+    // Invalid creds (this used to show the invalid creds notice, but we don't validate creds anymore)
     cy.get( 'input[name="beyondwords_api_key"]' ).clear().type( Cypress.env( 'apiKey' ) )
     cy.get( 'input[name="beyondwords_project_id"]' ).clear().type( '401' ) // Project 401 triggers a 403 response in Mockoon
     cy.get( 'input[type="submit"]' ).click().wait( 1000 )
-    cy.showsInvalidApiCredsNotice()
-    cy.showsOnlyCredentialsSettingsTab()
+    cy.showsAllSettingsTabs()
+
+    // No notices
+    cy.get( '.notice-error' ).should( 'not.exist' )
 
     // Valid API Key & Project ID
     cy.get( 'input[name="beyondwords_api_key"]' ).clear().type( Cypress.env( 'apiKey' ) )

--- a/tests/cypress/e2e/settings/credentials/credentials.cy.js
+++ b/tests/cypress/e2e/settings/credentials/credentials.cy.js
@@ -57,7 +57,6 @@ context( 'Settings > Credentials',  () => {
     cy.visit( '/wp-admin/options.php' )
     cy.get( '#beyondwords_api_key' ).should( 'exist' )
     cy.get( '#beyondwords_project_id' ).should( 'exist' )
-    cy.get( '#beyondwords_valid_api_connection' )
     cy.get( '#beyondwords_version' ).should( 'exist' )
   } )
 } )

--- a/tests/cypress/e2e/settings/credentials/credentials.cy.js
+++ b/tests/cypress/e2e/settings/credentials/credentials.cy.js
@@ -4,7 +4,7 @@ context( 'Settings > Credentials',  () => {
     cy.login()
   } )
 
-  it( 'prompts for API credentials and hides other settings tabs until they are validated', () => {
+  it.only( 'prompts for API credentials and hides other settings tabs until they are validated', () => {
     cy.visit( '/wp-admin' )
 
     cy.showsPluginSettingsNotice()

--- a/tests/cypress/e2e/settings/player/call-to-action.cy.js
+++ b/tests/cypress/e2e/settings/player/call-to-action.cy.js
@@ -15,7 +15,6 @@ context( 'Settings > Player > Call-to-action',  () => {
   ];
 
   values.forEach( value => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `sets "${value}"`, () => {
       cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/playback-from-segments.cy.js
+++ b/tests/cypress/e2e/settings/player/playback-from-segments.cy.js
@@ -9,7 +9,6 @@ context( 'Settings > Player > Playback from segments',  () => {
     cy.login()
   } )
 
-  // @todo skipping because this fails now we auto-sync the API with WordPress
   it( `sets "Playback from segments"`, () => {
     cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/player-colors.cy.js
+++ b/tests/cypress/e2e/settings/player/player-colors.cy.js
@@ -29,7 +29,6 @@ context( 'Settings > Player > Player colors',  () => {
     text_color: '#b00',
   };
 
-  // @todo skipping because this fails now we auto-sync the API with WordPress
   it( `sets Player colors"`, () => {
     cy.saveMinimalPluginSettings()
 
@@ -59,12 +58,12 @@ context( 'Settings > Player > Player colors',  () => {
       const data = JSON.parse( val.text() )
       expect( data ).to.deep.equal( light_theme )
     })
-      
+
     cy.getSiteHealthValue( 'Dark theme' ).then( val => {
       const data = JSON.parse( val.text() )
       expect( data ).to.deep.equal( dark_theme )
     })
-      
+
     cy.getSiteHealthValue( 'Video theme' ).then( val => {
       const data = JSON.parse( val.text() )
       expect( data ).to.deep.equal( video_theme )

--- a/tests/cypress/e2e/settings/player/player-theme.cy.js
+++ b/tests/cypress/e2e/settings/player/player-theme.cy.js
@@ -25,7 +25,6 @@ context( 'Settings > Player > Player theme',  () => {
   ];
 
   themes.forEach( theme => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `sets "${theme.label}"`, () => {
       cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/player-ui.cy.js
+++ b/tests/cypress/e2e/settings/player/player-ui.cy.js
@@ -9,7 +9,6 @@ context( 'Settings > Player UI',  () => {
     cy.login()
   } )
 
-  // @todo skipping because this fails now we auto-sync the API with WordPress
   it( 'uses "Enabled" Player UI setting', () => {
     cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/skip-button-style.cy.js
+++ b/tests/cypress/e2e/settings/player/skip-button-style.cy.js
@@ -15,7 +15,6 @@ context( 'Settings > Player > Skip button style',  () => {
   ];
 
   values.forEach( value => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `sets "${value}"`, () => {
       cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/text-highlighting.cy.js
+++ b/tests/cypress/e2e/settings/player/text-highlighting.cy.js
@@ -9,7 +9,6 @@ context( 'Settings > Player > Text highlighting',  () => {
     cy.login()
   } )
 
-  // @todo skipping because this fails now we auto-sync the API with WordPress
   it( `sets "Text highlighting"`, () => {
     cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/widget-position.cy.js
+++ b/tests/cypress/e2e/settings/player/widget-position.cy.js
@@ -30,7 +30,6 @@ context( 'Settings > Player > Widget position',  () => {
   ];
 
   options.forEach( option => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `sets "${option.label}"`, () => {
       cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/player/widget-style.cy.js
+++ b/tests/cypress/e2e/settings/player/widget-style.cy.js
@@ -33,7 +33,6 @@ context( 'Settings > Player > Widget style',  () => {
   ];
 
   options.forEach( option => {
-    // @todo skipping because this fails now we auto-sync the API with WordPress
     it( `sets "${option.label}"`, () => {
       cy.saveMinimalPluginSettings()
 

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -39,7 +39,7 @@ context( 'Settings',  () => {
   } )
 
   it( 'syncs the settings from the Dashboard to WordPress', () => {
-    cy.saveAllPluginSettings()
+    cy.saveMinimalPluginSettings()
 
     cy.visit( '/wp-admin/options.php' )
 
@@ -94,7 +94,7 @@ context( 'Settings',  () => {
   } )
 
   it( 'removes the plugin settings when uninstalled', () => {
-    cy.saveAllPluginSettings()
+    cy.saveMinimalPluginSettings()
 
     cy.visit( '/wp-admin/options.php' )
 

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -38,7 +38,7 @@ context( 'Settings',  () => {
     cy.get( 'select#beyondwords_project_body_voice_id' ).find( ':selected' ).contains( 'Voice 3' )
   } )
 
-  it.only( 'syncs the settings from the Dashboard to WordPress', () => {
+  it( 'syncs the settings from the Dashboard to WordPress', () => {
     cy.saveAllPluginSettings()
 
     cy.visit( '/wp-admin/options.php' )
@@ -120,6 +120,7 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_project_language_id' )
     cy.get( '#beyondwords_project_title_voice_id' )
     cy.get( '#beyondwords_project_title_voice_speaking_rate' )
+    cy.get( '#beyondwords_valid_api_connection' )
     cy.get( '#beyondwords_version' )
 
     // The plugin files will not be deleted. Only the uninstall procedure will be run.
@@ -149,6 +150,7 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_project_language_id' ).should( 'not.exist' )
     cy.get( '#beyondwords_project_title_voice_id' ).should( 'not.exist' )
     cy.get( '#beyondwords_project_title_voice_speaking_rate' ).should( 'not.exist' )
+    cy.get( '#beyondwords_valid_api_connection' ).should( 'not.exist' )
     cy.get( '#beyondwords_version' ).should( 'not.exist' )
   } )
 } )

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -66,8 +66,7 @@ context( 'Settings',  () => {
 
     cy.get( 'form#all-options' ).submit()
 
-    cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=content' )
-    cy.visit( '/wp-admin/options-general.php?page=beyondwords&tab=player' )
+    cy.visit( '/wp-admin/options-general.php?page=beyondwords' ).wait( 2000 )
 
     cy.visit( '/wp-admin/options.php' )
 
@@ -104,7 +103,6 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_player_call_to_action' )
     cy.get( '#beyondwords_player_clickable_sections' )
     cy.get( '#beyondwords_player_theme_dark' )
-    // cy.get( '#beyondwords_player_highlight_sections' ) // @todo get this to appear
     cy.get( '#beyondwords_player_theme_light' )
     cy.get( '#beyondwords_player_skip_button_style' )
     cy.get( '#beyondwords_player_style' )
@@ -112,8 +110,6 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_player_theme_video' )
     cy.get( '#beyondwords_player_widget_position' )
     cy.get( '#beyondwords_player_widget_style' )
-    // cy.get( '#beyondwords_prepend_excerpt' ) // @todo get this to appear
-    // cy.get( '#beyondwords_preselect' ) // @todo get this to appear
     cy.get( '#beyondwords_project_body_voice_id' )
     cy.get( '#beyondwords_project_id' )
     cy.get( '#beyondwords_project_language_code' )

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -121,7 +121,6 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_project_language_id' )
     cy.get( '#beyondwords_project_title_voice_id' )
     cy.get( '#beyondwords_project_title_voice_speaking_rate' )
-    cy.get( '#beyondwords_valid_api_connection' )
     cy.get( '#beyondwords_version' )
 
     // The plugin files will not be deleted. Only the uninstall procedure will be run.
@@ -151,7 +150,6 @@ context( 'Settings',  () => {
     cy.get( '#beyondwords_project_language_id' ).should( 'not.exist' )
     cy.get( '#beyondwords_project_title_voice_id' ).should( 'not.exist' )
     cy.get( '#beyondwords_project_title_voice_speaking_rate' ).should( 'not.exist' )
-    cy.get( '#beyondwords_valid_api_connection' ).should( 'not.exist' )
     cy.get( '#beyondwords_version' ).should( 'not.exist' )
   } )
 } )

--- a/tests/cypress/e2e/settings/settings.cy.js
+++ b/tests/cypress/e2e/settings/settings.cy.js
@@ -38,8 +38,7 @@ context( 'Settings',  () => {
     cy.get( 'select#beyondwords_project_body_voice_id' ).find( ':selected' ).contains( 'Voice 3' )
   } )
 
-  // Skip this test in CI because auto-syncing settings is not supported in CI
-  it( 'syncs the settings from the Dashboard to WordPress', () => {
+  it.only( 'syncs the settings from the Dashboard to WordPress', () => {
     cy.saveAllPluginSettings()
 
     cy.visit( '/wp-admin/options.php' )

--- a/tests/cypress/e2e/site-health.cy.js
+++ b/tests/cypress/e2e/site-health.cy.js
@@ -184,7 +184,7 @@ context( 'Site Health', () => {
         // BEYONDWORDS_AUTO_SYNC_SETTINGS
         cy.get( 'tr' ).eq( 32 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'BEYONDWORDS_AUTO_SYNC_SETTINGS' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Undefined' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', 'False' )
         } )
         // BEYONDWORDS_AUTOREGENERATE
         cy.get( 'tr' ).eq( 33 ).within( () => {

--- a/tests/cypress/e2e/site-health.cy.js
+++ b/tests/cypress/e2e/site-health.cy.js
@@ -2,7 +2,7 @@ context( 'Site Health', () => {
   before( () => {
     cy.task( 'reset' )
     cy.login()
-    cy.saveAllPluginSettings()
+    cy.saveMinimalPluginSettings()
   } )
 
   beforeEach( () => {
@@ -74,7 +74,7 @@ context( 'Site Health', () => {
         // Preselect ‘Generate audio’
         cy.get( 'tr' ).eq( 10 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Preselect ‘Generate audio’' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "post": "1",\n    "page": "1",\n    "cpt_active": "1"\n}' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "post": "1",\n    "page": "1"\n}' )
         } )
         // Default language code
         cy.get( 'tr' ).eq( 11 ).within( () => {
@@ -124,17 +124,17 @@ context( 'Site Health', () => {
         // Light theme
         cy.get( 'tr' ).eq( 20 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Light theme' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#f5f5f5",\n    "icon_color": "#000",\n    "text_color": "#111",\n    "highlight_color": "#eee"\n}' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#F5F5F5",\n    "icon_color": "#000",\n    "text_color": "#111",\n    "highlight_color": "#EEE"\n}' )
         } )
         // Dark theme
         cy.get( 'tr' ).eq( 21 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Dark theme' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "transparent",\n    "icon_color": "#fff",\n    "text_color": "#fff",\n    "highlight_color": "#444"\n}' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "TRANSPARENT",\n    "icon_color": "#FFF",\n    "text_color": "#FFF",\n    "highlight_color": "#444"\n}' )
         } )
         // Video theme
         cy.get( 'tr' ).eq( 22 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'Video theme' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#f5f5f5",\n    "icon_color": "#000",\n    "text_color": "#111"\n}' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', '{\n    "background_color": "#F5F5F5",\n    "icon_color": "#000",\n    "text_color": "#111"\n}' )
         } )
         // Call-to-action
         cy.get( 'tr' ).eq( 23 ).within( () => {

--- a/tests/cypress/e2e/site-health.cy.js
+++ b/tests/cypress/e2e/site-health.cy.js
@@ -184,7 +184,7 @@ context( 'Site Health', () => {
         // BEYONDWORDS_AUTO_SYNC_SETTINGS
         cy.get( 'tr' ).eq( 32 ).within( () => {
           cy.get( 'td' ).eq( 0 ).should( 'have.text', 'BEYONDWORDS_AUTO_SYNC_SETTINGS' )
-          cy.get( 'td' ).eq( 1 ).should( 'have.text', 'False' )
+          cy.get( 'td' ).eq( 1 ).should( 'have.text', 'Undefined' )
         } )
         // BEYONDWORDS_AUTOREGENERATE
         cy.get( 'tr' ).eq( 33 ).within( () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -84,7 +84,7 @@ Cypress.Commands.add( 'showsPluginSettingsNotice', () => {
 
 Cypress.Commands.add( 'showsInvalidApiCredsNotice', () => {
   cy.get( '.notice-error' ).find( 'li' ).should('have.length', 1)
-  cy.get( '.notice-error' ).find( 'li' ).eq( 0 ).contains( 'We were unable to validate your BeyondWords API connection. Please check your project ID and API key, Save changes, and contact us for support if this message remains.' )
+  cy.get( '.notice-error' ).find( 'li' ).eq( 0 ).contains( 'We were unable to validate your BeyondWords REST API connection.' )
 } )
 
 Cypress.Commands.add( 'getPluginSettingsNoticeLink', () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -84,7 +84,7 @@ Cypress.Commands.add( 'showsPluginSettingsNotice', () => {
 
 Cypress.Commands.add( 'showsInvalidApiCredsNotice', () => {
   cy.get( '.notice-error' ).find( 'li' ).should('have.length', 1)
-  cy.get( '.notice-error' ).find( 'li' ).eq( 0 ).contains( 'Please check and re-enter your BeyondWords API key and project ID. They appear to be invalid.' )
+  cy.get( '.notice-error' ).find( 'li' ).eq( 0 ).contains( 'We were unable to validate your BeyondWords API connection. Please check your project ID and API key, Save changes, and contact us for support if this message remains.' )
 } )
 
 Cypress.Commands.add( 'getPluginSettingsNoticeLink', () => {

--- a/tests/phpunit/Component/Post/Metabox/MetaboxTest.php
+++ b/tests/phpunit/Component/Post/Metabox/MetaboxTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Beyondwords\Wordpress\Component\Post\Metabox\Metabox;
-use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
 class MetaboxTest extends WP_UnitTestCase
@@ -21,8 +20,7 @@ class MetaboxTest extends WP_UnitTestCase
         global $wp_meta_boxes;
         $wp_meta_boxes = null;
 
-        $apiClient = new ApiClient();
-        $this->_instance = new Metabox($apiClient);
+        $this->_instance = new Metabox();
     }
 
     public function tearDown(): void

--- a/tests/phpunit/Component/Post/Panel/Inspect/InspectTest.php
+++ b/tests/phpunit/Component/Post/Panel/Inspect/InspectTest.php
@@ -128,7 +128,7 @@ class InspectTest extends \WP_UnitTestCase
      */
     public function saveWithRemove()
     {
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
         $postId = $this->factory->post->create([

--- a/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
@@ -21,7 +21,7 @@ class PostPlayerStyleTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Component/Post/PlayerStyle/PlayerStyleTest.php
@@ -23,7 +23,6 @@ class PostPlayerStyleTest extends WP_UnitTestCase
         // Your set up methods here.
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -31,7 +30,6 @@ class PostPlayerStyleTest extends WP_UnitTestCase
         // Your tear down methods here.
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
+++ b/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
@@ -11,31 +11,23 @@
  */
 
 use Beyondwords\Wordpress\Component\Post\SelectVoice\SelectVoice;
-use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
 class SelectVoiceTest extends WP_UnitTestCase
 {
-    /**
-     * @var ApiClient
-     */
-    private $apiClient;
-
     public function setUp(): void
     {
         // Before...
         parent::setUp();
 
         // Your set up methods here.
-        $this->apiClient = new ApiClient();
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
         // Your tear down methods here.
-        $this->apiClient = null;
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
@@ -48,7 +40,7 @@ class SelectVoiceTest extends WP_UnitTestCase
      */
     public function init()
     {
-        $selectVoice = new SelectVoice($this->apiClient);
+        $selectVoice = new SelectVoice();
         $selectVoice->init();
 
         do_action('wp_loaded');
@@ -74,7 +66,7 @@ class SelectVoiceTest extends WP_UnitTestCase
             ],
         ]);
 
-        $selectVoice = new SelectVoice($this->apiClient);
+        $selectVoice = new SelectVoice();
 
         $selectVoice->element($post);
 
@@ -127,7 +119,7 @@ class SelectVoiceTest extends WP_UnitTestCase
     {
         $_POST['beyondwords_select_voice_nonce'] = wp_create_nonce('beyondwords_select_voice');
 
-        $selectVoice = new SelectVoice($this->apiClient);
+        $selectVoice = new SelectVoice();
 
         $postId = self::factory()->post->create([
             'post_title' => 'SelectVoiceTest::save',

--- a/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
+++ b/tests/phpunit/Component/Post/SelectVoice/SelectVoiceTest.php
@@ -30,7 +30,6 @@ class SelectVoiceTest extends WP_UnitTestCase
         $this->apiClient = new ApiClient();
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -39,7 +38,6 @@ class SelectVoiceTest extends WP_UnitTestCase
         $this->apiClient = null;
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Core/ApiClientTest.php
+++ b/tests/phpunit/Core/ApiClientTest.php
@@ -33,27 +33,6 @@ class ApiClientTest extends WP_UnitTestCase
     /**
      * @test
      */
-    public function createAudioWithoutApiKeySetting()
-    {
-        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-
-        $postId = self::factory()->post->create([
-            'post_title' => 'ApiClientTest::createAudioWithoutApiKeySetting',
-        ]);
-
-        $response = ApiClient::createAudio($postId);
-
-        $this->assertSame(401, wp_remote_retrieve_response_code($response));
-        $this->assertEmptyString($response);
-
-        wp_delete_post($postId, true);
-
-        delete_option('beyondwords_project_id');
-    }
-
-    /**
-     * @test
-     */
     public function createAudioWithoutProjectIdSetting()
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
@@ -64,7 +43,7 @@ class ApiClientTest extends WP_UnitTestCase
 
         $response = ApiClient::createAudio($postId);
 
-        $this->assertEmptyString($response);
+        $this->assertFalse($response);
 
         wp_delete_post($postId, true);
 
@@ -85,7 +64,8 @@ class ApiClientTest extends WP_UnitTestCase
 
         $response = ApiClient::createAudio($postId);
 
-        $this->assertSame(201, wp_remote_retrieve_response_code($response));
+        $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID,  $response['id']);
+        $this->assertSame('processed',  $response['status']);
 
         wp_delete_post($postId, true);
 
@@ -111,7 +91,8 @@ class ApiClientTest extends WP_UnitTestCase
 
         $response = ApiClient::updateAudio($postId);
 
-        $this->assertSame(201, wp_remote_retrieve_response_code($response));
+        $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID,  $response['id']);
+        $this->assertSame('processed',  $response['status']);
 
         wp_delete_post($postId, true);
 
@@ -188,13 +169,12 @@ class ApiClientTest extends WP_UnitTestCase
     public function getLanguages()
     {
         $response = ApiClient::getLanguages();
-        $this->assertSame(401, wp_remote_retrieve_response_code($response));
+        $this->assertSame('Authentication token was not recognized.', $response['message']);
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
         $response = ApiClient::getLanguages();
-        $this->assertSame(200, wp_remote_retrieve_response_code($response));
 
         $this->assertSame('aa_AA', $response[0]['code']);
         $this->assertSame('bb_BB', $response[1]['code']);
@@ -240,13 +220,12 @@ class ApiClientTest extends WP_UnitTestCase
     public function getVoices()
     {
         $response = ApiClient::getVoices(2);
-        $this->assertSame(401, wp_remote_retrieve_response_code($response));
+        $this->assertSame('Authentication token was not recognized.', $response['message']);
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
         $response = ApiClient::getVoices(2);
-        $this->assertSame(200, wp_remote_retrieve_response_code($response));
 
         $this->assertSame(1, $response[0]['id']);
         $this->assertSame(2, $response[1]['id']);

--- a/tests/phpunit/Core/ApiClientTest.php
+++ b/tests/phpunit/Core/ApiClientTest.php
@@ -443,17 +443,15 @@ class ApiClientTest extends WP_UnitTestCase
      */
     public function callApiWithInvalidDomain()
     {
-        $this->markTestIncomplete();
-
         $postId = self::factory()->post->create([
             'post_title' => 'ApiClientTest::callApiWithInvalidDomain',
         ]);
 
         $request = new Request('POST', 'http://localhost:5678/foo', '{"body":"Hello"}');
 
-        $response = $this->_instance->callApi($request, $postId);
+        $response = ApiClient::callApi($request, $postId);
 
-        $this->assertSame(false, $response);
+        $this->assertTrue(is_a($response, 'WP_Error'));
 
         $errorMessage = get_post_meta($postId, 'beyondwords_error_message', true);
 
@@ -487,7 +485,7 @@ class ApiClientTest extends WP_UnitTestCase
 
         $response = ApiClient::callApi($request, $postId);
 
-        $this->assertFalse($response);
+        $this->assertSame(200, wp_remote_retrieve_response_code($response));
 
         $error = sprintf(ApiClient::ERROR_FORMAT, 500, 'Unable to parse JSON in BeyondWords API response. Reason: Syntax error.');
         $this->assertSame($error, get_post_meta($postId, 'beyondwords_error_message', true));

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -156,7 +156,7 @@ class CoreTest extends WP_UnitTestCase
 
         $this->assertNull($wp_scripts);
 
-        update_option('beyondwords_valid_api_connection', true);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
 
         /**
          * Enqueuing with a valid API connection should succeed

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -156,8 +156,7 @@ class CoreTest extends WP_UnitTestCase
 
         $this->assertNull($wp_scripts);
 
-        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
-        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', true);
 
         /**
          * Enqueuing with a valid API connection should succeed
@@ -168,8 +167,7 @@ class CoreTest extends WP_UnitTestCase
 
         $wp_scripts = null;
 
-        delete_option('beyondwords_api_key');
-        delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         wp_delete_post($post->ID, true);
     }
@@ -331,7 +329,7 @@ class CoreTest extends WP_UnitTestCase
     public function onTrashOrDeletePost($expectedResponse)
     {
         $this->markTestIncomplete();
-        
+
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -399,9 +397,9 @@ class CoreTest extends WP_UnitTestCase
      * @dataProvider notFoundResponse
      */
     public function onTrashOrDeletePostWithoutBeyondwordsData($expectedResponse)
-    {        
+    {
         $this->markTestIncomplete();
-        
+
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
 
         $postId = self::factory()->post->create([
@@ -429,7 +427,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPost($expectedResponse)
     {
         $this->markTestIncomplete();
-        
+
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -466,7 +464,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPostHandlesInvalidResponse($expectedResponse)
     {
         $this->markTestIncomplete();
-        
+
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::untrashingPostHandlesInvalidResponse',
             'post_status' => 'trash',
@@ -495,7 +493,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPostWithoutBeyondwordsData($expectedResponse)
     {
         $this->markTestIncomplete();
-        
+
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::onUntrashPostWithoutBeyondwordsData',
             'post_status' => 'trash',

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -331,7 +331,7 @@ class CoreTest extends WP_UnitTestCase
     public function onTrashOrDeletePost($expectedResponse)
     {
         $this->markTestIncomplete();
-
+        
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -367,7 +367,7 @@ class CoreTest extends WP_UnitTestCase
     public function onTrashOrDeletePostHandlesInvalidResponse($expectedResponse)
     {
         $this->markTestIncomplete();
-        
+
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -399,7 +399,7 @@ class CoreTest extends WP_UnitTestCase
      * @dataProvider notFoundResponse
      */
     public function onTrashOrDeletePostWithoutBeyondwordsData($expectedResponse)
-    {
+    {        
         $this->markTestIncomplete();
         
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
@@ -429,7 +429,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPost($expectedResponse)
     {
         $this->markTestIncomplete();
-
+        
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -466,7 +466,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPostHandlesInvalidResponse($expectedResponse)
     {
         $this->markTestIncomplete();
-
+        
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::untrashingPostHandlesInvalidResponse',
             'post_status' => 'trash',
@@ -495,7 +495,7 @@ class CoreTest extends WP_UnitTestCase
     public function onUntrashPostWithoutBeyondwordsData($expectedResponse)
     {
         $this->markTestIncomplete();
-
+        
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::onUntrashPostWithoutBeyondwordsData',
             'post_status' => 'trash',

--- a/tests/phpunit/Core/CoreTest.php
+++ b/tests/phpunit/Core/CoreTest.php
@@ -150,7 +150,6 @@ class CoreTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         /**
          * Enqueuing with a valid API connection should succeed
@@ -163,7 +162,6 @@ class CoreTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         wp_delete_post($post->ID, true);
     }
@@ -378,7 +376,6 @@ class CoreTest extends WP_UnitTestCase
     public function onTrashOrDeletePost($expectedResponse)
     {
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::onTrashOrDeletePost',
@@ -490,7 +487,6 @@ class CoreTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::untrashingPostWillUpdateAudio',

--- a/tests/phpunit/Core/PostContentUtilsTest.php
+++ b/tests/phpunit/Core/PostContentUtilsTest.php
@@ -294,6 +294,29 @@ class PostContentUtilsTest extends WP_UnitTestCase
     /**
      *
      */
+    public function exportedDataHelper($path)
+    {
+        $handle = fopen($path, 'r');
+
+        $output = [];
+
+        // Ignore first line of CSV
+        fgetcsv($handle, 0, ',', '"', "\0");
+
+        // Process remaining lines
+        while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
+            // Only test Posts with a state of "Processed"
+            if (strtolower($data[11]) == 'processed') {
+                $output['spktdotblog ID ' . $data[0]] = $data;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     *
+     */
     public function hasGenerateAudioProvider()
     {
         return [

--- a/tests/phpunit/Core/PostContentUtilsTest.php
+++ b/tests/phpunit/Core/PostContentUtilsTest.php
@@ -294,29 +294,6 @@ class PostContentUtilsTest extends WP_UnitTestCase
     /**
      *
      */
-    public function exportedDataHelper($path)
-    {
-        $handle = fopen($path, 'r');
-
-        $output = [];
-
-        // Ignore first line of CSV
-        fgetcsv($handle, 0, ',', '"', "\0");
-
-        // Process remaining lines
-        while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
-            // Only test Posts with a state of "Processed"
-            if (strtolower($data[11]) == 'processed') {
-                $output['spktdotblog ID ' . $data[0]] = $data;
-            }
-        }
-
-        return $output;
-    }
-
-    /**
-     *
-     */
     public function hasGenerateAudioProvider()
     {
         return [

--- a/tests/phpunit/Core/PostContentUtilsTest.php
+++ b/tests/phpunit/Core/PostContentUtilsTest.php
@@ -343,35 +343,35 @@ class PostContentUtilsTest extends WP_UnitTestCase
         update_option('beyondwords_project_auto_publish_enabled', true);
 
         $body = PostContentUtils::getContentParams($postId);
-        $body = json_decode($body);
+        $body = json_decode($body, true);
 
         delete_option('beyondwords_prepend_excerpt');
         delete_option('beyondwords_project_auto_publish_enabled');
 
-        $this->assertSame($args['post_title'], $body->title);
-        $this->assertSame('<div data-beyondwords-summary="true" data-beyondwords-voice-id="42"><p>The excerpt.</p></div><p>Some test HTML.</p>', $body->body);
-        $this->assertSame(get_the_permalink($postId), $body->source_url);
-        $this->assertSame(strval($postId), $body->source_id);
-        $this->assertSame('Jane Smith', $body->author);
+        $this->assertSame($args['post_title'], $body['title']);
+        $this->assertSame('<div data-beyondwords-summary="true" data-beyondwords-voice-id="42"><p>The excerpt.</p></div><p>Some test HTML.</p>', $body['body']);
+        $this->assertSame(get_the_permalink($postId), $body['source_url']);
+        $this->assertSame(strval($postId), $body['source_id']);
+        $this->assertSame('Jane Smith', $body['author']);
         $thumbnailUrl = strval(wp_get_original_image_url(get_post_thumbnail_id($postId)));
         $this->assertNotEmpty($thumbnailUrl);
-        $this->assertSame($thumbnailUrl, $body->image_url);
-        $this->assertSame('{"taxonomy":{"category":["Uncategorized"]}}', wp_json_encode($body->metadata));
-        $this->assertSame($args['post_date'], $body->publish_date);
+        $this->assertSame($thumbnailUrl, $body['image_url']);
+        $this->assertSame('{"taxonomy":{"category":["Uncategorized"]}}', wp_json_encode($body['metadata']));
+        $this->assertSame($args['post_date'], $body['publish_date']);
 
         // { published: true } should be sent because auto-publish is true
-        $this->assertTrue(property_exists($body, 'published'));
-        $this->assertTrue($body->published);
+        $this->assertArrayHasKey('published', $body);
+        $this->assertTrue($body['published']);
 
         update_option('beyondwords_project_auto_publish_enabled', false);
 
         $body = PostContentUtils::getContentParams($postId);
-        $body = json_decode($body);
+        $body = json_decode($body, true);
 
         delete_option('beyondwords_project_auto_publish_enabled');
 
         // { published: false } should not exist because auto-publish is false
-        $this->assertFalse(property_exists($body, 'published'));
+        $this->assertArrayNotHasKey('published', $body);
 
         wp_delete_post($postId, true);
     }
@@ -403,36 +403,36 @@ class PostContentUtilsTest extends WP_UnitTestCase
         update_option('beyondwords_project_auto_publish_enabled', true);
 
         $body = PostContentUtils::getContentParams($postId);
-        $body = json_decode($body);
+        $body = json_decode($body, true);
 
         delete_option('beyondwords_project_auto_publish_enabled');
-        
-        $this->assertSame($args['post_title'], $body->title);
-        $this->assertSame(PostContentUtils::getPostBody($postId), $body->body);
-        $this->assertSame('Jane Smith', $body->author);
-        $this->assertSame(get_the_permalink($postId), $body->source_url);
+
+        $this->assertSame($args['post_title'], $body['title']);
+        $this->assertSame(PostContentUtils::getPostBody($postId), $body['body']);
+        $this->assertSame('Jane Smith', $body['author']);
+        $this->assertSame(get_the_permalink($postId), $body['source_url']);
 
         // { published: false } SHOULD be sent because post_status is "pending"
-        $this->assertTrue(property_exists($body, 'published'));
-        $this->assertFalse($body->published);
+        $this->assertArrayHasKey('published', $body);
+        $this->assertFalse($body['published']);
 
         /*
          * Posts with "Pending Review" status will not have a `publish_date` date because
          * get_post_time() returns `false` for posts which are "Pending Review".
          */
-        $this->assertFalse(property_exists($body, 'publish_date'));
+        $this->assertArrayNotHasKey('publish_date', $body);
 
         // Set auto-publish to false
         update_option('beyondwords_project_auto_publish_enabled', false);
 
         $body = PostContentUtils::getContentParams($postId);
-        $body = json_decode($body);
+        $body = json_decode($body, true);
 
         delete_option('beyondwords_project_auto_publish_enabled');
 
         // { published: false } SHOULD be sent because post_status is "pending"
-        $this->assertTrue(property_exists($body, 'published'));
-        $this->assertFalse($body->published);
+        $this->assertArrayHasKey('published', $body);
+        $this->assertFalse($body['published']);
 
         wp_delete_post($postId, true);
     }
@@ -466,10 +466,10 @@ class PostContentUtilsTest extends WP_UnitTestCase
 
         remove_filter('beyondwords_content_params', $filter);
 
-        $params = json_decode($params);
+        $params = json_decode($params, true);
 
-        $this->assertSame('[POST ID: ' . $postId. ']<p>Baz bar foo.</p>[ADDED AFTER]', $params->body);
-        $this->assertSame($postId, $params->metadata->custom);
+        $this->assertSame('[POST ID: ' . $postId. ']<p>Baz bar foo.</p>[ADDED AFTER]', $params['body']);
+        $this->assertSame($postId, $params['metadata']['custom']);
 
         wp_delete_post($postId, true);
     }

--- a/tests/phpunit/Core/PostMetaUtilsTest.php
+++ b/tests/phpunit/Core/PostMetaUtilsTest.php
@@ -185,6 +185,65 @@ class PostMetaUtilsTest extends WP_UnitTestCase
     }
 
     /**
+     * Get API response body from post meta field.
+     *
+     * @test
+     * @dataProvider getHttpResponseBodyFromPostMetaProvider
+     *
+     * @param boolean $expected Expected speechkit_response
+     * @param int     $postArgs WordPress Post args
+     */
+    public function getHttpResponseBodyFromPostMeta($expected, $postArgs)
+    {
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $postId = self::factory()->post->create($postArgs);
+
+        $this->assertSame($expected, PostMetaUtils::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response'));
+
+        wp_delete_post($postId, true);
+
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     *
+     */
+    public function getHttpResponseBodyFromPostMetaProvider()
+    {
+        $json = '{"foo":"bar","baz":42}';
+
+        return [
+            'Missing'             => ['',    ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider']],
+            'Empty string'        => ['',    ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider', 'meta_input' => ['speechkit_response' => '']]],
+            'String'              => [$json, ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider', 'meta_input' => ['speechkit_response' => $json]]],
+        ];
+    }
+
+    /**
+     *
+     */
+    public function exportedDataHelper($path)
+    {
+        $handle = fopen($path, 'r');
+
+        $output = [];
+
+        // Ignore first line of CSV
+        fgetcsv($handle, 0, ',', '"', "\0");
+
+        // Process remaining lines
+        while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
+            // Only test Posts with a state of "Processed"
+            if (strtolower($data[11]) == 'processed') {
+                $output['spktdotblog ID ' . $data[0]] = $data;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
      * Test if we can get a content ID from all the various places it can be.
      *
      * @test

--- a/tests/phpunit/Core/PostMetaUtilsTest.php
+++ b/tests/phpunit/Core/PostMetaUtilsTest.php
@@ -185,65 +185,6 @@ class PostMetaUtilsTest extends WP_UnitTestCase
     }
 
     /**
-     * Get API response body from post meta field.
-     *
-     * @test
-     * @dataProvider getHttpResponseBodyFromPostMetaProvider
-     *
-     * @param boolean $expected Expected speechkit_response
-     * @param int     $postArgs WordPress Post args
-     */
-    public function getHttpResponseBodyFromPostMeta($expected, $postArgs)
-    {
-        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-
-        $postId = self::factory()->post->create($postArgs);
-
-        $this->assertSame($expected, PostMetaUtils::getHttpResponseBodyFromPostMeta($postId, 'speechkit_response'));
-
-        wp_delete_post($postId, true);
-
-        delete_option('beyondwords_project_id');
-    }
-
-    /**
-     *
-     */
-    public function getHttpResponseBodyFromPostMetaProvider()
-    {
-        $json = '{"foo":"bar","baz":42}';
-
-        return [
-            'Missing'             => ['',    ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider']],
-            'Empty string'        => ['',    ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider', 'meta_input' => ['speechkit_response' => '']]],
-            'String'              => [$json, ['post_title' => 'UtilsTest:getHttpResponseBodyFromPostMetaProvider', 'meta_input' => ['speechkit_response' => $json]]],
-        ];
-    }
-
-    /**
-     *
-     */
-    public function exportedDataHelper($path)
-    {
-        $handle = fopen($path, 'r');
-
-        $output = [];
-
-        // Ignore first line of CSV
-        fgetcsv($handle, 0, ',', '"', "\0");
-
-        // Process remaining lines
-        while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
-            // Only test Posts with a state of "Processed"
-            if (strtolower($data[11]) == 'processed') {
-                $output['spktdotblog ID ' . $data[0]] = $data;
-            }
-        }
-
-        return $output;
-    }
-
-    /**
      * Test if we can get a content ID from all the various places it can be.
      *
      * @test

--- a/tests/phpunit/Core/UninstallerTest.php
+++ b/tests/phpunit/Core/UninstallerTest.php
@@ -64,11 +64,10 @@ class UninstallerTest extends WP_UnitTestCase
             // v5.0 video settings
             'beyondwords_video_enabled' => ['beyondwords_video_enabled'],
             // v4.x
-            'beyondwords_languages'            => ['beyondwords_languages'],
-            'beyondwords_player_ui'            => ['beyondwords_player_ui'],
-            'beyondwords_player_style'         => ['beyondwords_player_style'],
-            'beyondwords_settings_updated'     => ['beyondwords_settings_updated'],
-            'beyondwords_valid_api_connection' => ['beyondwords_valid_api_connection'],
+            'beyondwords_languages'        => ['beyondwords_languages'],
+            'beyondwords_player_ui'        => ['beyondwords_player_ui'],
+            'beyondwords_player_style'     => ['beyondwords_player_style'],
+            'beyondwords_settings_updated' => ['beyondwords_settings_updated'],
             // v3.7.0 beyondwords_*
             'beyondwords_version'         => ['beyondwords_version'],
             'beyondwords_api_key'         => ['beyondwords_api_key'],
@@ -81,6 +80,8 @@ class UninstallerTest extends WP_UnitTestCase
             'speechkit_project_id'      => ['speechkit_project_id'],
             'speechkit_preselect'       => ['speechkit_preselect'],
             'speechkit_prepend_excerpt' => ['speechkit_prepend_excerpt'],
+            // deprecated v5.0
+            'beyondwords_valid_api_connection' => ['beyondwords_valid_api_connection'],
             // deprecated < v3.0
             'speechkit_settings'             => ['speechkit_settings'],
             'speechkit_enable'               => ['speechkit_enable'],

--- a/tests/phpunit/Core/UninstallerTest.php
+++ b/tests/phpunit/Core/UninstallerTest.php
@@ -64,10 +64,11 @@ class UninstallerTest extends WP_UnitTestCase
             // v5.0 video settings
             'beyondwords_video_enabled' => ['beyondwords_video_enabled'],
             // v4.x
-            'beyondwords_languages'        => ['beyondwords_languages'],
-            'beyondwords_player_ui'        => ['beyondwords_player_ui'],
-            'beyondwords_player_style'     => ['beyondwords_player_style'],
-            'beyondwords_settings_updated' => ['beyondwords_settings_updated'],
+            'beyondwords_languages'            => ['beyondwords_languages'],
+            'beyondwords_player_ui'            => ['beyondwords_player_ui'],
+            'beyondwords_player_style'         => ['beyondwords_player_style'],
+            'beyondwords_settings_updated'     => ['beyondwords_settings_updated'],
+            'beyondwords_valid_api_connection' => ['beyondwords_valid_api_connection'],
             // v3.7.0 beyondwords_*
             'beyondwords_version'         => ['beyondwords_version'],
             'beyondwords_api_key'         => ['beyondwords_api_key'],
@@ -80,8 +81,6 @@ class UninstallerTest extends WP_UnitTestCase
             'speechkit_project_id'      => ['speechkit_project_id'],
             'speechkit_preselect'       => ['speechkit_preselect'],
             'speechkit_prepend_excerpt' => ['speechkit_prepend_excerpt'],
-            // deprecated v5.0
-            'beyondwords_valid_api_connection' => ['beyondwords_valid_api_connection'],
             // deprecated < v3.0
             'speechkit_settings'             => ['speechkit_settings'],
             'speechkit_enable'               => ['speechkit_enable'],

--- a/tests/phpunit/Core/UpdaterTest.php
+++ b/tests/phpunit/Core/UpdaterTest.php
@@ -47,7 +47,7 @@ class UpdaterTest extends WP_UnitTestCase
         $this->assertFalse(get_option('speechkit_preselect'));
         $this->assertFalse(get_option('speechkit_prepend_excerpt'));
 
-        $apiKey = 'write_12345678ABCDEFGH';
+        $apiKey = BEYONDWORDS_TESTS_API_KEY;
         $projectId = BEYONDWORDS_TESTS_PROJECT_ID;
         $postTypes = array('post', 'page', 'my_custom_post_type');
         $categories = array('-1', '1', '2', '42');
@@ -101,7 +101,7 @@ class UpdaterTest extends WP_UnitTestCase
         $this->assertFalse(get_option('beyondwords_preselect'));
         $this->assertFalse(get_option('beyondwords_prepend_excerpt'));
 
-        $apiKey = 'write_12345678ABCDEFGH';
+        $apiKey = BEYONDWORDS_TESTS_API_KEY;
         $projectId = BEYONDWORDS_TESTS_PROJECT_ID;
         $prependExcerpt = '1';
         $preselect = [

--- a/tests/phpunit/PluginTest.php
+++ b/tests/phpunit/PluginTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Plugin;
-use Beyondwords\Wordpress\Core\ApiClient;
+use Beyondwords\Wordpress\Core\Core;
 
 class PluginTest extends WP_UnitTestCase
 {
@@ -29,7 +29,8 @@ class PluginTest extends WP_UnitTestCase
     public function constructor()
     {
         $plugin = new Plugin();
+        $plugin->init();
 
-        $this->assertInstanceOf(ApiClient::class, $plugin->apiClient);
+        $this->assertInstanceOf(Core::class, $plugin->core);
     }
 }

--- a/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
+++ b/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
@@ -25,7 +25,6 @@ class ApiKeyTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -35,7 +34,6 @@ class ApiKeyTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
+++ b/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
@@ -23,7 +23,7 @@ class ApiKeyTest extends WP_UnitTestCase
         // Your set up methods here.
         $this->_instance = new ApiKey();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
+++ b/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
@@ -23,7 +23,7 @@ class IncludeExcerptTest extends WP_UnitTestCase
         // Your set up methods here.
         $this->_instance = new IncludeExcerpt();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
+++ b/tests/phpunit/Settings/Fields/IncludeExcerpt/IncludeExcerptTest.php
@@ -25,7 +25,6 @@ class IncludeExcerptTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -35,7 +34,6 @@ class IncludeExcerptTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
+++ b/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Fields\Languages\Languages;
-use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
 /**
@@ -23,10 +22,9 @@ class LanguagesTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        $apiClient       = new ApiClient();
-        $this->_instance = new Languages($apiClient);
+        $this->_instance = new Languages();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
@@ -47,8 +45,7 @@ class LanguagesTest extends WP_UnitTestCase
      */
     public function init()
     {
-        $apiClient = new ApiClient();
-        $languages = new Languages($apiClient);
+        $languages = new Languages();
         $languages->init();
 
         do_action('wp_loaded');
@@ -81,7 +78,7 @@ class LanguagesTest extends WP_UnitTestCase
      */
     public function render()
     {
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
         $this->_instance->render();

--- a/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
+++ b/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
@@ -28,7 +28,6 @@ class LanguagesTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -38,7 +37,6 @@ class LanguagesTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();
@@ -85,7 +83,6 @@ class LanguagesTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $this->_instance->render();
 
@@ -128,6 +125,5 @@ class LanguagesTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
     }
 }

--- a/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
+++ b/tests/phpunit/Settings/Fields/Languages/LanguagesTest.php
@@ -10,20 +10,12 @@ use \Symfony\Component\DomCrawler\Crawler;
  */
 class LanguagesTest extends WP_UnitTestCase
 {
-    /**
-     * @var \Beyondwords\Wordpress\Component\Settings\Fields\Languages\Languages
-     */
-    private $_instance;
-
-
     public function setUp(): void
     {
         // Before...
         parent::setUp();
 
         // Your set up methods here.
-        $this->_instance = new Languages();
-
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
@@ -31,8 +23,6 @@ class LanguagesTest extends WP_UnitTestCase
     public function tearDown(): void
     {
         // Your tear down methods here.
-        $this->_instance = null;
-
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
@@ -60,7 +50,8 @@ class LanguagesTest extends WP_UnitTestCase
     {
         global $wp_settings_fields;
 
-        $this->_instance->addSetting();
+        $languages = new Languages();
+        $languages->addSetting();
 
         // Check for add_settings_field() result
         $this->assertArrayHasKey('beyondwords-languages', $wp_settings_fields['beyondwords_advanced']['advanced']);
@@ -69,7 +60,7 @@ class LanguagesTest extends WP_UnitTestCase
 
         $this->assertSame('beyondwords-languages', $field['id']);
         $this->assertSame('Multiple languages', $field['title']);
-        $this->assertSame(array($this->_instance, 'render'), $field['callback']);
+        $this->assertSame(array($languages, 'render'), $field['callback']);
         $this->assertSame([], $field['args']);
     }
 
@@ -81,7 +72,8 @@ class LanguagesTest extends WP_UnitTestCase
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
-        $this->_instance->render();
+        $languages = new Languages();
+        $languages->render();
 
         $html = $this->getActualOutput();
 

--- a/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Fields\PlayerStyle\PlayerStyle;
-use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
 /**
@@ -23,10 +22,9 @@ class SettingsPlayerStyleTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        $apiClient = new ApiClient();
-        $this->_instance = new PlayerStyle($apiClient);
+        $this->_instance = new PlayerStyle();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
@@ -47,8 +45,7 @@ class SettingsPlayerStyleTest extends WP_UnitTestCase
      */
     public function init()
     {
-        $apiClient = new ApiClient();
-        $playerStyle = new PlayerStyle($apiClient);
+        $playerStyle = new PlayerStyle();
         $playerStyle->init();
 
         do_action('wp_loaded');

--- a/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
+++ b/tests/phpunit/Settings/Fields/PlayerStyle/PlayerStyleTest.php
@@ -28,7 +28,6 @@ class SettingsPlayerStyleTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -38,7 +37,6 @@ class SettingsPlayerStyleTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
+++ b/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
@@ -26,7 +26,6 @@ class PlayerUITest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -36,7 +35,6 @@ class PlayerUITest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
+++ b/tests/phpunit/Settings/Fields/PlayerUI/PlayerUITest.php
@@ -24,7 +24,7 @@ class PlayerUITest extends WP_UnitTestCase
         // Your set up methods here.
         $this->_instance = new PlayerUI();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
+++ b/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
@@ -23,7 +23,7 @@ class PreselectGenerateAudioTest extends WP_UnitTestCase
         // Your set up methods here.
         $this->_instance = new PreselectGenerateAudio();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
+++ b/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
@@ -25,7 +25,6 @@ class PreselectGenerateAudioTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -35,7 +34,6 @@ class PreselectGenerateAudioTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
+++ b/tests/phpunit/Settings/Fields/PreselectGenerateAudio/PreselectGenerateAudioTest.php
@@ -113,12 +113,6 @@ class PreselectGenerateAudioTest extends WP_UnitTestCase
         $this->_instance->enqueueScripts( 'edit.php' );
         $this->assertNull($wp_scripts);
 
-        // @todo check this setting works in admin
-        // $this->_instance->enqueueScripts( 'settings_page_beyondwords' );
-        // $this->assertContains('beyondwords-settings--preselect-settings', $wp_scripts->queue);
-
-        // $wp_scripts = null;
-
         $this->_instance->enqueueScripts( 'post.php' );
         $this->assertContains('beyondwords-settings--preselect-post', $wp_scripts->queue);
 

--- a/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
+++ b/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
@@ -25,7 +25,6 @@ class ProjectIdTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -35,7 +34,6 @@ class ProjectIdTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
+++ b/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
@@ -23,7 +23,7 @@ class ProjectIdTest extends WP_UnitTestCase
         // Your set up methods here.
         $this->_instance = new ProjectId();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -125,7 +125,7 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
 
         $this->assertTrue(SettingsUtils::hasValidApiConnection());
 
@@ -159,7 +159,7 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
 
         $this->_instance->printPluginAdminNotices();
 
@@ -224,7 +224,7 @@ class SettingsTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
 
         $this->_instance->restApiInit();
 
@@ -252,7 +252,7 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
 
         $reponse = $this->_instance->restApiResponse();
 

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -98,44 +98,38 @@ class SettingsTest extends WP_UnitTestCase
     /**
      * @test
      */
-    public function hasApiCredsWithoutAnyField()
+    public function hasValidApiConnectionWithoutAnyField()
     {
-        $this->assertFalse(SettingsUtils::hasApiCreds());
+        $this->assertFalse(SettingsUtils::hasValidApiConnection());
     }
 
     /**
      * @test
      */
-    public function hasApiCredsWithOnlyApiKey()
+    public function hasValidApiConnectionWithExpectedOption()
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
-
-        $this->assertFalse(SettingsUtils::hasApiCreds());
-
-        delete_option('beyondwords_api_key');
-    }
-
-    /**
-     * @test
-     */
-    public function hasApiCredsWithOnlyProjectId()
-    {
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
-        $this->assertFalse(SettingsUtils::hasApiCreds());
+        $this->assertFalse(SettingsUtils::hasValidApiConnection());
 
+        delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
     }
 
     /**
      * @test
      */
-    public function hasApiCredsWithRemovedOption()
+    public function hasValidApiConnectionWithoutExpectedOption()
     {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
         update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
-        $this->assertFalse(SettingsUtils::hasApiCreds());
+        $this->assertTrue(SettingsUtils::hasValidApiConnection());
 
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
         delete_option('beyondwords_valid_api_connection');
     }
 
@@ -164,6 +158,7 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $this->_instance->printPluginAdminNotices();
 
@@ -172,6 +167,7 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
     }
 
     /**

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -101,21 +101,43 @@ class SettingsTest extends WP_UnitTestCase
     /**
      * @test
      */
-    public function hasApiSettingsWithoutOption()
+    public function hasApiCredsWithoutAnyField()
     {
-        delete_option('beyondwords_valid_api_connection');
-
-        $this->assertFalse(SettingsUtils::hasApiSettings());
+        $this->assertFalse(SettingsUtils::hasApiCreds());
     }
 
     /**
      * @test
      */
-    public function hasApiSettingsWithOption()
+    public function hasApiCredsWithOnlyApiKey()
+    {
+        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+
+        $this->assertFalse(SettingsUtils::hasApiCreds());
+
+        delete_option('beyondwords_api_key');
+    }
+
+    /**
+     * @test
+     */
+    public function hasApiCredsWithOnlyProjectId()
+    {
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $this->assertFalse(SettingsUtils::hasApiCreds());
+
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
+     */
+    public function hasApiCredsWithRemovedOption()
     {
         update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
-        $this->assertTrue(SettingsUtils::hasApiSettings());
+        $this->assertFalse(SettingsUtils::hasApiCreds());
 
         delete_option('beyondwords_valid_api_connection');
     }
@@ -145,7 +167,6 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $this->_instance->printPluginAdminNotices();
 
@@ -154,7 +175,6 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
     }
 
     /**
@@ -208,7 +228,6 @@ class SettingsTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $this->_instance->restApiInit();
 
@@ -223,7 +242,6 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_preselect');
-        delete_option('beyondwords_valid_api_connection');
 
         wp_delete_post($postId);
         wp_delete_user($userId);
@@ -236,7 +254,6 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $reponse = $this->_instance->restApiResponse();
 
@@ -249,6 +266,5 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_preselect');
-        delete_option('beyondwords_valid_api_connection');
     }
 }

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -175,6 +175,8 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function printPluginAdminNoticesWithSettingsErrors()
     {
+        $this->markTestSkipped();
+
         $errors = [];
         $errors['Settings/Test1'] = 'Errors test 1';
         $errors['Settings/Test2'] = 'Errors test 2';

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Settings;
 use Beyondwords\Wordpress\Component\Settings\SettingsUtils;
-use Beyondwords\Wordpress\Core\ApiClient;
 use \Symfony\Component\DomCrawler\Crawler;
 
 class SettingsTest extends WP_UnitTestCase
@@ -23,8 +22,7 @@ class SettingsTest extends WP_UnitTestCase
         // Your set up methods here.
         delete_transient('beyondwords_settings_errors');
 
-        $apiClient       = new ApiClient();
-        $this->_instance = new Settings($apiClient);
+        $this->_instance = new Settings();
     }
 
     public function tearDown(): void
@@ -41,8 +39,7 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function init()
     {
-        $apiClient = new ApiClient();
-        $settings = new Settings($apiClient);
+        $settings = new Settings();
         $settings->init();
 
         do_action('wp_loaded');
@@ -111,7 +108,7 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function hasApiCredsWithOnlyApiKey()
     {
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
 
         $this->assertFalse(SettingsUtils::hasApiCreds());
 
@@ -165,7 +162,7 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function printPluginAdminNoticesWithApiSettings()
     {
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
         $this->_instance->printPluginAdminNotices();
@@ -226,7 +223,7 @@ class SettingsTest extends WP_UnitTestCase
             'post_author' => $userId
         ]);
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
 
         $this->_instance->restApiInit();
@@ -237,7 +234,7 @@ class SettingsTest extends WP_UnitTestCase
 
         $this->assertInstanceOf(\WP_REST_Response::class, $response);
 
-        $this->assertSame('write_XXXXXXXXXXXXXXXX', $data['apiKey']);
+        $this->assertSame(BEYONDWORDS_TESTS_API_KEY, $data['apiKey']);
         $this->assertSame(['post' => '1', 'page' => '1'], $data['preselect']);
 
         delete_option('beyondwords_api_key');
@@ -252,7 +249,7 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function restApiResponse()
     {
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
 
         $reponse = $this->_instance->restApiResponse();
@@ -261,7 +258,7 @@ class SettingsTest extends WP_UnitTestCase
 
         $data = $reponse->get_data();
 
-        $this->assertSame('write_XXXXXXXXXXXXXXXX', $data['apiKey']);
+        $this->assertSame(BEYONDWORDS_TESTS_API_KEY, $data['apiKey']);
         $this->assertSame(['post' => '1', 'page' => '1'], $data['preselect']);
 
         delete_option('beyondwords_api_key');

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -45,14 +45,14 @@ class SettingsTest extends WP_UnitTestCase
         do_action('wp_loaded');
 
         // Actions
-        $this->assertEquals(1, has_action('admin_menu', array($settings, 'addOptionsPage')));
-        $this->assertEquals(100, has_action('admin_notices', array($settings, 'printMissingApiCredsWarning')));
-        $this->assertEquals(200, has_action('admin_notices', array($settings, 'printSettingsErrors')));
-        $this->assertEquals(10, has_action('admin_enqueue_scripts', array($settings, 'enqueueScripts')));
-        $this->assertEquals(10, has_action('rest_api_init', array($settings, 'restApiInit')));
+        $this->assertSame(1, has_action('admin_menu', array($settings, 'addOptionsPage')));
+        $this->assertSame(100, has_action('admin_notices', array($settings, 'printMissingApiCredsWarning')));
+        $this->assertSame(200, has_action('admin_notices', array($settings, 'printSettingsErrors')));
+        $this->assertSame(10, has_action('admin_enqueue_scripts', array($settings, 'enqueueScripts')));
+        $this->assertSame(10, has_action('rest_api_init', array($settings, 'restApiInit')));
 
         // Filters
-        $this->assertEquals(10, has_filter('plugin_action_links_speechkit/speechkit.php', array($settings, 'addSettingsLinkToPluginPage')));
+        $this->assertSame(10, has_filter('plugin_action_links_speechkit/speechkit.php', array($settings, 'addSettingsLinkToPluginPage')));
     }
 
     /**
@@ -70,8 +70,8 @@ class SettingsTest extends WP_UnitTestCase
 
         $newLinks = $this->_instance->addSettingsLinkToPluginPage($links);
 
-        $this->assertEquals($newLinks[0], $expected);
-        $this->assertEquals($newLinks[1], $links[0]);
+        $this->assertSame($newLinks[0], $expected);
+        $this->assertSame($newLinks[1], $links[0]);
     }
 
     /**
@@ -143,7 +143,7 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printSettingsErrors();
 
         $html = $this->getActualOutput();
-        $this->assertEquals('', $html);
+        $this->assertSame('', $html);
     }
 
     /**
@@ -178,14 +178,15 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printMissingApiCredsWarning();
 
         $html = $this->getActualOutput();
+        $this->assertNotEmpty($html);
 
         $crawler = new Crawler($html);
 
-        $this->assertEquals('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-error > p > strong')->text());
-        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-error > p > strong > a')->attr('href'));
+        $this->assertSame('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-info > p > strong')->text());
+        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-info > p > strong > a')->attr('href'));
 
-        $this->assertStringNotContainsString('Don’t have a BeyondWords account yet?', $html);
-        $this->assertStringNotContainsString('Sign up free', $html);
+        $this->assertStringContainsString('Don’t have a BeyondWords account yet?', $html);
+        $this->assertStringContainsString('Sign up free', $html);
     }
 
     /**
@@ -198,14 +199,15 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printMissingApiCredsWarning();
 
         $html = $this->getActualOutput();
+        $this->assertNotEmpty($html);
 
         $crawler = new Crawler($html);
 
-        $this->assertEquals('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-error > p > strong')->text());
-        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-error > p > strong > a')->attr('href'));
+        $this->assertSame('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-info > p > strong')->text());
+        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-info > p > strong > a')->attr('href'));
 
-        $this->assertStringNotContainsString('Don’t have a BeyondWords account yet?', $html);
-        $this->assertStringNotContainsString('Sign up free', $html);
+        $this->assertStringContainsString('Don’t have a BeyondWords account yet?', $html);
+        $this->assertStringContainsString('Sign up free', $html);
 
         delete_option('beyondwords_project_id');
     }
@@ -220,14 +222,15 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printMissingApiCredsWarning();
 
         $html = $this->getActualOutput();
+        $this->assertNotEmpty($html);
 
         $crawler = new Crawler($html);
 
-        $this->assertEquals('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-error > p > strong')->text());
-        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-error > p > strong > a')->attr('href'));
+        $this->assertSame('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-info > p > strong')->text());
+        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-info > p > strong > a')->attr('href'));
 
-        $this->assertStringNotContainsString('Don’t have a BeyondWords account yet?', $html);
-        $this->assertStringNotContainsString('Sign up free', $html);
+        $this->assertStringContainsString('Don’t have a BeyondWords account yet?', $html);
+        $this->assertStringContainsString('Sign up free', $html);
 
         delete_option('beyondwords_api_key');
     }
@@ -243,7 +246,7 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printMissingApiCredsWarning();
 
         $html = $this->getActualOutput();
-        $this->assertEquals('', $html);
+        $this->assertSame('', $html);
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
@@ -264,14 +267,6 @@ class SettingsTest extends WP_UnitTestCase
         $this->_instance->printSettingsErrors();
 
         $html = $this->getActualOutput();
-
-        $crawler = new Crawler($html);
-
-        $this->assertEquals('To use BeyondWords, please update the plugin settings.', $crawler->filter('div.notice.notice-error > p > strong')->text());
-        $this->assertStringEndsWith('/wp-admin/options-general.php?page=beyondwords', $crawler->filter('div.notice.notice-error > p > strong > a')->attr('href'));
-
-        $this->assertStringNotContainsString('Don’t have a BeyondWords account yet?', $html);
-        $this->assertStringNotContainsString('Sign up free', $html);
 
         $this->assertStringContainsString('<li>Errors test 1</li>', $html);
         $this->assertStringContainsString('<li>Errors test 2</li>', $html);

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -100,6 +100,7 @@ class SettingsTest extends WP_UnitTestCase
      */
     public function hasValidApiConnectionWithoutAnyField()
     {
+        delete_option('beyondwords_valid_api_connection');
         $this->assertFalse(SettingsUtils::hasValidApiConnection());
     }
 
@@ -223,6 +224,7 @@ class SettingsTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $this->_instance->restApiInit();
 
@@ -237,6 +239,7 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_preselect');
+        delete_option('beyondwords_valid_api_connection');
 
         wp_delete_post($postId);
         wp_delete_user($userId);
@@ -249,6 +252,7 @@ class SettingsTest extends WP_UnitTestCase
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_preselect', ['post' => '1', 'page' => '1']);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
 
         $reponse = $this->_instance->restApiResponse();
 
@@ -261,5 +265,6 @@ class SettingsTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_preselect');
+        delete_option('beyondwords_valid_api_connection');
     }
 }

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -29,6 +29,7 @@ class AdvancedTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -38,6 +39,7 @@ class AdvancedTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -29,7 +29,7 @@ class AdvancedTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
     }
 
     public function tearDown(): void

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Tabs\Advanced\Advanced;
-use Beyondwords\Wordpress\Core\ApiClient;
 
 /**
  * @group settings
@@ -26,10 +25,9 @@ class AdvancedTabTest extends WP_UnitTestCase
         // Your set up methods here.
         delete_transient('beyondwords_settings_errors');
 
-        $apiClient       = new ApiClient();
-        $this->_instance = new Advanced($apiClient);
+        $this->_instance = new Advanced();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -31,7 +31,6 @@ class AdvancedTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -41,7 +40,6 @@ class AdvancedTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
@@ -27,7 +27,7 @@ class CredentialsTabTest extends WP_UnitTestCase
 
         $this->_instance = new Credentials();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
@@ -29,7 +29,6 @@ class CredentialsTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -39,7 +38,6 @@ class CredentialsTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -28,7 +28,7 @@ class PlayerTabTest extends WP_UnitTestCase
         $this->_instance = new Player();
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
     }
 
     public function tearDown(): void

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -30,7 +30,6 @@ class PlayerTabTest extends WP_UnitTestCase
         $this->_instance = new Player($apiClient);
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -40,7 +39,6 @@ class PlayerTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Tabs\Player\Player;
-use Beyondwords\Wordpress\Core\ApiClient;
 
 /**
  * @group settings
@@ -26,9 +25,8 @@ class PlayerTabTest extends WP_UnitTestCase
         // Your set up methods here.
         delete_transient('beyondwords_settings_errors');
 
-        $apiClient       = new ApiClient();
-        $this->_instance = new Player($apiClient);
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        $this->_instance = new Player();
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -28,6 +28,7 @@ class PlayerTabTest extends WP_UnitTestCase
         $this->_instance = new Player();
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -37,6 +38,7 @@ class PlayerTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -27,7 +27,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         $this->_instance = new Pronunciations();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -29,7 +29,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
     }
 
     public function tearDown(): void

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -29,7 +29,6 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -39,7 +38,6 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -29,6 +29,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -38,6 +39,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -31,7 +31,6 @@ class VoicesTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -41,7 +40,6 @@ class VoicesTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
-        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Beyondwords\Wordpress\Component\Settings\Tabs\Voices\Voices;
-use Beyondwords\Wordpress\Core\ApiClient;
 
 /**
  * @group settings
@@ -26,10 +25,9 @@ class VoicesTabTest extends WP_UnitTestCase
         // Your set up methods here.
         delete_transient('beyondwords_settings_errors');
 
-        $apiClient       = new ApiClient();
-        $this->_instance = new Voices($apiClient);
+        $this->_instance = new Voices();
 
-        update_option('beyondwords_api_key', 'write_XXXXXXXXXXXXXXXX');
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -29,7 +29,7 @@ class VoicesTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
-        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
     }
 
     public function tearDown(): void

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -29,6 +29,7 @@ class VoicesTabTest extends WP_UnitTestCase
 
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+        update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM));
     }
 
     public function tearDown(): void
@@ -38,6 +39,7 @@ class VoicesTabTest extends WP_UnitTestCase
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
+        delete_option('beyondwords_valid_api_connection');
 
         // Then...
         parent::tearDown();


### PR DESCRIPTION
When API credentials are updated in WordPress we currently check to see whether the API connection is valid by requesting the project details. 

If they are valid we store a convenience `beyondwords_valid_api_connection` setting and check this throughout the code e.g. we only show the credentials settings tab if the creds are invalid (we hide the other tabs).

During a support call last week we found `beyondwords_valid_api_connection` was `false` even though the user had valid creds. This was possibly due to a recent update from `4.x` to `5.x`.

To prevent these errors from occurring again we have removed the setting that stores the result of the API creds check, and instead perform API calls if both API Key and Project ID are available, without validating them.