### PR TITLE
Test against and support PHP 8.4

### DIFF
--- a/.github/.nginx/sites-available/localhost.conf
+++ b/.github/.nginx/sites-available/localhost.conf
@@ -11,7 +11,7 @@ server {
     }
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
         include snippets/fastcgi-php.conf;
     }
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,14 +120,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/composer-cache
-          key: ${{ runner.os }}-php8.3-dev-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php8.4-dev-${{ hashFiles('**/composer.lock') }}
 
       - name: Install Composer dependencies (dev)
         uses: php-actions/composer@v6
         with:
           dev: yes
           args: --ignore-platform-reqs --optimize-autoloader --profile
-          php_version: '8.3'
+          php_version: '8.4'
 
       - name: Run GrumPHP code_quality test suite
         run: ./vendor/bin/grumphp run --testsuite code_quality
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3']
+        php-version: ['8.4']
         phpunit-version: ['10']
         operating-system: ['ubuntu-latest']
         include:
@@ -305,7 +305,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Publish results only for the latest PHP version
-          name: PHPUnit Test Results - PHP 8.3
+          name: PHPUnit Test Results - PHP 8.4
           path: .
 
       - name: Setup Pages
@@ -335,7 +335,7 @@ jobs:
       # don't fail the entire matrix on failure
       fail-fast: false
       matrix:
-        php-version: ['8.3']
+        php-version: ['8.4']
         phpunit-version: ['10']
         operating-system: ['ubuntu-latest']
         include:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
     "core": null,
-    "phpVersion": "8.3",
+    "phpVersion": "8.4",
     "plugins": [
         "WP-API/Basic-Auth",
         "./tests/fixtures/wp-content/plugins/cpt-active",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Github Actions Workflow](https://github.com/beyondwords-io/wordpress-plugin/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/beyondwords-io/wordpress-plugin/actions/workflows/main.yml)
 [![PHPUnit Code Coverage](https://beyondwords-io.github.io/wordpress-plugin/coverage-badge.svg)](https://beyondwords-io.github.io/wordpress-plugin/dashboard.html)
 [![Supported WordPress Versions](https://img.shields.io/static/v1?label=&message=5.8+-+6.7&color=blue&logo=wordpress&logoColor=white)](https://wordpress.org/)
-[![Supported PHP Versions](https://img.shields.io/static/v1?label=&message=8.0+-+8.3&color=777bb4&logo=php&logoColor=white)](https://www.php.net/)
+[![Supported PHP Versions](https://img.shields.io/static/v1?label=&message=8.0+-+8.4&color=777bb4&logo=php&logoColor=white)](https://www.php.net/)
 
 ##  Description
 


### PR DESCRIPTION
This pull request includes updates to various configuration files to support PHP version 8.4 instead of 8.3. The changes ensure compatibility and consistency across the project.

### PHP Version Update:

* [`.github/.nginx/sites-available/localhost.conf`](diffhunk://#diff-a58e0fdc6220f74afd3ebeb62b6b36e6531a793b074188ad134fa7e90d560a0cL14-R14): Updated `fastcgi_pass` to use PHP 8.4 socket.
* `.github/workflows/main.yml`: 
  * Updated cache key to reflect PHP 8.4.
  * Updated `php_version` in the Composer dependencies installation step to 8.4.
  * Updated matrix strategy to include PHP 8.4. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L182-R182) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L338-R338)
  * Updated artifact name to reflect PHP 8.4 for PHPUnit Test Results.
* [`.wp-env.json`](diffhunk://#diff-9fd21b09a0144355cfd001e3952767df08b2e04241994470aa1d627f797b171eL3-R3): Updated `phpVersion` to 8.4.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8): Updated supported PHP versions badge to include 8.4.