### PR TITLE
Add composer.json to build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,7 @@ jobs:
             src \
             vendor \
             changelog.txt \
+            composer.json \
             index.php \
             LICENSE.txt \
             readme.txt \

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,6 @@
     "description": "The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.",
     "license": "GPL-2.0-or-later",
     "type": "project",
-    "authors": [
-        {
-            "name": "Stuart McAlpine",
-            "email": "stu@beyondwords.io"
-        }
-    ],
     "homepage": "https://beyondwords.io",
     "require": {
         "php": ">=8.0",


### PR DESCRIPTION
We now include `composer.json` in our built plugin files to address the Plugin Check warning added in https://github.com/WordPress/plugin-check/issues/829.

---

This pull request includes changes to the `.github/workflows/main.yml` file.

Workflow configuration updates:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R87): Added `composer.json` to the list of files to be added to the build.