### PR TITLE
Improve handling of failed REST API requests when syncing settings

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -25,6 +25,7 @@
         "wp-content/plugins/beyondwords-filter-player-script-onload": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-script-onload",
         "wp-content/plugins/beyondwords-filter-player-inline-script-tag": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-inline-script-tag",
         "wp-content/plugins/beyondwords-filter-player-sdk-params": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-sdk-params",
+        "wp-content/plugins/query-monitor": "https://downloads.wordpress.org/plugin/query-monitor.zip",
         "wp-content/plugins/plugin-check": "https://downloads.wordpress.org/plugin/plugin-check.zip",
         "wp-content/plugins/rest-api-insert": "./tests/fixtures/wp-content/plugins/rest-api-insert",
         "wp-content/plugins/rest-api-publish": "./tests/fixtures/wp-content/plugins/rest-api-publish",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "5.2.0",
+  "version": "5.2.1-beta.2",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 5.2.0
+Stable tag: 5.2.1-beta.2
 Requires PHP: 8.0
 Tested up to: 6.7
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,18 @@ Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&
 
 == Changelog ==
 
+= 5.2.1 =
+
+Release date: 27th November 2024
+
+**Fixes**
+
+* [#417](https://github.com/beyondwords-io/wordpress-plugin/pull/417) Improve handling of failed REST API requests when syncing settings.
+    * Add Query Monitor plugin to wp-env local dev config to help with debugging.
+    * Replace transients with object cache to reduce db writes.
+    * Add HTTP status code into failed API credentials validation message to improve debugging for empty response body.
+    * Fix the undefined index errors that are logged when REST API responses do not contain the expected structure.
+
 = 5.2.0 =
 
 Release date: 22nd November 2024

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           5.2.0
+ * Version:           5.2.1-beta.2
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '5.2.0');
+define('BEYONDWORDS__PLUGIN_VERSION', '5.2.1-beta.2');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/Settings/Fields/Languages/Languages.php
+++ b/src/Component/Settings/Fields/Languages/Languages.php
@@ -94,7 +94,7 @@ class Languages
 
         $selectedLanguages = get_option(self::OPTION_NAME);
 
-        if (! is_array($selectedLanguages) || empty($selectedLanguages)) {
+        if (empty($selectedLanguages) || ! is_array($selectedLanguages)) {
             $selectedLanguages = self::DEFAULT_LANGUAGES;
         }
 

--- a/src/Component/Settings/Fields/Languages/Languages.php
+++ b/src/Component/Settings/Fields/Languages/Languages.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Beyondwords\Wordpress\Component\Settings\Fields\Languages;
 
 use Beyondwords\Wordpress\Core\ApiClient;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * Languages
@@ -34,6 +35,27 @@ class Languages
      * @since 3.0.0
      */
     public const DEFAULT_LANGUAGES = [];
+
+    /**
+     * PropertyAccessor.
+     *
+     * @var PropertyAccess
+     *
+     * @since 5.2.1
+     */
+    public $propertyAccessor;
+
+    /**
+     * Constructor.
+     *
+     * @since 5.0.0
+     */
+    public function __construct()
+    {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->disableExceptionOnInvalidPropertyPath()
+            ->getPropertyAccessor();
+    }
 
     /**
      * Init.
@@ -89,7 +111,7 @@ class Languages
 
         $selectedLanguages = get_option(self::OPTION_NAME);
 
-        if (! is_array($selectedLanguages)) {
+        if (! is_array($selectedLanguages) || empty($selectedLanguages)) {
             $selectedLanguages = self::DEFAULT_LANGUAGES;
         }
 
@@ -103,21 +125,23 @@ class Languages
                 style="width: 500px;"
                 autocomplete="off"
             >
-                <?php foreach ($allLanguages as $language) : 
-                    $bodyId            = $language['default_voices']['body']['id'];
-                    $bodySpeakingRate  = $language['default_voices']['body']['speaking_rate'];
-                    $titleId           = $language['default_voices']['title']['id'];
-                    $titleSpeakingRate = $language['default_voices']['title']['speaking_rate'];
+                <?php foreach ($allLanguages as $language) :
+                    $languageId        = $this->propertyAccessor->getValue($language, '[id]');
+                    $languageName      = $this->propertyAccessor->getValue($language, '[name]');
+                    $bodyId            = $this->propertyAccessor->getValue($language, '[default_voices][body][id]');
+                    $bodySpeakingRate  = $this->propertyAccessor->getValue($language, '[default_voices][body][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
+                    $titleId           = $this->propertyAccessor->getValue($language, '[default_voices][title][id]');
+                    $titleSpeakingRate = $this->propertyAccessor->getValue($language, '[default_voices][title][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
                     ?>
                     <option
-                        value="<?php echo esc_attr($language['id']); ?>"
+                        value="<?php echo esc_attr($languageId); ?>"
                         data-default-voice-body-id="<?php echo esc_attr($bodyId); ?>"
                         data-default-voice-body-speaking-rate="<?php echo esc_attr($bodySpeakingRate); ?>"
                         data-default-voice-title-id="<?php echo esc_attr($titleId); ?>"
                         data-default-voice-title-speaking-rate="<?php echo esc_attr($titleSpeakingRate); ?>"
-                        <?php selected(in_array($language['id'], $selectedLanguages), true); ?>
+                        <?php selected(in_array($languageId, $selectedLanguages), true); ?>
                     >
-                        <?php echo esc_attr($language['name']); ?>
+                        <?php echo esc_attr($languageName); ?>
                     </option>
                 <?php endforeach; ?>
             </select>

--- a/src/Component/Settings/Fields/Languages/Languages.php
+++ b/src/Component/Settings/Fields/Languages/Languages.php
@@ -37,27 +37,6 @@ class Languages
     public const DEFAULT_LANGUAGES = [];
 
     /**
-     * PropertyAccessor.
-     *
-     * @var PropertyAccess
-     *
-     * @since 5.2.1
-     */
-    public $propertyAccessor;
-
-    /**
-     * Constructor.
-     *
-     * @since 5.0.0
-     */
-    public function __construct()
-    {
-        $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
-            ->disableExceptionOnInvalidPropertyPath()
-            ->getPropertyAccessor();
-    }
-
-    /**
      * Init.
      *
      * @since 4.0.0
@@ -103,6 +82,10 @@ class Languages
      **/
     public function render()
     {
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->disableExceptionOnInvalidPropertyPath()
+            ->getPropertyAccessor();
+
         $allLanguages = ApiClient::getLanguages();
 
         if (! is_array($allLanguages)) {
@@ -126,12 +109,12 @@ class Languages
                 autocomplete="off"
             >
                 <?php foreach ($allLanguages as $language) :
-                    $languageId        = $this->propertyAccessor->getValue($language, '[id]');
-                    $languageName      = $this->propertyAccessor->getValue($language, '[name]');
-                    $bodyId            = $this->propertyAccessor->getValue($language, '[default_voices][body][id]');
-                    $bodySpeakingRate  = $this->propertyAccessor->getValue($language, '[default_voices][body][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
-                    $titleId           = $this->propertyAccessor->getValue($language, '[default_voices][title][id]');
-                    $titleSpeakingRate = $this->propertyAccessor->getValue($language, '[default_voices][title][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
+                    $languageId        = $propertyAccessor->getValue($language, '[id]');
+                    $languageName      = $propertyAccessor->getValue($language, '[name]');
+                    $bodyId            = $propertyAccessor->getValue($language, '[default_voices][body][id]');
+                    $bodySpeakingRate  = $propertyAccessor->getValue($language, '[default_voices][body][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
+                    $titleId           = $propertyAccessor->getValue($language, '[default_voices][title][id]');
+                    $titleSpeakingRate = $propertyAccessor->getValue($language, '[default_voices][title][speaking_rate]'); // phpcs:ignore Generic.Files.LineLength.TooLong
                     ?>
                     <option
                         value="<?php echo esc_attr($languageId); ?>"

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -284,9 +284,8 @@ class Settings
      */
     public function printSettingsErrors()
     {
-        $settingsErrors = get_transient('beyondwords_settings_errors');
-
-        delete_transient('beyondwords_settings_errors');
+        $settingsErrors = wp_cache_get('beyondwords_settings_errors', 'beyondwords');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         if (is_array($settingsErrors) && count($settingsErrors)) :
             ?>

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -199,13 +199,13 @@ class SettingsUtils
 
         if ($validConnection) {
             update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
-            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
-            delete_transient('beyondwords_settings_errors');
+            wp_cache_set('beyondwords_sync_to_wordpress', ['all'], 'beyondwords', 60);
+            wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
             return true;
         }
 
         // Cancel any syncs
-        delete_transient('beyondwords_sync_to_wordpress');
+        wp_cache_delete('beyondwords_sync_to_wordpress', 'beyondwords');
 
         self::addSettingsErrorMessage(
             sprintf(
@@ -269,7 +269,7 @@ class SettingsUtils
      **/
     public static function addSettingsErrorMessage($message, $errorId = '')
     {
-        $errors = get_transient('beyondwords_settings_errors');
+        $errors = wp_cache_get('beyondwords_settings_errors', 'beyondwords');
 
         if (empty($errors)) {
             $errors = [];
@@ -281,6 +281,6 @@ class SettingsUtils
 
         $errors[$errorId] = $message;
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
     }
 }

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -199,6 +199,7 @@ class SettingsUtils
 
         if ($statusCode === 200) {
             update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
+            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
             return true;
         }
 

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -206,15 +206,20 @@ class SettingsUtils
         // Cancel any syncs
         wp_cache_delete('beyondwords_sync_to_wordpress', 'beyondwords');
 
+        $debug = sprintf(
+            '<code>%s</code>: <code>%s</code>',
+            wp_remote_retrieve_response_code($response),
+            wp_remote_retrieve_body($response)
+        );
+
         self::addSettingsErrorMessage(
             sprintf(
-                /* translators: %s is replaced with the JSON encoded REST API response body */
+                /* translators: %s is replaced with the BeyondWords REST API response debug data */
                 __(
-                    'We were unable to validate your BeyondWords REST API connection.<br />Please check your project ID and API key, save changes, and contact us for support if this message remains.<br /><br />BeyondWords REST API Response:<br /><code>%s</code>: <code>%s</code>', // phpcs:ignore Generic.Files.LineLength.TooLong
+                    'We were unable to validate your BeyondWords REST API connection.<br />Please check your project ID and API key, save changes, and contact us for support if this message remains.<br /><br />BeyondWords REST API Response:<br />%s', // phpcs:ignore Generic.Files.LineLength.TooLong
                     'speechkit'
                 ),
-                wp_remote_retrieve_response_code($response),
-                wp_remote_retrieve_body($response)
+                $debug,
             ),
             'Settings/ValidApiConnection'
         );

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -309,7 +309,7 @@ class Sync
      **/
     public function shouldSyncOptionToDashboard($option_name)
     {
-        if (empty(self::MAP_SETTINGS[$option_name])) {
+        if (! array_key_exists($option_name, self::MAP_SETTINGS)) {
             return false;
         }
 

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -103,18 +103,23 @@ class Sync
      */
     public function scheduleSyncs()
     {
-        $tab = Settings::getActiveTab();
+        $tab       = Settings::getActiveTab();
+        $endpoints = [];
 
         switch ($tab) {
             case 'content':
-                set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
+                $endpoints = ['project'];
                 break;
             case 'voices':
-                set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
+                $endpoints = ['project'];
                 break;
             case 'player':
-                set_transient('beyondwords_sync_to_wordpress', ['player_settings', 'video_settings'], 60);
+                $endpoints = ['player_settings', 'video_settings'];
                 break;
+        }
+
+        if (count($endpoints)) {
+            wp_cache_set('beyondwords_sync_to_wordpress', $endpoints, 'beyondwords', 60);
         }
     }
 
@@ -127,8 +132,8 @@ class Sync
      **/
     public function syncToWordPress()
     {
-        $sync_to_wordpress = get_transient('beyondwords_sync_to_wordpress');
-        delete_transient('beyondwords_sync_to_wordpress');
+        $sync_to_wordpress = wp_cache_get('beyondwords_sync_to_wordpress', 'beyondwords');
+        wp_cache_delete('beyondwords_sync_to_wordpress', 'beyondwords');
 
         if (empty($sync_to_wordpress) || ! is_array($sync_to_wordpress)) {
             return;
@@ -206,8 +211,8 @@ class Sync
      **/
     public function syncToDashboard()
     {
-        $options = get_transient('beyondwords_sync_to_dashboard');
-        delete_transient('beyondwords_sync_to_dashboard');
+        $options = wp_cache_get('beyondwords_sync_to_dashboard', 'beyondwords');
+        wp_cache_delete('beyondwords_sync_to_dashboard', 'beyondwords');
 
         if (empty($options) || ! is_array($options)) {
             return;
@@ -332,7 +337,7 @@ class Sync
      **/
     public static function syncOptionToDashboard($optionName)
     {
-        $options = get_transient('beyondwords_sync_to_dashboard');
+        $options = wp_cache_get('beyondwords_sync_to_dashboard', 'beyondwords');
 
         if (! is_array($options)) {
             $options = [];
@@ -341,7 +346,7 @@ class Sync
         $options[] = $optionName;
         $options   = array_unique($options);
 
-        set_transient('beyondwords_sync_to_dashboard', $options, 30); // 30 seconds.
+        wp_cache_set('beyondwords_sync_to_dashboard', $options, 'beyondwords', 30);
     }
 
     /**

--- a/src/Core/Updater.php
+++ b/src/Core/Updater.php
@@ -29,7 +29,7 @@ class Updater
         $version = get_option('beyondwords_version', '1.0.0');
 
         if (version_compare($version, '5.0.0', '<') && get_option('beyondwords_api_key')) {
-            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
+            wp_cache_set('beyondwords_sync_to_wordpress', ['all'], 'beyondwords', 60);
         }
 
         if (version_compare($version, '3.0.0', '<')) {

--- a/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
+++ b/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
@@ -93,16 +93,16 @@ class ApiKeyTest extends WP_UnitTestCase
      */
     public function sanitize()
     {
-        set_transient('beyondwords_settings_errors', []);
+        wp_cache_set('beyondwords_settings_errors', [], 'beyondwords');
 
         // Assert valid value does not add an error
         $result = $this->_instance->sanitize('ABCDE');
 
-        $this->assertNotContains('Please enter the BeyondWords API key. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertNotContains('Please enter the BeyondWords API key. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
 
         // Assert empty value adds an error
         $result = $this->_instance->sanitize('');
 
-        $this->assertContains('Please enter the BeyondWords API key. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertContains('Please enter the BeyondWords API key. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
     }
 }

--- a/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
+++ b/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
@@ -93,16 +93,16 @@ class ProjectIdTest extends WP_UnitTestCase
      */
     public function sanitize()
     {
-        set_transient('beyondwords_settings_errors', []);
+        wp_cache_set('beyondwords_settings_errors', [], 'beyondwords');
 
         // Assert valid value does not add an error
         $result = $this->_instance->sanitize('ABCDE');
 
-        $this->assertNotContains('Please enter your BeyondWords project ID. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertNotContains('Please enter your BeyondWords project ID. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
 
         // Assert empty value adds an error
         $result = $this->_instance->sanitize('');
 
-        $this->assertContains('Please enter your BeyondWords project ID. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertContains('Please enter your BeyondWords project ID. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
     }
 }

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -20,7 +20,7 @@ class SettingsTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Settings();
     }
@@ -156,7 +156,7 @@ class SettingsTest extends WP_UnitTestCase
         $errors['Settings/Test2'] = 'Errors test 2';
         $errors['Settings/Test3'] = 'Errors test 3';
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
 
         $this->_instance->printSettingsErrors();
 
@@ -262,7 +262,7 @@ class SettingsTest extends WP_UnitTestCase
         $errors['Settings/Test2'] = 'Errors test 2';
         $errors['Settings/Test3'] = 'Errors test 3';
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
 
         $this->_instance->printSettingsErrors();
 

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -23,7 +23,7 @@ class AdvancedTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Advanced();
 

--- a/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
@@ -23,7 +23,7 @@ class CredentialsTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Credentials();
 

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -23,7 +23,7 @@ class PlayerTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Player();
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -23,7 +23,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Pronunciations();
 

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -23,7 +23,7 @@ class VoicesTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Voices();
 


### PR DESCRIPTION
- Add [Query Monitor](https://en-gb.wordpress.org/plugins/query-monitor/) plugin to `wp-env` local dev config to help with debugging
- Replace transients with object cache to reduce db writes
- Add HTTP status code into failed API credentials validation message to improve debugging for empty response body
- Fix the undefined index errors that are logged when REST API responses do not contain the expected structure