### PR TITLE
fix: resolve post ID in Content::get_content_without_excluded_blocks

### DIFF
--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -175,11 +175,16 @@ class Content {
 	 * @return string The post body without excluded blocks.
 	 */
 	public static function get_content_without_excluded_blocks( int|\WP_Post $post ): string {
+		$post = get_post( $post );
+
+		if ( ! ( $post instanceof \WP_Post ) ) {
+			throw new \Exception( esc_html__( 'Post Not Found', 'speechkit' ) );
+		}
+
 		if ( ! has_blocks( $post ) ) {
 			return trim( $post->post_content );
 		}
 
-		$blocks = parse_blocks( $post->post_content );
 		$output = '';
 
 		$blocks = self::get_audio_enabled_blocks( $post );

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -137,6 +137,42 @@ class ContentTest extends TestCase
 
     /**
      * @test
+     *
+     * Passing a post ID (int) must behave identically to passing the WP_Post
+     * object — the method resolves the argument internally like its siblings.
+     *
+     * Regression test: previously an int argument fell straight through to
+     * `$post->post_content`, emitting a PHP warning ("Attempt to read property
+     * on int") and returning an empty string instead of the post content.
+     */
+    public function get_content_without_excluded_blocks_accepts_post_id()
+    {
+        $post = self::factory()->post->create_and_get([
+            'post_title'   => 'ContentTest:getContentWithoutExcludedBlocksAcceptsPostId',
+            'post_content' => '<p>Plain content.</p>',
+        ]);
+
+        $byId     = Content::get_content_without_excluded_blocks($post->ID);
+        $byObject = Content::get_content_without_excluded_blocks($post);
+
+        $this->assertSame('<p>Plain content.</p>', $byId);
+        $this->assertSame($byObject, $byId);
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     */
+    public function get_content_without_excluded_blocks_with_invalid_post_id()
+    {
+        $this->expectException(\Exception::class);
+
+        Content::get_content_without_excluded_blocks(-1);
+    }
+
+    /**
+     * @test
      */
     public function get_post_body_with_invalid_post_id()
     {


### PR DESCRIPTION
## What

`Content::get_content_without_excluded_blocks()` declares `int|\WP_Post $post` but — uniquely among the input-normalising methods in this class — never resolved the argument. `has_blocks()` accepts an int and resolves it internally (returning `false`), so an int post ID fell straight through to `trim( $post->post_content )` on a raw int.

On PHP 8 that emits `Attempt to read property "post_content" on int`, yields `null`, and `trim( null )` returns `''` — so the method **silently returned an empty string** instead of the post body whenever a caller passed a post ID, which the public signature explicitly permits.

The only in-repo caller (`get_post_body()`) already passes a resolved `WP_Post`, so this was a *latent* contract violation — reachable by any external/future caller using the documented `int` form.

## Fix

- Resolve the post at the top of the method and guard, mirroring every sibling in the class (`get_content_body`, `get_post_body`, `get_post_summary`, `get_post_summary_wrapper_format`):

  ```php
  $post = get_post( $post );

  if ( ! ( $post instanceof \WP_Post ) ) {
      throw new \Exception( esc_html__( 'Post Not Found', 'speechkit' ) );
  }
  ```

  Chose `throw` (over returning `''`) to match the four sibling methods and their existing `*_with_invalid_post_id` tests — and because returning `''` would perpetuate the same silent-empty-output failure mode.
- Removed a dead `parse_blocks( $post->post_content )` call whose result was immediately overwritten by `get_audio_enabled_blocks()` before use — it was also the second of the two raw-int property accesses.

## Tests

Added two `ContentTest` cases in `tests/phpunit/post/test-content.php`:

- **`get_content_without_excluded_blocks_accepts_post_id`** — passes a post **ID** and asserts the content is returned (and matches the `WP_Post`-object path). Tight regression: against the pre-fix source it fails with `Attempt to read property "post_content" on int` at `class-content.php:179`; passes after.
- **`get_content_without_excluded_blocks_with_invalid_post_id`** — `expectException` on `-1`, matching the four sibling contract tests.

## Verification

- `phpcs` (WordPress-VIP-Go ruleset) clean — confirmed both host-side and via the grumphp pre-commit hook (no `phpcs:ignore` added).
- All **29 `ContentTest` tests pass** (83 assertions), run filtered in a wp-env tests container.
- Regression test proven fails-before / passes-after.

## Reviewer notes

- No behaviour change for existing callers — `get_post_body()` already passes a `WP_Post`. This only fixes (and locks down) the documented `int` code path.
- Follows AGENTS.md conventions; the test file is outside the phpcs scan scope (`src` + entry files only), consistent with the existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
