### PR TITLE
Add `$context` param to `beyondwords_player_html` filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "6.0.4",
+  "version": "6.1.0-beta.1",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check-licenses": "wp-scripts check-licenses",
     "composer": "wp-env run cli --env-cwd=/var/www/html/wp-content/plugins/speechkit composer",
     "cypress:open": "yarn cypress open --e2e --browser chrome",
-    "cypress:run": "yarn cypress run --browser chrome",
+    "cypress:run": "ELECTRON_RUN_AS_NODE= yarn cypress run",
     "cypress:setup": "node tests/cypress/scripts/setup-ci.js",
     "format": "wp-scripts format",
     "format:src": "wp-scripts format ./src",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 6.0.4
+Stable tag: 6.1.0-beta.1
 Requires PHP: 8.0
 Tested up to: 6.9
 License: GPLv2 or later
@@ -75,6 +75,16 @@ You get access to project analytics, which means you can track listener engageme
 You can even leverage your listenership through audio advertising. Use our self-serve audio advertising feature to create your own campaigns or use VAST (video ad serving template) to connect a programmatic advertising platform, such as Google Ad Manager.
 
 == Changelog ==
+
+= 6.1.0 =
+
+Release date: TBC
+
+**Enhancements**
+
+* [#481](https://github.com/beyondwords-io/wordpress-plugin/pull/481) Add `$context` param to `beyondwords_player_html` filter.
+    * Use the `$context` param to filter the HTML output of the player depending on whether it was output using a shortcode, a WordPress block, or if has been autoprepended to the content.
+    * This filter can be used to hide autoprepended players and shown when using the shortcode, enabling the shortcode to the used effectively in PHP template files.
 
 = 6.0.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,8 +83,9 @@ Release date: TBC
 **Enhancements**
 
 * [#481](https://github.com/beyondwords-io/wordpress-plugin/pull/481) Add `$context` param to `beyondwords_player_html` filter.
-    * Use the `$context` param to filter the HTML output of the player depending on whether it was output using a shortcode, a WordPress block, or if has been autoprepended to the content.
-    * This filter can be used to hide autoprepended players and shown when using the shortcode, enabling the shortcode to the used effectively in PHP template files.
+    * Use the `$context` param to enable filtering of the player HTML based on whether it was auto-prepended to `the_content` or added manually using a shortcode.
+    * This filter can be used to hide only the auto-prepended players, enabling the shortcode to be used effectively in PHP template files.
+    * Check the [Examples](https://docs.beyondwords.io/docs-and-guides/integrations/wordpress/filters?utm_source=wordpress&utm_medium=referral&utm_campaign=&utm_content=plugin#beyondwords_player_html) in our docs for further information.
 
 = 6.0.4 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           6.0.4
+ * Version:           6.1.0-beta.1
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '6.0.4');
+define('BEYONDWORDS__PLUGIN_VERSION', '6.1.0-beta.1');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/Core/Player/Player.php
+++ b/src/Core/Player/Player.php
@@ -48,11 +48,9 @@ class Player
     public static function registerShortcodes(): void
     {
         add_shortcode('beyondwords_player', function ($atts) {
-            $atts = shortcode_atts(['context' => 'shortcode'], $atts);
-            return self::renderPlayer($atts['context']);
+            return self::renderPlayer('shortcode');
         });
     }
-
     /**
      * Conditionally prepend the player to a string (the post content).
      *

--- a/src/Core/Player/Player.php
+++ b/src/Core/Player/Player.php
@@ -117,7 +117,7 @@ class Player
         foreach (self::$renderers as $rendererClass) {
             if (is_callable([$rendererClass, 'check']) && $rendererClass::check($post)) {
                 if (is_callable([$rendererClass, 'render'])) {
-                    $html = $rendererClass::render($post);
+                    $html = $rendererClass::render($post, $context);
                     break;
                 }
             }
@@ -140,11 +140,6 @@ class Player
          * @param string $context   The context: 'auto' or 'shortcode'.
          */
         $html = apply_filters('beyondwords_player_html', $html, $post->ID, $projectId, $contentId, $context);
-
-        if (! empty($html)) {
-            $attr = sprintf('data-beyondwords-player-context="%s"', esc_attr($context));
-            $html = preg_replace('/^(\s*<\w[\w-]*)/', "$1 $attr", $html, 1);
-        }
 
         return $html;
     }

--- a/src/Core/Player/Player.php
+++ b/src/Core/Player/Player.php
@@ -47,9 +47,7 @@ class Player
      */
     public static function registerShortcodes(): void
     {
-        add_shortcode('beyondwords_player', function ($atts) {
-            return self::renderPlayer('shortcode');
-        });
+        add_shortcode('beyondwords_player', fn() => self::renderPlayer('shortcode'));
     }
     /**
      * Conditionally prepend the player to a string (the post content).

--- a/src/Core/Player/Player.php
+++ b/src/Core/Player/Player.php
@@ -95,14 +95,14 @@ class Player
         // - <div data-beyondwords-player />
         $pattern = '/<div\s+(?=[^>]*data-beyondwords-player[\s>=\/])[^>]*(?:\/>|>\s*<\/div>)/i';
 
-        return preg_replace($pattern, '[beyondwords_player context="block"]', $content);
+        return preg_replace($pattern, '[beyondwords_player]', $content);
     }
 
     /**
      * Render a player (AMP/JS depending on context).
      *
      * @param string $context The context in which the player is being rendered.
-     *                        One of 'shortcode', 'block', or 'auto'.
+     *                        One of 'auto' or 'shortcode'.
      */
     public static function renderPlayer(string $context = 'shortcode'): string
     {
@@ -131,18 +131,18 @@ class Player
          *
          * @since 4.0.0
          * @since 4.3.0 Applied to all player renderers (AMP and JavaScript).
-         * @since 6.1.0 Add $content parameter.
+         * @since 6.1.0 Add $context parameter.
          *
          * @param string $html      The HTML for the audio player.
          * @param int    $postId    WordPress post ID.
          * @param int    $projectId BeyondWords project ID.
          * @param int    $contentId BeyondWords content ID.
-         * @param string $context   The context: 'shortcode', 'block', or 'auto'.
+         * @param string $context   The context: 'auto' or 'shortcode'.
          */
         $html = apply_filters('beyondwords_player_html', $html, $post->ID, $projectId, $contentId, $context);
 
         if (! empty($html)) {
-            $attr = sprintf('data-beyondwords-wp-context="%s"', esc_attr($context));
+            $attr = sprintf('data-beyondwords-player-context="%s"', esc_attr($context));
             $html = preg_replace('/^(\s*<\w[\w-]*)/', "$1 $attr", $html, 1);
         }
 

--- a/src/Core/Player/Renderer/Amp.php
+++ b/src/Core/Player/Renderer/Amp.php
@@ -39,7 +39,7 @@ class Amp extends Base
      *
      * @return string HTML markup for AMP player.
      */
-    public static function render(\WP_Post $post): string
+    public static function render(\WP_Post $post, string $context = 'shortcode'): string
     {
         $projectId = PostMetaUtils::getProjectId($post->ID);
         $contentId = PostMetaUtils::getContentId($post->ID, true); // Fallback to Post ID if Content ID is not set
@@ -49,6 +49,7 @@ class Amp extends Base
         ob_start();
         ?>
         <amp-iframe
+            data-beyondwords-player-context="<?php echo esc_attr($context); ?>"
             frameborder="0"
             height="43"
             layout="responsive"

--- a/src/Core/Player/Renderer/Javascript.php
+++ b/src/Core/Player/Renderer/Javascript.php
@@ -20,10 +20,9 @@ class Javascript extends Base
     /**
      * Render the JavaScript player HTML.
      *
-     * @param \WP_Post $post
      * @return string HTML output.
      */
-    public static function render($post): string
+    public static function render(\WP_Post $post, string $context = 'shortcode'): string
     {
         if (PlayerUI::DISABLED === get_option(PlayerUI::OPTION_NAME)) {
             return '';
@@ -39,7 +38,8 @@ class Javascript extends Base
 
         return sprintf(
             // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-            '<script async defer src="%s" onload=\'%s\'></script>',
+            '<script data-beyondwords-player-context="%s" async defer src="%s" onload=\'%s\'></script>',
+            esc_attr($context),
             Environment::getJsSdkUrl(),
             $onload
         );

--- a/src/Core/Player/Renderer/Javascript.php
+++ b/src/Core/Player/Renderer/Javascript.php
@@ -20,6 +20,8 @@ class Javascript extends Base
     /**
      * Render the JavaScript player HTML.
      *
+     * @param \WP_Post $post   WordPress post object for which to render the player.
+     * @param string   $context Rendering context, either 'auto' or 'shortcode'.
      * @return string HTML output.
      */
     public static function render(\WP_Post $post, string $context = 'shortcode'): string

--- a/tests/cypress/e2e/filters.cy.js
+++ b/tests/cypress/e2e/filters.cy.js
@@ -65,4 +65,29 @@ describe( 'WordPress Filters', () => {
 				cy.task( 'deactivatePlugin', 'beyondwords-filter-player-script-onload' );
 			} );
 		} );
+
+	it( 'displays two players when shortcode is placed outside the_content', () => {
+		cy.task( 'activatePlugin', 'beyondwords-shortcode-in-footer' );
+
+		cy.createTestPostWithAudio( {
+			title: 'Shortcode in footer test',
+		} ).then( ( postId ) => {
+			cy.visit( `/?p=${ postId }` );
+
+			// Should have 2 player script tags: auto + footer shortcode
+			cy.hasPlayerInstances( 2 );
+
+			// Verify contexts via the data attribute
+			cy.get( '[data-beyondwords-wp-context="auto"]' ).should(
+				'have.length',
+				1
+			);
+			cy.get( '[data-beyondwords-wp-context="shortcode"]' ).should(
+				'have.length',
+				1
+			);
+		} );
+
+		cy.task( 'deactivatePlugin', 'beyondwords-shortcode-in-footer' );
+	} );
 } );

--- a/tests/cypress/e2e/filters.cy.js
+++ b/tests/cypress/e2e/filters.cy.js
@@ -78,11 +78,11 @@ describe( 'WordPress Filters', () => {
 			cy.hasPlayerInstances( 2 );
 
 			// Verify contexts via the data attribute
-			cy.get( '[data-beyondwords-wp-context="auto"]' ).should(
+			cy.get( '[data-beyondwords-player-context="auto"]' ).should(
 				'have.length',
 				1
 			);
-			cy.get( '[data-beyondwords-wp-context="shortcode"]' ).should(
+			cy.get( '[data-beyondwords-player-context="shortcode"]' ).should(
 				'have.length',
 				1
 			);

--- a/tests/fixtures/wp-content/plugins/beyondwords-shortcode-in-footer.php
+++ b/tests/fixtures/wp-content/plugins/beyondwords-shortcode-in-footer.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Output a BeyondWords player shortcode in the site footer.
+ *
+ * @package           BeyondWords
+ * @license           GPL-2.0-or-later
+ *
+ * @wordpress-plugin
+ * Plugin Name:       BeyondWords: Shortcode in footer
+ * Description:       Outputs a BeyondWords player shortcode in the site footer.
+ * Author:            BeyondWords
+ * Text Domain:       speechkit
+ * License:           No License
+ */
+function beyondwords_shortcode_in_footer() {
+    echo do_shortcode( '[beyondwords_player]' );
+}
+
+add_action( 'wp_footer', 'beyondwords_shortcode_in_footer' );

--- a/tests/phpunit/Core/PlayerTest.php
+++ b/tests/phpunit/Core/PlayerTest.php
@@ -362,12 +362,12 @@ class PlayerTest extends TestCase
         $this->assertSame(BEYONDWORDS_TESTS_PROJECT_ID, $wrapper->attr('data-project-id'));
         $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID, $wrapper->attr('data-podcast-id'));
         $this->assertSame('shortcode', $wrapper->attr('data-context'));
-        $this->assertSame('shortcode', $wrapper->attr('data-beyondwords-player-context'));
 
         $script = $wrapper->filter('script[async][defer]');
         $this->assertCount(1, $script);
         $this->assertSame(Environment::getJsSdkUrl(), $script->attr('src'));
         $this->assertNotEmpty($script->attr('onload'));
+        $this->assertSame('shortcode', $script->attr('data-beyondwords-player-context'));
 
         wp_reset_postdata();
         wp_delete_post($post->ID, true);

--- a/tests/phpunit/Core/PlayerTest.php
+++ b/tests/phpunit/Core/PlayerTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class PlayerTest extends TestCase
 {
-    public const PLAYER_HTML_FORMAT = '<script data-beyondwords-wp-context="%s" async defer src="https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js" onload=\'new BeyondWords.Player({target:this, ...{"projectId":9969,"contentId":"9279c9e0-e0b5-4789-9040-f44478ed3e9e","playerStyle":"standard"}});\'></script>';
+    public const PLAYER_HTML_FORMAT = '<script data-beyondwords-player-context="%s" async defer src="https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js" onload=\'new BeyondWords.Player({target:this, ...{"projectId":9969,"contentId":"9279c9e0-e0b5-4789-9040-f44478ed3e9e","playerStyle":"standard"}});\'></script>';
 
     /**
      * @test
@@ -63,12 +63,12 @@ class PlayerTest extends TestCase
      * @test
      * @group player
      */
-    public function addBlock()
+    public function addLegacyPlayer()
     {
         global $post;
 
         $post = self::factory()->post->create_and_get([
-            'post_title' => 'PlayerTest::addBlock',
+            'post_title' => 'PlayerTest::addLegacyPlayer',
             'meta_input' => [
                 'beyondwords_project_id' => BEYONDWORDS_TESTS_PROJECT_ID,
                 'beyondwords_podcast_id' => BEYONDWORDS_TESTS_CONTENT_ID,
@@ -84,7 +84,7 @@ class PlayerTest extends TestCase
         \the_content();
         $content = trim(ob_get_clean());
 
-        $this->assertSame("<p>Before</p>\n" . sprintf(self::PLAYER_HTML_FORMAT, 'block') . "\n<p>After</p>", $content);
+        $this->assertSame("<p>Before</p>\n" . sprintf(self::PLAYER_HTML_FORMAT, 'shortcode') . "\n<p>After</p>", $content);
 
         wp_reset_postdata();
 
@@ -172,67 +172,67 @@ class PlayerTest extends TestCase
             // === SHOULD BE REPLACED ===
             'Basic div' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with contenteditable after' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\" contenteditable=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with contenteditable before' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player=\"true\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Self-closing div' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\" />\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with whitespace inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with contenteditable before and whitespace inside' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player=\"true\"> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with single quotes' => [
                 "<p>Before</p>\n<div data-beyondwords-player='true'></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with newline inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\">\n</div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Div with tabs inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\">\t\t</div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Multiple player divs' => [
                 "<div data-beyondwords-player=\"true\"></div>\n<p>Middle</p>\n<div data-beyondwords-player=\"true\"> </div>",
-                "[beyondwords_player context=\"block\"]\n<p>Middle</p>\n[beyondwords_player context=\"block\"]",
+                "[beyondwords_player]\n<p>Middle</p>\n[beyondwords_player]",
             ],
             'Attribute value without quotes' => [
                 "<p>Before</p>\n<div data-beyondwords-player=true></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Boolean attribute (no value)' => [
                 "<p>Before</p>\n<div data-beyondwords-player></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Boolean attribute with other attrs' => [
                 "<p>Before</p>\n<div data-beyondwords-player contenteditable=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Boolean attribute with whitespace inside' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Attribute with false value (still a boolean attr)' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
             'Attribute with arbitrary value' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"anything\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
             ],
 
             // === SHOULD NOT BE REPLACED ===
@@ -270,7 +270,7 @@ class PlayerTest extends TestCase
             // 2. Even if replaced, the shortcode in a comment won't render (invisible to users)
             'HTML comment with player div - known limitation' => [
                 "<p>Before</p>\n<!-- <div data-beyondwords-player=\"true\"></div> -->\n<p>After</p>",
-                "<p>Before</p>\n<!-- [beyondwords_player context=\"block\"] -->\n<p>After</p>",
+                "<p>Before</p>\n<!-- [beyondwords_player] -->\n<p>After</p>",
             ],
             'Div with child div inside - should preserve' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"><div></div></div>\n<p>After</p>",
@@ -362,7 +362,7 @@ class PlayerTest extends TestCase
         $this->assertSame(BEYONDWORDS_TESTS_PROJECT_ID, $wrapper->attr('data-project-id'));
         $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID, $wrapper->attr('data-podcast-id'));
         $this->assertSame('shortcode', $wrapper->attr('data-context'));
-        $this->assertSame('shortcode', $wrapper->attr('data-beyondwords-wp-context'));
+        $this->assertSame('shortcode', $wrapper->attr('data-beyondwords-player-context'));
 
         $script = $wrapper->filter('script[async][defer]');
         $this->assertCount(1, $script);

--- a/tests/phpunit/Core/PlayerTest.php
+++ b/tests/phpunit/Core/PlayerTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class PlayerTest extends TestCase
 {
-    public const PLAYER_HTML = '<script async defer src="https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js" onload=\'new BeyondWords.Player({target:this, ...{"projectId":9969,"contentId":"9279c9e0-e0b5-4789-9040-f44478ed3e9e","playerStyle":"standard"}});\'></script>';
+    public const PLAYER_HTML_FORMAT = '<script data-beyondwords-wp-context="%s" async defer src="https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js" onload=\'new BeyondWords.Player({target:this, ...{"projectId":9969,"contentId":"9279c9e0-e0b5-4789-9040-f44478ed3e9e","playerStyle":"standard"}});\'></script>';
 
     /**
      * @test
@@ -52,7 +52,39 @@ class PlayerTest extends TestCase
         \the_content();
         $content = trim(ob_get_clean());
 
-        $this->assertSame("<p>Before</p>\n" . self::PLAYER_HTML . "\n<p>After</p>", $content);
+        $this->assertSame("<p>Before</p>\n" . sprintf(self::PLAYER_HTML_FORMAT, 'shortcode') . "\n<p>After</p>", $content);
+
+        wp_reset_postdata();
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     * @group player
+     */
+    public function addBlock()
+    {
+        global $post;
+
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'PlayerTest::addBlock',
+            'meta_input' => [
+                'beyondwords_project_id' => BEYONDWORDS_TESTS_PROJECT_ID,
+                'beyondwords_podcast_id' => BEYONDWORDS_TESTS_CONTENT_ID,
+            ],
+            'post_content' => "<p>Before</p>\n<div data-beyondwords-player=\"true\"></div>\n<p>After</p>",
+        ]);
+
+        $this->go_to("/?p={$post->ID}");
+
+        setup_postdata($post);
+
+        ob_start();
+        \the_content();
+        $content = trim(ob_get_clean());
+
+        $this->assertSame("<p>Before</p>\n" . sprintf(self::PLAYER_HTML_FORMAT, 'block') . "\n<p>After</p>", $content);
 
         wp_reset_postdata();
 
@@ -89,7 +121,7 @@ class PlayerTest extends TestCase
         $output = Player::autoPrependPlayer($content);
 
         // We are now is_singular() so player should be prepended
-        $this->assertSame(self::PLAYER_HTML . $content, $output);
+        $this->assertSame(sprintf(self::PLAYER_HTML_FORMAT, 'auto') . $content, $output);
 
         wp_reset_postdata();
 
@@ -140,67 +172,67 @@ class PlayerTest extends TestCase
             // === SHOULD BE REPLACED ===
             'Basic div' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with contenteditable after' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\" contenteditable=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with contenteditable before' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player=\"true\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Self-closing div' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\" />\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with whitespace inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with contenteditable before and whitespace inside' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player=\"true\"> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with single quotes' => [
                 "<p>Before</p>\n<div data-beyondwords-player='true'></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with newline inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\">\n</div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Div with tabs inside' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\">\t\t</div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Multiple player divs' => [
                 "<div data-beyondwords-player=\"true\"></div>\n<p>Middle</p>\n<div data-beyondwords-player=\"true\"> </div>",
-                "[beyondwords_player]\n<p>Middle</p>\n[beyondwords_player]",
+                "[beyondwords_player context=\"block\"]\n<p>Middle</p>\n[beyondwords_player context=\"block\"]",
             ],
             'Attribute value without quotes' => [
                 "<p>Before</p>\n<div data-beyondwords-player=true></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Boolean attribute (no value)' => [
                 "<p>Before</p>\n<div data-beyondwords-player></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Boolean attribute with other attrs' => [
                 "<p>Before</p>\n<div data-beyondwords-player contenteditable=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Boolean attribute with whitespace inside' => [
                 "<p>Before</p>\n<div contenteditable=\"false\" data-beyondwords-player> </div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Attribute with false value (still a boolean attr)' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"false\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
             'Attribute with arbitrary value' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"anything\"></div>\n<p>After</p>",
-                "<p>Before</p>\n[beyondwords_player]\n<p>After</p>",
+                "<p>Before</p>\n[beyondwords_player context=\"block\"]\n<p>After</p>",
             ],
 
             // === SHOULD NOT BE REPLACED ===
@@ -238,7 +270,7 @@ class PlayerTest extends TestCase
             // 2. Even if replaced, the shortcode in a comment won't render (invisible to users)
             'HTML comment with player div - known limitation' => [
                 "<p>Before</p>\n<!-- <div data-beyondwords-player=\"true\"></div> -->\n<p>After</p>",
-                "<p>Before</p>\n<!-- [beyondwords_player] -->\n<p>After</p>",
+                "<p>Before</p>\n<!-- [beyondwords_player context=\"block\"] -->\n<p>After</p>",
             ],
             'Div with child div inside - should preserve' => [
                 "<p>Before</p>\n<div data-beyondwords-player=\"true\"><div></div></div>\n<p>After</p>",
@@ -281,7 +313,7 @@ class PlayerTest extends TestCase
 
         // Case 5: Post exists, player enabled, should render player HTML
         delete_post_meta($post->ID, 'beyondwords_disabled');
-        $this->assertSame(self::PLAYER_HTML, Player::renderPlayer());
+        $this->assertSame(sprintf(self::PLAYER_HTML_FORMAT, 'shortcode'), Player::renderPlayer());
 
         wp_reset_postdata();
         wp_delete_post($post->ID, true);
@@ -304,21 +336,22 @@ class PlayerTest extends TestCase
 
         setup_postdata($post);
 
-        $filter = function($html, $postId, $projectId, $contentId) {
+        $filter = function($html, $postId, $projectId, $contentId, $context) {
             return sprintf(
-                '<div id="wrapper" data-post-id="%d" data-project-id="%d" data-podcast-id="%s">%s</div>',
+                '<div id="wrapper" data-post-id="%d" data-project-id="%d" data-podcast-id="%s" data-context="%s">%s</div>',
                 $postId,
                 $projectId,
                 $contentId,
+                $context,
                 $html
             );
         };
 
-        add_filter('beyondwords_player_html', $filter, 10, 4);
+        add_filter('beyondwords_player_html', $filter, 10, 5);
 
-        $html = Player::renderPlayer($post);
+        $html = Player::renderPlayer();
 
-        remove_filter('beyondwords_player_html', $filter, 10, 4);
+        remove_filter('beyondwords_player_html', $filter, 10, 5);
 
         $crawler = new Crawler($html);
 
@@ -328,6 +361,8 @@ class PlayerTest extends TestCase
         $this->assertSame("$post->ID", $wrapper->attr('data-post-id'));
         $this->assertSame(BEYONDWORDS_TESTS_PROJECT_ID, $wrapper->attr('data-project-id'));
         $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID, $wrapper->attr('data-podcast-id'));
+        $this->assertSame('shortcode', $wrapper->attr('data-context'));
+        $this->assertSame('shortcode', $wrapper->attr('data-beyondwords-wp-context'));
 
         $script = $wrapper->filter('script[async][defer]');
         $this->assertCount(1, $script);


### PR DESCRIPTION
This pull request introduces enhancements to the BeyondWords WordPress plugin, focusing on improving the flexibility of the audio player rendering and its integration with WordPress filters. The main change is the addition of a `$context` parameter to the `beyondwords_player_html` filter, allowing developers to distinguish between players auto-inserted into content and those added via shortcode. The update also includes improvements to player rendering, test coverage, and documentation.

**Enhancements to player rendering and filtering:**

* Added a `$context` parameter to the `beyondwords_player_html` filter, enabling filtering based on whether the player was auto-prepended to `the_content` or inserted via shortcode. This allows for more granular control over player display in themes and templates. [[1]](diffhunk://#diff-086ae2fb00bf15bb44ffb68885a2abb50b5b2d99b0cac7fd91254b91d833a221R101-R105) [[2]](diffhunk://#diff-086ae2fb00bf15bb44ffb68885a2abb50b5b2d99b0cac7fd91254b91d833a221R132-R140)
* Updated the player rendering methods (`renderPlayer`, `Renderer\Amp::render`, and `Renderer\Javascript::render`) to accept and propagate the `$context` parameter, and added a `data-beyondwords-player-context` attribute to the player HTML output. [[1]](diffhunk://#diff-086ae2fb00bf15bb44ffb68885a2abb50b5b2d99b0cac7fd91254b91d833a221R101-R105) [[2]](diffhunk://#diff-1730702571f6c3dbc40efc8b00b9f2c7caed5a9eb9c0003e5f8bf49a00774401L42-R42) [[3]](diffhunk://#diff-1730702571f6c3dbc40efc8b00b9f2c7caed5a9eb9c0003e5f8bf49a00774401R52) [[4]](diffhunk://#diff-713031162094acb780b3cd7e907f1ddfba5c418fe583a19d9065768ce84d28dcL23-R27) [[5]](diffhunk://#diff-713031162094acb780b3cd7e907f1ddfba5c418fe583a19d9065768ce84d28dcL42-R44)

**Testing improvements:**

* Expanded PHPUnit and Cypress test coverage to verify correct player rendering and context differentiation, including scenarios where both auto and shortcode players are present. [[1]](diffhunk://#diff-a34a533b1cccb24fa998fa3074695b516eb2e7951c9c8b8fcc54ba558e2ea3f3R68-R92) [[2]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfL12-R12) [[3]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfL55-R87) [[4]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfL92-R124) [[5]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfL284-R316) [[6]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfL307-R354) [[7]](diffhunk://#diff-77d1524306ea26581e846cb68ba0ec886a521ebc779b8202ec4c459d6951c5cfR364-R370) [[8]](diffhunk://#diff-56b2c6ba9f12120a93602d70fa4c57a39364770dd97d56249c1a0b25a7c8b2c5R1-R19)

**Documentation and metadata updates:**

* Updated plugin version to `6.1.0-beta.1` in `package.json`, `readme.txt`, and `speechkit.php`, and documented the new enhancement in the changelog. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R79-R89) [[4]](diffhunk://#diff-0d93b1e53792ccbe500672a18922a5e9e422b526c054f694679561651eff163cL18-R18) [[5]](diffhunk://#diff-0d93b1e53792ccbe500672a18922a5e9e422b526c054f694679561651eff163cL38-R38)

**Build and CI adjustments:**

* Modified the `cypress:run` script to improve compatibility with CI environments.