### PR TITLE
fix: guard null languages API result in classic-editor voice select

### DIFF
--- a/src/editor/components/select-voice/class-select-voice.php
+++ b/src/editor/components/select-voice/class-select-voice.php
@@ -78,7 +78,7 @@ class SelectVoice {
 	public static function element( $post ) {
 		$language_code = self::get_language_code( $post->ID );
 		$voice_id      = self::get_voice_id( $post->ID );
-		$languages     = \BeyondWords\Api\Client::get_languages();
+		$languages     = self::get_languages();
 		$voices        = self::get_voices_for_language( $language_code );
 
 		wp_nonce_field( 'beyondwords_select_voice', 'beyondwords_select_voice_nonce' );
@@ -114,6 +114,25 @@ class SelectVoice {
 	private static function get_voice_id( int $post_id ) {
 		$post_voice_id = get_post_meta( $post_id, 'beyondwords_body_voice_id', true );
 		return $post_voice_id ?: '';
+	}
+
+	/**
+	 * Get all available languages.
+	 *
+	 * Coerces the API result to an array so the language dropdown degrades to
+	 * empty when the languages API call fails (network error, WP_Error, non-2xx
+	 * status, empty body or invalid JSON). Client::get_languages() is declared
+	 * array|null|false, so an unguarded null/false would throw a TypeError
+	 * against render_language_select()'s array-typed parameter under
+	 * strict_types. Mirrors get_voices_for_language().
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array The languages array, or an empty array on API failure.
+	 */
+	private static function get_languages(): array {
+		$languages = \BeyondWords\Api\Client::get_languages();
+		return is_array( $languages ) ? $languages : [];
 	}
 
 	/**

--- a/tests/phpunit/editor/components/select-voice/test-select-voice.php
+++ b/tests/phpunit/editor/components/select-voice/test-select-voice.php
@@ -156,6 +156,53 @@ class SelectVoiceTest extends TestCase
     }
 
     /**
+     * Regression: a failed languages API call returns null (network error,
+     * WP_Error, non-2xx, empty body or invalid JSON). Passed unguarded into
+     * render_language_select()'s array-typed parameter under strict_types this
+     * threw an uncatchable TypeError, crashing the classic-editor metabox. The
+     * language dropdown must now render empty instead of fataling.
+     *
+     * @test
+     */
+    public function element_degrades_gracefully_when_languages_api_fails()
+    {
+        // Simulate the languages API being unreachable. Priority 1 short-circuits
+        // before the mock API filter, which respects an earlier preempt.
+        $filter = function ($preempt, $args, $url) {
+            if (str_contains($url, '/organization/languages')) {
+                return new \WP_Error('http_request_failed', 'Connection refused');
+            }
+            return $preempt;
+        };
+        add_filter('pre_http_request', $filter, 1, 3);
+
+        // No language code, so no voices API call is made — the languages call
+        // is the only one exercised here.
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'PostSelectVoiceTest::element_languages_api_fails',
+        ]);
+
+        $html = $this->capture_output(function () use ($post) {
+            SelectVoice::element($post);
+        });
+
+        remove_filter('pre_http_request', $filter, 1);
+
+        $crawler = new Crawler($html);
+
+        // The language dropdown still renders, with no options.
+        $languageSelect = $crawler->filter('#beyondwords_language_code');
+        $this->assertCount(1, $languageSelect);
+        $this->assertCount(0, $languageSelect->filter('option'));
+
+        // Render continued past the language select to the voice select, proving
+        // no TypeError was thrown.
+        $this->assertCount(1, $crawler->filter('#beyondwords_voice'));
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
      * @test
      */
     public function voice_model_variants()


### PR DESCRIPTION
## What

`SelectVoice::element()` ([src/editor/components/select-voice/class-select-voice.php](src/editor/components/select-voice/class-select-voice.php)) passed the result of `\BeyondWords\Api\Client::get_languages()` — declared `array|null|false` — straight into the private `render_language_select( array $languages, … )`, whose first parameter is a **non-nullable `array`**. The file declares `strict_types=1`.

`Client::get_languages()` delegates to `cached_get()`, which returns `json_decode( wp_remote_retrieve_body( $response ), true )`. That is `null` on every ordinary API-failure path — network error, `WP_Error`, non-2xx status, empty body, or invalid JSON — and failures are **not** cached, so the next render retries and stays `null`.

So opening the **classic-editor** Add New / Edit Post screen (which invokes `element()` via [src/editor/classic/class-metabox.php](src/editor/classic/class-metabox.php)) while the API is unreachable and the languages transient is cold passed `null` into the array-typed parameter and threw an **uncatchable `TypeError`**, crashing the metabox render with a fatal 500 for the author — no graceful degradation.

## Fix

Add a private `get_languages()` getter that coerces the result to an array — `return is_array( $languages ) ? $languages : [];` — mirroring the existing `get_voices_for_language()`. `element()` now calls `self::get_languages()`, so `render_language_select()` always receives an array and the language dropdown degrades to **empty** instead of fataling.

No `phpcs:ignore`; the render's output was already escaped (`esc_attr`/`esc_html`/`selected`) and the getter takes no input to sanitize.

## Test

New regression test `element_degrades_gracefully_when_languages_api_fails` mocks a failed `/organization/languages` request (`pre_http_request` → `WP_Error`) and asserts the language `<select>` renders with zero `<option>`s and that the render continues to the voice select (proving no `TypeError`).

**Red-green proof:** with the fix reverted, this test fails with the exact reported error — `TypeError: render_language_select(): Argument #1 ($languages) must be of type array, null given` — and passes once restored.

## Verification

- `npm run phpcs` (WordPress-VIP-Go ruleset): clean.
- PHPUnit `SelectVoiceTest`: 10/10 pass (incl. the new test); `MetaboxTest` (the caller): 11/11 pass.
- Full Cypress suite intentionally not run.
- Swept all 18 other `Client::get_*` call sites in `src/` for the same nullable-result-into-non-nullable-array pattern — **none** are vulnerable: they either guard with `is_array()` (e.g. `settings-fields`, the structurally identical case), pass into `mixed`-typed sinks (`Sync::process_response`, `WP_REST_Response`), or return/discard the value. `element()` was the lone outlier.

## Reviewer notes

- Out of scope (unchanged): if the endpoint returns an associative error body like `{"message":…}`, `is_array()` passes it through and `render_language_select()`'s `foreach` produces zero options via the existing `empty()` checks — no fatal, and behaviour is identical before/after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)