### PR TITLE
Optimise WordPress HTTP calls to BeyondWords REST API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -86,7 +86,7 @@ Release date: 10th December 2024
 
 **Fixes**
 
-* Optimise WordPress HTTP calls to BeyondWords REST API.
+* [423](https://github.com/beyondwords-io/wordpress-plugin/pull/423) Optimise WordPress HTTP calls to BeyondWords REST API.
     * Increase the WordPress default `timeout` param from `5` to `30`. This is to address a reported issue where REST API calls are sometimes timing out in WordPress/PHP before the REST API is able to respond.
     * Also removed the `sslverify` param for API calls. This is no longer recommended.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 5.2.1
+Stable tag: 5.2.2
 Requires PHP: 8.0
 Tested up to: 6.7
 License: GPLv2 or later
@@ -79,6 +79,16 @@ You can even leverage your listenership through audio advertising. Use our self-
 Any questions? [Visit our website](https://beyondwords.io/?utm_source=wordpress&utm_medium=referral&utm_campaign=&utm_content=plugin) or email <hello@beyondwords.io>.
 
 == Changelog ==
+
+= 5.2.2 =
+
+Release date: 10th December 2024
+
+**Fixes**
+
+* Optimise WordPress HTTP calls to BeyondWords REST API.
+    * Increase the WordPress default `timeout` param from `5` to `30`. This is to address a reported issue where REST API calls are sometimes timing out in WordPress/PHP before the REST API is able to respond.
+    * Also removed the `sslverify` param for API calls. This is no longer recommended.
 
 = 5.2.1 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           5.2.1
+ * Version:           5.2.2
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '5.2.1');
+define('BEYONDWORDS__PLUGIN_VERSION', '5.2.2');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Component/SiteHealth/SiteHealth.php
+++ b/src/Component/SiteHealth/SiteHealth.php
@@ -323,6 +323,7 @@ class SiteHealth
      * Adds debugging data for the BeyondWords REST API connection.
      *
      * @since 3.7.0
+     * @since 5.2.2 Remove sslverify param for REST API calls.
      *
      * @param array  $info Debugging info array
      *
@@ -342,7 +343,6 @@ class SiteHealth
             'blocking'    => true,
             'body'        => '',
             'method'      => 'GET',
-            'sslverify'   => true,
         ]);
 
         if (! is_wp_error($response)) {
@@ -419,7 +419,7 @@ class SiteHealth
 
         $info['beyondwords']['fields'][$name] = [
             'label' => $name,
-            'value' => $value, 
+            'value' => $value,
             'debug' => $value,
         ];
     }

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -118,6 +118,7 @@ class ApiClient
      *
      * @since 4.1.0
      * @since 5.2.0 Make static.
+     * @since 5.2.2 Remove sslverify param & increase timeout to 30s for REST API calls.
      *
      * @param int[] $postIds Array of WordPress Post IDs.
      *
@@ -163,11 +164,11 @@ class ApiClient
         $request = new Request('POST', $url, $body);
 
         $args = array(
-            'blocking'    => true,
-            'body'        => $request->getBody(),
-            'headers'     => $request->getHeaders(),
-            'method'      => $request->getMethod(),
-            'sslverify'   => true,
+            'blocking' => true,
+            'body'     => $request->getBody(),
+            'headers'  => $request->getHeaders(),
+            'method'   => $request->getMethod(),
+            'timeout'  => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
         );
 
         $response = wp_remote_request($request->getUrl(), $args);
@@ -486,6 +487,7 @@ class ApiClient
      * @since 4.0.0 Removed hash comparison and display 403 errors.
      * @since 4.1.0 Introduced.
      * @since 5.2.0 Make static.
+     * @since 5.2.2 Remove sslverify param & increase timeout to 30s for REST API calls.
      *
      * @param Request $request BeyondWords Request.
      *
@@ -494,11 +496,11 @@ class ApiClient
     public static function buildRequestArgs($request)
     {
         return [
-            'blocking'    => true,
-            'body'        => $request->getBody(),
-            'headers'     => $request->getHeaders(),
-            'method'      => $request->getMethod(),
-            'sslverify'   => true,
+            'blocking' => true,
+            'body'     => $request->getBody(),
+            'headers'  => $request->getHeaders(),
+            'method'   => $request->getMethod(),
+            'timeout'  => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
         ];
     }
 


### PR DESCRIPTION
- Increase the WordPress default `timeout` param from `5` to `30`. This is to address a reported issue where REST API calls are sometimes timing out in WordPress/PHP before the REST API is able to respond.
- Also removed the `sslverify` param for API calls. This is no longer recommended.