### PR TITLE
fix: prevent player SDK error from clobbering saved content on Fetch

### DIFF
--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -128,14 +128,15 @@
 		}
 
 		// Language select — only update if the value exists as an option.
+		// Match option values directly so a malformed API value can't throw.
 		const languageSelect = document.getElementById(
 			'beyondwords_language_code'
 		);
 		if ( languageSelect && meta.beyondwords_language_code ) {
-			const option = languageSelect.querySelector(
-				'option[value="' + meta.beyondwords_language_code + '"]'
+			const hasOption = [ ...languageSelect.options ].some(
+				( option ) => option.value === meta.beyondwords_language_code
 			);
-			if ( option ) {
+			if ( hasOption ) {
 				languageSelect.value = meta.beyondwords_language_code;
 			}
 		}
@@ -152,7 +153,8 @@
 		if (
 			meta.beyondwords_content_id &&
 			meta.beyondwords_project_id &&
-			typeof BeyondWords !== 'undefined'
+			typeof BeyondWords !== 'undefined' &&
+			typeof BeyondWords.Player === 'function'
 		) {
 			let playerContainer = document.getElementById(
 				'beyondwords-metabox-player'
@@ -172,17 +174,26 @@
 
 			if ( playerContainer ) {
 				playerContainer.innerHTML = '';
-				new BeyondWords.Player( {
-					target: playerContainer,
-					projectId: Number( meta.beyondwords_project_id ),
-					contentId: meta.beyondwords_content_id,
-					previewToken: meta.beyondwords_preview_token || '',
-					adverts: [],
-					analyticsConsent: 'none',
-					introsOutros: [],
-					playerStyle: 'small',
-					widgetStyle: 'none',
-				} );
+
+				// The player SDK is an external CDN script, so its constructor
+				// can throw; contain it so a preview-only error can't fail the
+				// save. Mirrors play-audio/hooks.js.
+				try {
+					new BeyondWords.Player( {
+						target: playerContainer,
+						projectId: Number( meta.beyondwords_project_id ),
+						contentId: meta.beyondwords_content_id,
+						previewToken: meta.beyondwords_preview_token || '',
+						adverts: [],
+						analyticsConsent: 'none',
+						introsOutros: [],
+						playerStyle: 'small',
+						widgetStyle: 'none',
+					} );
+				} catch {
+					// Preview failed to initialise; the saved content is intact.
+					// @todo display error notice in the WordPress admin.
+				}
 			}
 		}
 	}
@@ -280,7 +291,14 @@
 
 				return savePostMeta( restBase, postId, meta ).then(
 					function () {
-						updateMetaboxUI( meta );
+						// Save succeeded. Refreshing the UI is best-effort —
+						// contain failures so they can't reject the chain and
+						// divert into the .catch, overwriting the saved meta.
+						try {
+							updateMetaboxUI( meta );
+						} catch {
+							// UI refresh failed; the saved content is intact.
+						}
 						showNotice(
 							wp.i18n.__(
 								'Content fetched and saved successfully.',


### PR DESCRIPTION
## What

In the **classic-editor Content ID metabox**, clicking **Fetch** with a valid Content ID could report a failure **and overwrite the just-saved content meta with an error** — even when the API fetch and the save both succeeded.

## Why

The Fetch success path returned the UI-refresh work into the outer promise chain:

```js
return savePostMeta( restBase, postId, meta ).then( () => {
    updateMetaboxUI( meta );      // re-inits the player
    showNotice( '…success…', 'success' );
} );
```

`updateMetaboxUI()` re-initialises the preview with `new BeyondWords.Player({…})`, guarded **only** by `typeof BeyondWords !== 'undefined'` and **not** wrapped in `try/catch`. The player SDK is loaded as an external CDN script and is **not a declared dependency** of this metabox script, so the constructor can throw (partial load, `BeyondWords` defined but `.Player` not a usable constructor, bad config, or a runtime error inside the SDK).

Because that success block was *awaited*, a throw rejected the chain and hit the outer `.catch`. It didn't match the `'Failed to save'` case, so it fell through to the generic branch — which persisted an **`errorMeta` (overwriting the good content meta just saved)** and showed a misleading **"Failed to fetch content. Please check the Content ID."** notice, despite fetch + save both succeeding.

A second, co-located instance of the same bug class also existed: the language-select lookup built a CSS selector from `meta.beyondwords_language_code` (which comes from the API response) via raw string concatenation, so a selector-breaking character would make `querySelector` throw a `SyntaxError` synchronously — same data-loss outcome.

## How (fixed in layers)

- **Guard + contain the player re-init** — added `typeof BeyondWords.Player === 'function'` to the guard and wrapped `new BeyondWords.Player({…})` in `try/catch`, mirroring the block-editor sibling [`src/editor/components/play-audio/hooks.js`](https://github.com/beyondwords-io/wordpress-plugin/blob/main/src/editor/components/play-audio/hooks.js).
- **Structural root-cause fix** — wrapped the whole `updateMetaboxUI(meta)` call in the save-success handler in its own `try/catch`, so **no** UI-refresh failure (current or future) can reject the save-success chain and divert into the error branch. `showNotice('success')` stays *outside* the try (it only uses null-guarded, non-throwing DOM APIs), so the success notice always fires once fetch + save succeed.
- **Hardened the language-select lookup** — replaced the `querySelector('option[value="…"]')` (built from the API-supplied value) with a direct comparison of option values, so the lookup can never throw on a malformed value and no selector is built from external input.

## Behaviour preserved

Genuine error paths are unchanged:
- A failed content **GET** still throws and routes to the generic error branch (saves `errorMeta` + shows the error notice).
- A failed **save** still rejects `savePostMeta` *before* the success callback runs, so the new `try/catch` can't swallow it → the `'Failed to save'` branch shows "Failed to save fetched content."

The language-select semantics are also preserved: the value is only applied when a matching `<option>` exists (otherwise the select is left unchanged).

## Testing

- `npm run lint:js` → clean (exit 0)
- `npm run test:unit` → 24/24 pass *(no Jest tests cover content-id; `classic-metabox.js` is an export-less IIFE)*
- Cypress suite **not** run (per project convention — run only affected specs, not the full 20-min suite).

## Reviewer notes

- The fix was validated with an adversarial multi-agent review; layers 2 (structural `try/catch`) and 3 (language-select hardening) were added after that review found the player-only patch closed the documented *trigger* but not the bug *class*.
- **Follow-up (not in this PR):** there's no regression test that forces a throwing `Player` constructor on the success path, so a future removal of the `try/catch` wouldn't be caught by CI. A Cypress case in `tests/cypress/e2e/classic-editor/content-id.cy.js` (stub `window.BeyondWords.Player` to throw, assert meta is preserved + `.beyondwords-success` shows) would lock this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)