### PR TITLE
fix: surface WP_Error from get_content() instead of fatal TypeError

### DIFF
--- a/src/api/class-client.php
+++ b/src/api/class-client.php
@@ -110,9 +110,13 @@ class Client {
 	 * @param string          $content_id BeyondWords content ID.
 	 * @param int|string|null $project_id Optional project ID override.
 	 *
-	 * @return array<mixed>|false Response array, or false when project/content ID is missing.
+	 * @return array<mixed>|\WP_Error|false Raw HTTP response array, a `\WP_Error`
+	 *                                      on transport-level failure (unreachable
+	 *                                      host, timeout) which the caller surfaces
+	 *                                      as a connection error, or false when the
+	 *                                      project/content ID is missing.
 	 */
-	public static function get_content( int|string $content_id, int|string|null $project_id = null ): array|false {
+	public static function get_content( int|string $content_id, int|string|null $project_id = null ): array|\WP_Error|false {
 		if ( ! $project_id ) {
 			$project_id = get_option( 'beyondwords_project_id' );
 		}

--- a/tests/phpunit/api/test-client.php
+++ b/tests/phpunit/api/test-client.php
@@ -828,6 +828,38 @@ class ClientTest extends TestCase
 
     /**
      * @test
+     *
+     * A transport-level failure (DNS error, timeout, refused/blocked connection)
+     * makes wp_remote_request() — and therefore call_api() — return a WP_Error.
+     * get_content() must surface that WP_Error rather than throwing a TypeError,
+     * so InspectPanel::rest_api_response() can fall through to its is_wp_error()
+     * branch and degrade to a "Could not connect to BeyondWords API" response.
+     */
+    public function get_content_returns_wp_error_on_connection_failure()
+    {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        // Priority 1 short-circuits before the mock plugin (priority 10), which
+        // respects an earlier WP_Error and passes it straight through.
+        $filter = function () {
+            return new \WP_Error('http_request_failed', 'cURL error 6: Could not resolve host');
+        };
+        add_filter('pre_http_request', $filter, 1, 3);
+
+        $result = Client::get_content(BEYONDWORDS_TESTS_CONTENT_ID);
+
+        remove_filter('pre_http_request', $filter, 1);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('http_request_failed', $result->get_error_code());
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
      */
     public function get_voice_returns_false_without_language_code()
     {


### PR DESCRIPTION
## What changed

`Client::get_content()` ([src/api/class-client.php](src/api/class-client.php)) was declared with return type `: array|false`, but its final statement returns the raw result of `call_api()`, which is declared `: array|\WP_Error`. WordPress returns a `\WP_Error` from `wp_remote_request()` on any transport-level failure (DNS failure, timeout, connection refused, blocked outbound HTTP). PHP enforces declared return types **regardless of `strict_types`**, so returning a `\WP_Error` from a function typed `array|false` threw an uncaught `TypeError`.

This change widens `get_content()`'s return type to `array|\WP_Error|false` and updates the matching `@return` docblock, and adds a regression test.

## Why

The only caller — `InspectPanel::rest_api_response()` ([src/editor/components/inspect-panel/class-inspect-panel.php](src/editor/components/inspect-panel/class-inspect-panel.php), reached via `GET /beyondwords/v1/projects/<id>/content/<id>`) — already branches on `if ( is_wp_error( $response ) )` to return a graceful *"Could not connect to BeyondWords API"* response. But `get_content()` **threw before that branch could run**, so:

- The intended graceful connection-error handling was dead code.
- Every transient network failure surfaced as an opaque **HTTP 500** on the editor Inspect/Fetch feature — exactly when the code was meant to degrade gracefully.

## Why this approach (widen the type) over normalising to `false`

`rest_api_response()` is designed to distinguish three outcomes:

| `get_content()` returns | Caller behaviour |
|---|---|
| `\WP_Error` | 500 *"Could not connect to BeyondWords API"* (connection error) |
| response array | parse status / body / JSON |
| `false` | missing project/content ID |

Normalising the `\WP_Error` to `false` would conflate an **unreachable host** with a **missing ID** (it would fall through to `wp_remote_retrieve_response_code( false )` → `''` → the generic *"returned error code 0"*). Widening the type keeps the `is_wp_error()` branch live and preserves the distinction.

`get_content()` is the only method in the file with this latent bug — every other method either funnels the result through `json_decode( wp_remote_retrieve_body( … ) )` (so `\WP_Error` → `''` → `null`, which is in their unions) or explicitly checks `is_wp_error()`.

## Testing

- **`npm run phpcs`** (WordPress-VIP-Go ruleset): clean. **No `phpcs:ignore` added.**
- **PHPUnit `ClientTest`** (the affected api/client suite): 36 tests / 121 assertions, all passing — including the new `get_content_returns_wp_error_on_connection_failure`.
- The new test is verified **load-bearing**: against the pre-fix code it fails with the exact `TypeError: ... Return value must be of type array|false, WP_Error returned` at `class-client.php:126`; with the fix it passes.
- Full Cypress suite intentionally not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)