### PR TITLE
fix(test): correct language-dropdown option count in select-voice graceful-degradation test

### DIFF
--- a/tests/phpunit/editor/components/select-voice/test-select-voice.php
+++ b/tests/phpunit/editor/components/select-voice/test-select-voice.php
@@ -190,10 +190,14 @@ class SelectVoiceTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // The language dropdown still renders, with no options.
+        // The language dropdown still renders, with only the empty placeholder
+        // option ("Select a language…") and none of the (unavailable) languages —
+        // render_language_select() always emits that placeholder before the loop.
         $languageSelect = $crawler->filter('#beyondwords_language_code');
         $this->assertCount(1, $languageSelect);
-        $this->assertCount(0, $languageSelect->filter('option'));
+        $options = $languageSelect->filter('option');
+        $this->assertCount(1, $options);
+        $this->assertSame('', $options->first()->attr('value'));
 
         // Render continued past the language select to the voice select, proving
         // no TypeError was thrown.


### PR DESCRIPTION
## Summary

`main`'s PHPUnit suite has been **red on both PHP 8.0 and 8.5** since the select-voice "Customize" feature landed (PR #543). One test fails deterministically:

- **`element_degrades_gracefully_when_languages_api_fails`** (`tests/phpunit/editor/components/select-voice/test-select-voice.php`)
- `Failed asserting that actual size 1 matches expected size 0.`

## Root cause

The test stubs the languages API to fail and asserts the `#beyondwords_language_code` `<select>` has **0** `<option>` elements. But [`SelectVoice::render_language_select()`](../blob/main/src/editor/components/select-voice/class-select-voice.php) **unconditionally** emits an empty `"Select a language…"` placeholder option *before* looping the languages:

```php
printf(
    '<option value="" %s>%s</option>',
    selected( '', strval( $selected_lang_code ), false ),
    esc_html__( 'Select a language…', 'speechkit' )
);
foreach ( $languages as $language ) { /* ... */ }
```

So when the API fails and `get_languages()` returns `[]`, the dropdown renders **exactly one** option — the placeholder — never zero. The assertion therefore fails every time (actual 1, expected 0). The CI's observed "actual size 1" is precisely that placeholder.

This is a **test-expectation bug, not a product bug**: the component degrades correctly (placeholder only, no language options, no `TypeError`).

## Fix

Assert the dropdown renders exactly the single empty-value placeholder option, which still proves graceful degradation (no languages listed, render not aborted):

```php
$options = $languageSelect->filter('option');
$this->assertCount(1, $options);
$this->assertSame('', $options->first()->attr('value'));
```

## Notes

- Scoped to the one failing assertion; no product code changes.
- This unblocks `main`'s CI (and every open PR that merges against it).