### PR TITLE
Add support article language in WordPress

### DIFF
--- a/src/Component/Post/Panel/Inspect/index.js
+++ b/src/Component/Post/Panel/Inspect/index.js
@@ -22,6 +22,7 @@ export function PostInspectPanel( {
 	beyondwordsPreviewToken,
 	beyondwordsPlayerContent,
 	beyondwordsPlayerStyle,
+	beyondwordsLanguageCode,
 	beyondwordsLanguageId,
 	beyondwordsBodyVoiceId,
 	beyondwordsTitleVoiceId,
@@ -81,6 +82,7 @@ export function PostInspectPanel( {
 			beyondwords_preview_token: beyondwordsPreviewToken,
 			beyondwords_player_content: beyondwordsPlayerContent,
 			beyondwords_player_style: beyondwordsPlayerStyle,
+			beyondwords_language_code: beyondwordsLanguageCode,
 			beyondwords_language_id: beyondwordsLanguageId,
 			beyondwords_body_voice_id: beyondwordsBodyVoiceId,
 			beyondwords_title_voice_id: beyondwordsTitleVoiceId,
@@ -116,6 +118,7 @@ export function PostInspectPanel( {
 			`beyondwords_preview_token\r\n${ beyondwordsPreviewToken }`,
 			`beyondwords_player_content\r\n${ beyondwordsPlayerContent }`,
 			`beyondwords_player_style\r\n${ beyondwordsPlayerStyle }`,
+			`beyondwords_language_code\r\n${ beyondwordsLanguageCode }`,
 			`beyondwords_language_id\r\n${ beyondwordsLanguageId }`,
 			`beyondwords_body_voice_id\r\n${ beyondwordsBodyVoiceId }`,
 			`beyondwords_title_voice_id\r\n${ beyondwordsTitleVoiceId }`,
@@ -216,6 +219,13 @@ export function PostInspectPanel( {
 				label="beyondwords_player_style"
 				readOnly
 				value={ beyondwordsPlayerStyle }
+				__nextHasNoMarginBottom
+			/>
+
+			<TextControl
+				label="beyondwords_language_code"
+				readOnly
+				value={ beyondwordsLanguageCode }
 				__nextHasNoMarginBottom
 			/>
 
@@ -327,6 +337,8 @@ export default compose( [
 				getEditedPostAttribute( 'meta' ).beyondwords_player_content,
 			beyondwordsPlayerStyle:
 				getEditedPostAttribute( 'meta' ).beyondwords_player_style,
+			beyondwordsLanguageCode:
+				getEditedPostAttribute( 'meta' ).beyondwords_language_code,
 			beyondwordsLanguageId:
 				getEditedPostAttribute( 'meta' ).beyondwords_language_id,
 			beyondwordsBodyVoiceId:

--- a/src/Component/Post/PostMetaUtils.php
+++ b/src/Component/Post/PostMetaUtils.php
@@ -107,6 +107,7 @@ class PostMetaUtils
             'beyondwords_preview_token',
             'beyondwords_player_content',
             'beyondwords_player_style',
+            'beyondwords_language_code',
             'beyondwords_language_id',
             'beyondwords_body_voice_id',
             'beyondwords_title_voice_id',

--- a/src/Component/Post/SelectVoice/classic-metabox.js
+++ b/src/Component/Post/SelectVoice/classic-metabox.js
@@ -23,6 +23,21 @@
 		/**
 		 * Setup click events.
 		 *
+		 * @since 5.4.0
+		 */
+		setupClickEvents() {
+			$( document ).on(
+				'change',
+				'select#beyondwords_language_code',
+				function () {
+					selectVoice.getVoices( this.value );
+				}
+			);
+		},
+
+		/**
+		 * Setup click events.
+		 *
 		 * @since 4.0.0
 		 */
 		setupClickEvents() {
@@ -30,7 +45,7 @@
 				'change',
 				'select#beyondwords_language_id',
 				function () {
-					selectVoice.getVoices( this.value );
+					selectVoice.getVoicesLegacy( this.value );
 				}
 			);
 		},
@@ -66,9 +81,45 @@
 		/**
 		 * Get voices for a language.
 		 *
+		 * @since 5.4.0
+		 */
+		getVoices( languageCode ) {
+			const $voicesSelect = $( '#beyondwords_voice_id' );
+
+			if ( ! languageCode ) {
+				$voicesSelect.empty().attr( 'disabled', true );
+				return;
+			}
+
+			const endpoint = `${beyondwordsData.root}beyondwords/v1/languages/${languageCode}/voices`;
+
+			jQuery.ajax( {
+				url: endpoint,
+				method: 'GET',
+				beforeSend: function ( xhr ) {
+					xhr.setRequestHeader( 'X-WP-Nonce', beyondwordsData.nonce );
+				}
+			} ).done( function( voices ) {
+				$voicesSelect
+					.empty()
+					.append( '<option value=""></option>' )
+					.append( voices.map( ( voice ) => {
+						return $( '<option></option>' ).val( voice.id ).text( voice.name );
+					} ) )
+					.attr( 'disabled', false );
+			} ).fail(function ( xhr ) {
+				console.log( '🔊 Unable to load voices', xhr );
+				$voicesSelect.empty().attr( 'disabled', true )
+			} );
+		},
+	};
+
+		/**
+		 * Get voices for a language.
+		 *
 		 * @since 4.0.0
 		 */
-		getVoices( languageId ) {
+		getVoicesLegacy( languageId ) {
 			const $voicesSelect = $( '#beyondwords_voice_id' );
 
 			languageId = parseInt(languageId);

--- a/src/Component/Post/SelectVoice/index.js
+++ b/src/Component/Post/SelectVoice/index.js
@@ -23,8 +23,16 @@ export function SelectVoice( { wrapper } ) {
 
 	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
+	const languageCode = meta.beyondwords_language_code;
 	const languageId = meta.beyondwords_language_id;
 	const bodyVoiceId = meta.beyondwords_body_voice_id;
+
+	const setLanguageCode = ( newLanguageCode ) => {
+		setMeta( {
+			...meta,
+			beyondwords_language_code: newLanguageCode,
+		} );
+	};
 
 	const setLanguageId = ( newLanguageId ) => {
 		setMeta( {
@@ -50,7 +58,13 @@ export function SelectVoice( { wrapper } ) {
 
 	const { voices } = useSelect( ( select ) => {
 		return {
-			voices: languageId ? select( 'beyondwords/settings' ).getVoices( languageId ) : [],
+			voices: languageCode ? select( 'beyondwords/settings' ).getVoices( languageCode ) : [],
+		}
+	}, [ languageCode ] );
+
+	const { voices } = useSelect( ( select ) => {
+		return {
+			voices: languageId ? select( 'beyondwords/settings' ).getVoicesLegacy( languageId ) : [],
 		}
 	}, [ languageId ] );
 
@@ -58,7 +72,7 @@ export function SelectVoice( { wrapper } ) {
 		return ( languages ?? [] ).map( ( language ) => {
 			return {
 				label: decodeEntities( language.name ),
-				value: decodeEntities( language.id ),
+				value: decodeEntities( language.code ),
 			};
 		} );
 	}, [ languages ] );

--- a/src/Component/Settings/Fields/Voice/Voice.php
+++ b/src/Component/Settings/Fields/Voice/Voice.php
@@ -25,13 +25,19 @@ abstract class Voice
      * Get all options for the current component.
      *
      * @since 5.0.0
+     * @since 5.4.0
      *
      * @return string[] Associative array of options.
      **/
     public function getOptions()
     {
-        $languageId = get_option('beyondwords_project_language_id');
-        $voices     = ApiClient::getVoices($languageId);
+        $languageCode = get_option('beyondwords_project_language_code');
+        if ($languageCode) {
+            $voices = ApiClient::getVoices($languageCode);
+        } else {
+            $languageId = get_option('beyondwords_project_language_id');
+            $voices = ApiClient::getVoicesLegacy($languageId);
+        }
 
         if (! $voices) {
             return [];
@@ -39,7 +45,7 @@ abstract class Voice
 
         $options = array_map(function ($voice) {
             return [
-                'value' => $voice['id'],
+                'value' => $voice['code'],
                 'label' => $voice['name'],
             ];
         }, $voices);

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -223,7 +223,34 @@ class ApiClient
      *
      * @return mixed JSON-decoded response body
      **/
-    public static function getVoices($language)
+    public static function getVoices($languageCode)
+    {
+        $url = sprintf(
+            '%s/organization/voices?filter[language.code]=%s&filter[scopes][]=primary&filter[scopes][]=secondary',
+            Environment::getApiUrl(),
+            urlencode(strval($languageCode))
+        );
+
+        $request  = new Request('GET', $url);
+        $response = self::callApi($request);
+
+        return json_decode(wp_remote_retrieve_body($response), true);
+    }
+
+    /**
+     * GET /organization/voices
+     *
+     * @since 4.0.0 Introduced
+     * @since 4.0.2 Prefix endpoint with /organization
+     * @since 4.5.1 Check the $languageId param is numeric.
+     * @since 5.0.0 Accept numeric language ID or string language code as param.
+     * @since 5.2.0 Make static.
+     *
+     * @param int|string $language BeyondWords Language code or numeric ID
+     *
+     * @return mixed JSON-decoded response body
+     **/
+    public static function getVoicesLegacy($language)
     {
         $field = 'language.code';
 
@@ -248,6 +275,32 @@ class ApiClient
      * Loops though GET /organization/voices, because
      * GET /organization/voice is not available.
      *
+     * @since 5.4.0
+     *
+     * @param int       $voiceId  Voice ID.
+     * @param int|false $languageCode Language code, optional.
+     *
+     * @return object|false Voice, or false if not found.
+     **/
+    public static function getVoice($voiceId, $languageCode = false)
+    {
+        if (! $languageCode) {
+            $languageCode = get_option('beyondwords_project_language_code');
+        }
+
+        $voices = self::getVoices($languageCode);
+
+        if (empty($voices)) {
+            return false;
+        }
+
+        return array_column($voices, null, 'id')[$voiceId] ?? false;
+    }
+
+    /**
+     * Loops though GET /organization/voices, because
+     * GET /organization/voice is not available.
+     *
      * @since 5.0.0
      * @since 5.2.0 Make static.
      *
@@ -256,13 +309,13 @@ class ApiClient
      *
      * @return object|false Voice, or false if not found.
      **/
-    public static function getVoice($voiceId, $languageId = false)
+    public static function getVoiceLegacy($voiceId, $languageId = false)
     {
         if (! $languageId) {
             $languageId = get_option('beyondwords_project_language_id');
         }
 
-        $voices = self::getVoices($languageId);
+        $voices = self::getVoicesLegacy($languageId);
 
         if (empty($voices)) {
             return false;

--- a/src/Core/Settings/store/resolvers.js
+++ b/src/Core/Settings/store/resolvers.js
@@ -19,7 +19,12 @@ const resolvers = {
 		const languages = yield actions.fetchFromAPI( path );
 		return actions.setLanguages( languages );
 	},
-	*getVoices( languageId ) {
+	*getVoices( languageCode ) {
+		const path = `/beyondwords/v1/languages/${languageCode}/voices`;
+		const voices = yield actions.fetchFromAPI( path );
+		return actions.setVoices( voices );
+	},
+	*getVoicesLegacy( languageId ) {
 		const path = `/beyondwords/v1/languages/${languageId}/voices`;
 		const voices = yield actions.fetchFromAPI( path );
 		return actions.setVoices( voices );

--- a/src/Core/Settings/store/selectors.js
+++ b/src/Core/Settings/store/selectors.js
@@ -14,6 +14,9 @@ const selectors = {
 	getVoices( state ) {
 		return state.voices;
 	},
+	getVoicesLegacy( state ) {
+		return state.voices;
+	},
 };
 
 export default selectors;


### PR DESCRIPTION
We need to make sure that each POST/PUT request to the API includes the language for the article. 

The hierarchy is `segment voice` > `article voice` > `project voice`. We recently added this language field to the content endpoint - it accepts locale code e.g., `en_gb`. 

By default we should use the project.language but then also let user specify on a per post basis before they select the voice. 