### PR TITLE
Update WordPress GET voice queries to use scopes

### DIFF
--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -230,7 +230,12 @@ class ApiClient
             $field = 'language.id';
         }
 
-        $url = sprintf('%s/organization/voices?filter[%s]=%s', Environment::getApiUrl(), $field, urlencode(strval($language))); // phpcs:ignore Generic.Files.LineLength.TooLong
+        $url = sprintf(
+            '%s/organization/voices?filter[%s]=%s&filter[scopes][]=primary&filter[scopes][]=secondary',
+            Environment::getApiUrl(),
+            $field,
+            urlencode(strval($language))
+        );
 
         $request  = new Request('GET', $url);
         $response = self::callApi($request);


### PR DESCRIPTION
To include multilingual voices in the REST API responses for voices, they need to use scopes similar to this:

```
https://api.staging-beyondwords.io/v1/organization/voices?filter[language.code]=bg_BG&filter[scopes][]=primary&filter[scopes][]=secondary
```