### PR TITLE
fix: prevent TypeError in deferred audio-generation cron when post is deleted

### DIFF
--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -91,7 +91,17 @@ class Sync {
 			return false;
 		}
 
-		if ( ! self::should_process_post_status( get_post_status( $post_id ) ) ) {
+		// get_post_status() returns false when the post no longer exists — e.g. it
+		// was trashed or permanently deleted between a deferred job being queued
+		// (see on_add_or_update_post()) and the cron firing. An empty status is
+		// never processable, so bail before the strict-typed
+		// should_process_post_status() call, which would TypeError on false.
+		$status = get_post_status( $post_id );
+		if ( ! $status ) {
+			return false;
+		}
+
+		if ( ! self::should_process_post_status( $status ) ) {
 			return false;
 		}
 
@@ -319,11 +329,27 @@ class Sync {
 	}
 
 	/**
+	 * Clear any pending deferred audio-generation cron event for a post.
+	 *
+	 * Called when a post is trashed or deleted so a job queued by
+	 * `on_add_or_update_post()` doesn't fire for a post that no longer exists.
+	 * Runs before the `has_content()` checks in the lifecycle handlers because a
+	 * queued post may not have written its content meta yet.
+	 *
+	 * @since 7.0.0
+	 */
+	private static function unschedule_audio_generation( int $post_id ): void {
+		wp_clear_scheduled_hook( self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] );
+	}
+
+	/**
 	 * Trash hook — DELETE the audio so it disappears from the dashboard, then
 	 * remove our local metadata.
 	 */
 	public static function on_trash_post( $post_id ): void {
 		$post_id = (int) $post_id;
+
+		self::unschedule_audio_generation( $post_id );
 
 		if ( ! \BeyondWords\Post\Meta::has_content( $post_id ) ) {
 			return;
@@ -339,6 +365,8 @@ class Sync {
 	 */
 	public static function on_delete_post( $post_id ): void {
 		$post_id = (int) $post_id;
+
+		self::unschedule_audio_generation( $post_id );
 
 		if ( ! \BeyondWords\Post\Meta::has_content( $post_id ) ) {
 			return;

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -329,12 +329,39 @@ class Sync {
 	}
 
 	/**
+	 * Schedule a deferred audio-generation cron event for a post.
+	 *
+	 * Only reached on the async path, which is VIP-only by default (see
+	 * `is_async_generation_enabled()`). Prefers VIP's
+	 * `wpcom_vip_schedule_single_event()` wrapper when it exists (classic
+	 * WordPress.com VIP); on VIP Go — and anywhere the async filter is forced
+	 * on — the core function is the correct call and is routed through Cron
+	 * Control. No-ops when an event for this post is already queued, so repeated
+	 * saves don't stack duplicate jobs.
+	 *
+	 * @since 7.0.0
+	 */
+	private static function schedule_audio_generation( int $post_id ): void {
+		if ( wp_next_scheduled( self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] ) ) {
+			return;
+		}
+
+		if ( function_exists( 'wpcom_vip_schedule_single_event' ) ) {
+			wpcom_vip_schedule_single_event( time(), self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] );
+			return;
+		}
+
+		wp_schedule_single_event( time(), self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] );
+	}
+
+	/**
 	 * Clear any pending deferred audio-generation cron event for a post.
 	 *
 	 * Called when a post is trashed or deleted so a job queued by
 	 * `on_add_or_update_post()` doesn't fire for a post that no longer exists.
 	 * Runs before the `has_content()` checks in the lifecycle handlers because a
-	 * queued post may not have written its content meta yet.
+	 * queued post may not have written its content meta yet. `wp_clear_scheduled_hook()`
+	 * is routed through Cron Control on VIP, so it unschedules reliably there too.
 	 *
 	 * @since 7.0.0
 	 */
@@ -397,12 +424,12 @@ class Sync {
 		}
 
 		// On VIP, defer the blocking create/update API call to a background cron
-		// job so the save request returns immediately. The eligibility check is
-		// repeated inside generate_audio_for_post() when the job runs.
+		// job so the save request returns immediately. Off-VIP we fall through to
+		// the synchronous call below, because WP-Cron there is traffic-triggered
+		// and unreliable. The eligibility check is repeated inside
+		// generate_audio_for_post() when the deferred job runs.
 		if ( self::is_async_generation_enabled() && self::should_generate_audio_for_post( $post_id ) ) {
-			if ( ! wp_next_scheduled( self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] ) ) {
-				wp_schedule_single_event( time(), self::GENERATE_AUDIO_CRON_HOOK, [ $post_id ] );
-			}
+			self::schedule_audio_generation( $post_id );
 
 			return true;
 		}

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -1303,4 +1303,97 @@ class SyncTest extends TestCase
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
     }
+
+    /**
+     * @test
+     * @group generateAudio
+     */
+    public function should_generate_audio_for_post_returns_false_for_missing_post()
+    {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+            'meta_input'  => ['beyondwords_generate_audio' => '1'],
+        ]);
+
+        // Remove the post so get_post_status() returns false — mimics a post
+        // trashed/deleted between a deferred job being queued and the cron firing.
+        wp_delete_post($postId, true);
+
+        // Regression: this previously threw an uncaught TypeError under
+        // strict_types because get_post_status() returns false for a missing post
+        // and should_process_post_status() requires a non-nullable string.
+        $this->assertFalse(Sync::should_generate_audio_for_post($postId));
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
+     * @group generateAudio
+     */
+    public function generate_audio_for_post_returns_false_for_missing_post()
+    {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+            'meta_input'  => ['beyondwords_generate_audio' => '1'],
+        ]);
+
+        wp_delete_post($postId, true);
+
+        // The deferred cron callback must no-op rather than fatal when its post
+        // has already been removed.
+        $this->assertFalse(Sync::generate_audio_for_post($postId));
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
+     * @test
+     * @group trash
+     */
+    public function on_trash_post_unschedules_pending_generate_audio_event()
+    {
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+        ]);
+
+        wp_schedule_single_event(time(), Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]);
+        $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+
+        Sync::on_trash_post($postId);
+
+        // The pending deferred job must be cleared so it can't fire for a trashed post.
+        $this->assertFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     * @group delete
+     */
+    public function on_delete_post_unschedules_pending_generate_audio_event()
+    {
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+        ]);
+
+        wp_schedule_single_event(time(), Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]);
+        $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+
+        Sync::on_delete_post($postId);
+
+        // The pending deferred job must be cleared so it can't fire for a deleted post.
+        $this->assertFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+
+        wp_delete_post($postId, true);
+    }
 }


### PR DESCRIPTION
This PR has two commits: a fatal-error fix, and a follow-up that hardens
the (already VIP-only) deferred-generation cron path.

## 1. Fix: `TypeError` in the deferred audio-generation cron

`Sync::should_generate_audio_for_post()` passed `get_post_status( $post_id )`
straight into `should_process_post_status( string $status )`. `get_post_status()`
returns `string|false` — `false` when the post no longer exists — and the file
declares `strict_types=1`, so the `false` is **not** coerced and the call throws
an **uncaught `TypeError`**.

It fires in the **background audio-generation cron job** on the async path:

- `on_add_or_update_post()` schedules `GENERATE_AUDIO_CRON_HOOK` with the post ID
  when async generation is enabled.
- The cron callback `generate_audio_for_post()` calls
  `should_generate_audio_for_post()` **before** its `get_post()` null-guard.
- `on_trash_post()` / `on_delete_post()` did **not** unschedule the event, so if
  the post is trashed or permanently deleted between scheduling and the cron
  firing, `get_post_status()` returns `false` and the job fatals.
  (`wp_is_post_autosave()` / `wp_is_post_revision()` both return `false` for a
  missing post, so they don't short-circuit it.) The existing `get_post()` check
  was effectively dead code — the `TypeError` fired first.

**Changes:**

- **Guard the missing-post case** in `should_generate_audio_for_post()`: capture
  `$status = get_post_status( $post_id )` and `return false` on an empty/`false`
  status before the strict-typed `should_process_post_status()` call.
- **Unschedule on removal**: new private `unschedule_audio_generation()` helper,
  called at the top of `on_trash_post()` and `on_delete_post()` (before the
  `has_content()` early-return, since a queued post may not have written its
  content meta yet) so a pending job can't fire for a removed post.
- **Regression tests** for the four new paths.

## 2. Refactor: harden the VIP-only cron path

WordPress cron is unreliable off-VIP, so it should only be relied on under VIP.
The code already enforced this — `on_add_or_update_post()` schedules a cron event
only when `is_async_generation_enabled()` is true (VIP symbols present, or the
`beyondwords_async_generate_audio` filter forced on); on a plain non-VIP install
nothing is ever scheduled and the API call runs synchronously inline.

This commit tightens that path:

- Extracts the inline scheduling into a private `schedule_audio_generation()`
  helper, symmetric with `unschedule_audio_generation()`.
- The helper **prefers VIP's `wpcom_vip_schedule_single_event()` wrapper when it
  exists** (classic WordPress.com VIP), falling back to core
  `wp_schedule_single_event()` on VIP Go (where core is routed through Cron
  Control) and when the async filter is forced on.
- **No behavior change off-VIP** — nothing is ever scheduled there.

## Testing

- `npm run phpcs` (WordPress-VIP-Go) — **clean**, no `phpcs:ignore` added.
- PHPUnit `SyncTest` — **OK (73 tests, 150 assertions)**, including the 4 new
  regression tests and the existing async/synchronous/unschedule cases; no
  regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
