### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -256,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.5']
         phpunit-version: ['10']
         operating-system: ['ubuntu-22.04']
         include:
@@ -379,7 +379,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Publish results only for the latest PHP version
-          name: PHPUnit Test Results - PHP 8.4
+          name: PHPUnit Test Results - PHP 8.5
           path: .
 
       - name: Setup Pages
@@ -409,7 +409,7 @@ jobs:
       # don't fail the entire matrix on failure
       fail-fast: false
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.5']
         operating-system: ['ubuntu-22.04']
         include:
         - php-version: '8.0'

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
     "core": null,
     "port": 8888,
     "testsPort": 8889,
-    "phpVersion": "8.4",
+    "phpVersion": "8.5",
     "plugins": [
         "./",
         "WP-API/Basic-Auth",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Github Actions Workflow](https://github.com/beyondwords-io/wordpress-plugin/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/beyondwords-io/wordpress-plugin/actions/workflows/main.yml)
 [![PHPUnit Code Coverage](https://beyondwords-io.github.io/wordpress-plugin/coverage-badge.svg)](https://beyondwords-io.github.io/wordpress-plugin/dashboard.html)
 [![Supported WordPress Versions](https://img.shields.io/static/v1?label=&message=5.8+-+6.9&color=blue&logo=wordpress&logoColor=white)](https://wordpress.org/)
-[![Supported PHP Versions](https://img.shields.io/static/v1?label=&message=8.0+-+8.4&color=777bb4&logo=php&logoColor=white)](https://www.php.net/)
+[![Supported PHP Versions](https://img.shields.io/static/v1?label=&message=8.0+-+8.5&color=777bb4&logo=php&logoColor=white)](https://www.php.net/)
 
 ##  Description
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 6.3.0
+Stable tag: 6.4.0
 Requires PHP: 8.0
 Tested up to: 6.9
 License: GPLv2 or later
@@ -75,6 +75,14 @@ Monetize your BeyondWords audio and video by uploading your own advertising asse
 Keep on top of performance with BeyondWords Analytics or by forwarding events to your own analytics tools. You can track plays, engagement rate, unique listeners, listening time, retention, and other key audio and video metrics.
 
 == Changelog ==
+
+= 6.4.0 =
+
+**Compatibility**
+
+* PHP 8.5 support.
+    * Run unit and e2e tests against PHP 8.0 and PHP 8.5 in GitHub Actions.
+    * Bumped `phpVersion` in wp-env to 8.5.
 
 = 6.3.0 =
 

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           6.3.0
+ * Version:           6.4.0
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -35,7 +35,7 @@ require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '6.3.0');
+define('BEYONDWORDS__PLUGIN_VERSION', '6.4.0');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable


### PR DESCRIPTION
This pull request updates the plugin to support PHP 8.5, including changes across configuration, documentation, and CI workflows to reflect this new compatibility. The version is also bumped to 6.4.0, with all relevant files updated accordingly.

**PHP 8.5 compatibility and configuration:**

* Updated the GitHub Actions workflow in `.github/workflows/main.yml` to run tests and publish results for PHP 8.5 instead of 8.4. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L259-R259) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L382-R382) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L412-R412)
* Changed the `phpVersion` in `.wp-env.json` from 8.4 to 8.5.

**Documentation and metadata updates:**

* Updated the supported PHP version badge in `README.md` to reflect support for PHP 8.5.
* Updated the plugin version to 6.4.0 in `speechkit.php` and its constants. [[1]](diffhunk://#diff-0d93b1e53792ccbe500672a18922a5e9e422b526c054f694679561651eff163cL18-R18) [[2]](diffhunk://#diff-0d93b1e53792ccbe500672a18922a5e9e422b526c054f694679561651eff163cL38-R38)
* Updated the stable tag and changelog in `readme.txt` to 6.4.0, noting PHP 8.5 compatibility and related changes. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R79-R86)