### PR TITLE
Replace transients with object cache to reduce db writes

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -25,6 +25,7 @@
         "wp-content/plugins/beyondwords-filter-player-script-onload": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-script-onload",
         "wp-content/plugins/beyondwords-filter-player-inline-script-tag": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-inline-script-tag",
         "wp-content/plugins/beyondwords-filter-player-sdk-params": "./tests/fixtures/wp-content/plugins/beyondwords-filter-player-sdk-params",
+        "wp-content/plugins/query-monitor": "https://downloads.wordpress.org/plugin/query-monitor.zip",
         "wp-content/plugins/plugin-check": "https://downloads.wordpress.org/plugin/plugin-check.zip",
         "wp-content/plugins/rest-api-insert": "./tests/fixtures/wp-content/plugins/rest-api-insert",
         "wp-content/plugins/rest-api-publish": "./tests/fixtures/wp-content/plugins/rest-api-publish",

--- a/src/Component/Settings/Settings.php
+++ b/src/Component/Settings/Settings.php
@@ -284,9 +284,8 @@ class Settings
      */
     public function printSettingsErrors()
     {
-        $settingsErrors = get_transient('beyondwords_settings_errors');
-
-        delete_transient('beyondwords_settings_errors');
+        $settingsErrors = wp_cache_get('beyondwords_settings_errors', 'beyondwords');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         if (is_array($settingsErrors) && count($settingsErrors)) :
             ?>

--- a/src/Component/Settings/SettingsUtils.php
+++ b/src/Component/Settings/SettingsUtils.php
@@ -199,13 +199,13 @@ class SettingsUtils
 
         if ($validConnection) {
             update_option('beyondwords_valid_api_connection', gmdate(\DateTime::ATOM), false);
-            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
-            delete_transient('beyondwords_settings_errors');
+            wp_cache_set('beyondwords_sync_to_wordpress', ['all'], 'beyondwords', 60);
+            wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
             return true;
         }
 
         // Cancel any syncs
-        delete_transient('beyondwords_sync_to_wordpress');
+        wp_cache_delete('beyondwords_sync_to_wordpress', 'beyondwords');
 
         self::addSettingsErrorMessage(
             sprintf(
@@ -269,7 +269,7 @@ class SettingsUtils
      **/
     public static function addSettingsErrorMessage($message, $errorId = '')
     {
-        $errors = get_transient('beyondwords_settings_errors');
+        $errors = wp_cache_get('beyondwords_settings_errors', 'beyondwords');
 
         if (empty($errors)) {
             $errors = [];
@@ -281,6 +281,6 @@ class SettingsUtils
 
         $errors[$errorId] = $message;
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
     }
 }

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -103,18 +103,23 @@ class Sync
      */
     public function scheduleSyncs()
     {
-        $tab = Settings::getActiveTab();
+        $tab       = Settings::getActiveTab();
+        $endpoints = [];
 
         switch ($tab) {
             case 'content':
-                set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
+                $endpoints = ['project'];
                 break;
             case 'voices':
-                set_transient('beyondwords_sync_to_wordpress', ['project'], 60);
+                $endpoints = ['project'];
                 break;
             case 'player':
-                set_transient('beyondwords_sync_to_wordpress', ['player_settings', 'video_settings'], 60);
+                $endpoints = ['player_settings', 'video_settings'];
                 break;
+        }
+
+        if ($endpoints) {
+            wp_cache_set('beyondwords_sync_to_wordpress', $endpoints, 'beyondwords', 60);
         }
     }
 
@@ -127,8 +132,8 @@ class Sync
      **/
     public function syncToWordPress()
     {
-        $sync_to_wordpress = get_transient('beyondwords_sync_to_wordpress');
-        delete_transient('beyondwords_sync_to_wordpress');
+        $sync_to_wordpress = wp_cache_get('beyondwords_sync_to_wordpress', 'beyondwords');
+        wp_cache_delete('beyondwords_sync_to_wordpress', 'beyondwords');
 
         if (empty($sync_to_wordpress) || ! is_array($sync_to_wordpress)) {
             return;
@@ -206,8 +211,8 @@ class Sync
      **/
     public function syncToDashboard()
     {
-        $options = get_transient('beyondwords_sync_to_dashboard');
-        delete_transient('beyondwords_sync_to_dashboard');
+        $options = wp_cache_get('beyondwords_sync_to_dashboard', 'beyondwords');
+        wp_cache_delete('beyondwords_sync_to_dashboard', 'beyondwords');
 
         if (empty($options) || ! is_array($options)) {
             return;
@@ -332,7 +337,7 @@ class Sync
      **/
     public static function syncOptionToDashboard($optionName)
     {
-        $options = get_transient('beyondwords_sync_to_dashboard');
+        $options = wp_cache_get('beyondwords_sync_to_dashboard', 'beyondwords');
 
         if (! is_array($options)) {
             $options = [];
@@ -341,7 +346,7 @@ class Sync
         $options[] = $optionName;
         $options   = array_unique($options);
 
-        set_transient('beyondwords_sync_to_dashboard', $options, 30); // 30 seconds.
+        wp_cache_set('beyondwords_sync_to_dashboard', $options, 'beyondwords', 30);
     }
 
     /**

--- a/src/Component/Settings/Sync.php
+++ b/src/Component/Settings/Sync.php
@@ -118,7 +118,7 @@ class Sync
                 break;
         }
 
-        if ($endpoints) {
+        if (count($endpoints)) {
             wp_cache_set('beyondwords_sync_to_wordpress', $endpoints, 'beyondwords', 60);
         }
     }

--- a/src/Core/Updater.php
+++ b/src/Core/Updater.php
@@ -29,7 +29,7 @@ class Updater
         $version = get_option('beyondwords_version', '1.0.0');
 
         if (version_compare($version, '5.0.0', '<') && get_option('beyondwords_api_key')) {
-            set_transient('beyondwords_sync_to_wordpress', ['all'], 60);
+            wp_cache_set('beyondwords_sync_to_wordpress', ['all'], 'beyondwords', 60);
         }
 
         if (version_compare($version, '3.0.0', '<')) {

--- a/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
+++ b/tests/phpunit/Settings/Fields/ApiKey/ApiKeyTest.php
@@ -93,16 +93,16 @@ class ApiKeyTest extends WP_UnitTestCase
      */
     public function sanitize()
     {
-        set_transient('beyondwords_settings_errors', []);
+        wp_cache_set('beyondwords_settings_errors', [], 'beyondwords');
 
         // Assert valid value does not add an error
         $result = $this->_instance->sanitize('ABCDE');
 
-        $this->assertNotContains('Please enter the BeyondWords API key. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertNotContains('Please enter the BeyondWords API key. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
 
         // Assert empty value adds an error
         $result = $this->_instance->sanitize('');
 
-        $this->assertContains('Please enter the BeyondWords API key. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertContains('Please enter the BeyondWords API key. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
     }
 }

--- a/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
+++ b/tests/phpunit/Settings/Fields/ProjectId/ProjectIdTest.php
@@ -93,16 +93,16 @@ class ProjectIdTest extends WP_UnitTestCase
      */
     public function sanitize()
     {
-        set_transient('beyondwords_settings_errors', []);
+        wp_cache_set('beyondwords_settings_errors', [], 'beyondwords');
 
         // Assert valid value does not add an error
         $result = $this->_instance->sanitize('ABCDE');
 
-        $this->assertNotContains('Please enter your BeyondWords project ID. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertNotContains('Please enter your BeyondWords project ID. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
 
         // Assert empty value adds an error
         $result = $this->_instance->sanitize('');
 
-        $this->assertContains('Please enter your BeyondWords project ID. This can be found in your project settings.', get_transient('beyondwords_settings_errors'));
+        $this->assertContains('Please enter your BeyondWords project ID. This can be found in your project settings.', wp_cache_get('beyondwords_settings_errors', 'beyondwords'));
     }
 }

--- a/tests/phpunit/Settings/SettingsTest.php
+++ b/tests/phpunit/Settings/SettingsTest.php
@@ -20,7 +20,7 @@ class SettingsTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Settings();
     }
@@ -156,7 +156,7 @@ class SettingsTest extends WP_UnitTestCase
         $errors['Settings/Test2'] = 'Errors test 2';
         $errors['Settings/Test3'] = 'Errors test 3';
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
 
         $this->_instance->printSettingsErrors();
 
@@ -262,7 +262,7 @@ class SettingsTest extends WP_UnitTestCase
         $errors['Settings/Test2'] = 'Errors test 2';
         $errors['Settings/Test3'] = 'Errors test 3';
 
-        set_transient('beyondwords_settings_errors', $errors);
+        wp_cache_set('beyondwords_settings_errors', $errors, 'beyondwords');
 
         $this->_instance->printSettingsErrors();
 

--- a/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
+++ b/tests/phpunit/Settings/Tabs/AdvancedTabTest.php
@@ -23,7 +23,7 @@ class AdvancedTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Advanced();
 

--- a/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/CredentialsTabTest.php
@@ -23,7 +23,7 @@ class CredentialsTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Credentials();
 

--- a/tests/phpunit/Settings/Tabs/PlayerTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PlayerTabTest.php
@@ -23,7 +23,7 @@ class PlayerTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Player();
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);

--- a/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
+++ b/tests/phpunit/Settings/Tabs/PronunciationsTabTest.php
@@ -23,7 +23,7 @@ class PronunciationsTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Pronunciations();
 

--- a/tests/phpunit/Settings/Tabs/VoicesTabTest.php
+++ b/tests/phpunit/Settings/Tabs/VoicesTabTest.php
@@ -23,7 +23,7 @@ class VoicesTabTest extends WP_UnitTestCase
         parent::setUp();
 
         // Your set up methods here.
-        delete_transient('beyondwords_settings_errors');
+        wp_cache_delete('beyondwords_settings_errors', 'beyondwords');
 
         $this->_instance = new Voices();
 


### PR DESCRIPTION
- Replaced transient writes (db writes) with object cache.
- Add `query-monitor` plugin to wp-env setup to help with debugging.