### PR TITLE
feat(editor): state-reflecting generation labels; rename Standard model to Legacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,7 @@ Plugin version lives in two places — keep them in sync:
 - `BEYONDWORDS__PLUGIN_VERSION` constant in the same file
 - `version` in [package.json](package.json) (informational; npm publish is not used)
 
-Bump on any release. Pre-release versions use `7.0.0-dev-2.0` style (matches existing convention).
+Bump on any release. Pre-release versions use `7.0.0-dev-3.0` style (matches existing convention).
 
 ## Known issues
 

--- a/languages/speechkit.pot
+++ b/languages/speechkit.pot
@@ -1,633 +1,1091 @@
-# Copyright (C) 2023 BeyondWords
+# Copyright (C) 2026 BeyondWords
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: BeyondWords - Text-to-Speech 4.2.4\n"
+"Project-Id-Version: BeyondWords - Text-to-Speech 7.0.0-dev-3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/speechkit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-11-15T15:45:53+00:00\n"
+"POT-Creation-Date: 2026-07-06T05:27:34+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.8.1\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: speechkit\n"
 
 #. Plugin Name of the plugin
-#: src/Component/SiteHealth/SiteHealth.php:81
+#: speechkit.php
+#: src/site-health/class-site-health.php:91
 msgid "BeyondWords - Text-to-Speech"
 msgstr ""
 
 #. Plugin URI of the plugin
 #. Author URI of the plugin
+#: speechkit.php
 msgid "https://beyondwords.io"
 msgstr ""
 
 #. Description of the plugin
+#: speechkit.php
 msgid "The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player."
 msgstr ""
 
 #. Author of the plugin
-#: src/Compatibility/Elementor/ControlsSections/Beyondwords.php:53
-#: src/Compatibility/Elementor/Elementor.php:194
-#: src/Component/Post/Metabox/Metabox.php:82
-#: src/Component/Post/Panel/Inspect/Inspect.php:108
-#: src/Component/Posts/BulkEdit/BulkEdit.php:77
-#: src/Component/Posts/Column/Column.php:62
-#: src/Component/Settings/Settings.php:59
-#: src/Component/Settings/Settings.php:60
-#: build/index.js:1
-#: src/Component/Plugin/Panel/DocumentSetting/index.js:25
-#: src/Component/Plugin/Panel/Prepublish/index.js:22
-#: src/Component/Plugin/Sidebar/index.js:20
-#: src/Component/Plugin/Sidebar/index.js:24
-#: src/Component/Post/BlockAttributes/addControls.js:80
-#: src/Component/Post/Panel/Prepublish/index.js:10
+#: speechkit.php
+#: plugins/beyondwords-debug-tool/src/class-page.php:44
+#: plugins/beyondwords-debug-tool/src/class-page.php:45
+#: plugins/beyondwords-debug-tool/src/class-page.php:60
+#: plugins/beyondwords-import-tool/src/class-page.php:52
+#: plugins/beyondwords-import-tool/src/class-page.php:53
+#: plugins/beyondwords-import-tool/src/class-page.php:68
+#: src/editor/classic/class-metabox.php:54
+#: src/editor/components/inspect-panel/class-inspect-panel.php:84
+#: src/posts-list/class-bulk-edit.php:72
+#: src/posts-list/class-column.php:71
+#: src/settings/class-settings.php:50
+#: src/editor/block/sidebar/index.js:26
+#: src/editor/components/add-player/index.js:38
+#: src/editor/components/icon/index.js:51
 msgid "BeyondWords"
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Beyondwords.php:82
-#: src/Component/Post/GenerateAudio/GenerateAudio.php:91
-#: src/Component/Posts/BulkEdit/BulkEdit.php:80
-#: src/Component/Posts/BulkEdit/BulkEdit.php:178
-#: build/index.js:1
-#: src/Component/Post/GenerateAudio/index.js:35
-#: src/Component/Post/Panel/Prepublish/index.js:13
-msgid "Generate audio"
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:98
+#, php-format
+msgid "Could not create directory: %s. Please create it manually with write permissions."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Beyondwords.php:110
-#: src/Component/Post/DisplayPlayer/DisplayPlayer.php:96
-#: build/index.js:1
-#: src/Component/Post/DisplayPlayer/index.js:40
-msgid "Display player"
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:116
+#, php-format
+msgid "Could not create log file: %s. Please create it manually with write permissions."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Help.php:45
-#: build/index.js:1
-#: src/Component/Post/Panel/Help/index.js:16
-msgid "Help"
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:130
+#, php-format
+msgid "Log file is not writable: %s. Please ensure PHP has write permissions."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Help.php:53
-#: build/index.js:1
-#: src/Component/Post/Panel/Help/index.js:28
-msgid "Setup guide"
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:178
+msgid "You do not have permission to download this file."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Help.php:56
-#: build/index.js:1
-#: src/Component/Post/Panel/Help/index.js:21
-msgid "For setup instructions, troubleshooting, and FAQs, see our BeyondWords for WordPress guide."
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:184
+msgid "Security check failed."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Help.php:64
-#: build/index.js:1
-#: src/Component/Post/Panel/Help/index.js:38
-msgid "Email BeyondWords"
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:191
+msgid "Log file does not exist."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Help.php:68
-#: build/index.js:1
-#: src/Component/Post/Panel/Help/index.js:33
-msgid "Need help? Email our support team."
+#: plugins/beyondwords-debug-tool/src/class-log-file.php:210
+msgid "Failed to open log file for reading."
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Inspect.php:58
-#: src/Component/Post/Panel/Inspect/Inspect.php:108
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:204
-msgid "Inspect"
+#: plugins/beyondwords-debug-tool/src/class-page.php:78
+msgid "Debug Tool"
 msgstr ""
 
-#: src/Compatibility/Elementor/ControlsSections/Inspect.php:187
-#: src/Component/Post/Panel/Inspect/Inspect.php:137
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:122
-msgid "Copy"
+#: plugins/beyondwords-debug-tool/src/class-page.php:79
+msgid "Log BeyondWords REST API requests and responses for debugging purposes."
 msgstr ""
 
-#: src/Compatibility/Elementor/Elementor.php:119
-msgid "Post not found."
+#: plugins/beyondwords-debug-tool/src/class-page.php:83
+msgid "Important:"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:84
+msgid "The log file is stored in a publicly accessible location. We mask API keys, but the log may contain other sensitive information. You are responsible for deleting the log file when debugging is complete."
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:93
+msgid "Debug REST API Requests"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:97
+msgid "Enable logging of BeyondWords API requests and responses"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:100
+msgid "When enabled, all requests to and responses from the BeyondWords API will be logged."
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:109
+msgid "API URL Being Monitored"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:115
+msgid "Log File Location"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:120
+msgid "Writable"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:129
+msgid "Download"
+msgstr ""
+
+#: plugins/beyondwords-debug-tool/src/class-page.php:138
+msgid "Save Debug Settings"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-ajax.php:40
+msgid "Permission denied."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-ajax.php:46
+msgid "Import data not found. Please start over."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:62
+#, php-format
+msgid "Processing %1$d of %2$d records..."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:64
+#, php-format
+msgid "Successfully updated %1$d records (%2$d meta values)."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:66
+#, php-format
+msgid "%d record(s) could not be imported because a matching WordPress post could not be found:"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:67
+msgid "An error occurred during import."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:68
+msgid "A network error occurred. Please try again."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-assets.php:69
+msgid "Failed records copied to clipboard."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:87
+msgid "Error uploading file. Please try again."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:96
+msgid "File is too large. Maximum size is 10 MB."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:102
+msgid "Invalid file type. Please upload a JSON file."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:129
+msgid "Invalid file content. Please upload a valid JSON file."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:149
+msgid "Could not verify the uploaded file. Please try again."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:156
+msgid "Could not read the uploaded file. Please try again."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:165
+#, php-format
+msgid "Invalid JSON: %s"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:172
+msgid "JSON file must contain a non-empty array."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:180
+#, php-format
+msgid "Too many records. Maximum is %s per import. Please split your file into smaller batches and import them separately."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:222
+msgid "Validation errors:"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:229
+msgid "No valid records found to import."
+msgstr ""
+
+#. translators: 1: row number, 2: field name
+#: plugins/beyondwords-import-tool/src/class-file-handler.php:254
+#, php-format
+msgid "Row %1$d: Missing required field \"%2$s\"."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:86
+msgid "Import Tool"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:128
+msgid "Your import session has expired. Please upload the file again."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:132
+msgid "Start Over"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:145
+msgid "Import BeyondWords data from a JSON file."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:147
+msgid "This tool allows you to bulk import BeyondWords audio assignments from a JSON file supplied by BeyondWords."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:148
+msgid "It will update the relevant WordPress posts with the necessary meta fields to link them to your BeyondWords projects and content."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:149
+msgid "The JSON file will contain an array of objects with the following fields: <code>source_id</code>, <code>source_url</code>, <code>project_id</code>, <code>content_id</code>."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:150
+msgid "Audio that was created with WordPress plugin versions later than <code>v4.0</code> (released July 2023) should have a numeric WordPress Post ID for the <code>source_id</code>, so assigning audio to those posts should go smoothly."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:151
+msgid "For audio that was created with plugin versions earlier than <code>v4.0</code> we will attempt to locate the post using the <code>source_url</code> field."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:152
+msgid "If we are unable to locate the post using either <code>source_id</code> or <code>source_url</code>, audio assignment will be skipped."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:156
+msgid "You will have the opportunity to review the changes before they are applied. Please do so carefully."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:163
+msgid "JSON File"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:167
+msgid "Select a JSON file to import."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:172
+msgid "Upload and Validate"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:208
+#, php-format
+msgid "Processing %d records..."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:210
+#, php-format
+msgid "Found %1$d records to import (%2$d post meta operations)."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:218
+#, php-format
+msgid "%d record(s) will be skipped because a matching WordPress post could not be found:"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:226
+#: plugins/beyondwords-import-tool/src/class-page.php:294
+msgid "Source ID"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:227
+#: plugins/beyondwords-import-tool/src/class-page.php:295
+msgid "Source URL"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:242
+msgid "The following update_post_meta() calls will be executed:"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:248
+msgid "Confirm and Execute"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:249
+msgid "Cancel"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:268
+msgid "Importing data..."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:273
+#, php-format
+msgid "Processing 0 of %d records..."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:277
+msgid "Import completed!"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:284
+msgid "Please copy the list of failed records below and send it to BeyondWords support so we can help resolve the issue."
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:286
+#: plugins/beyondwords-import-tool/src/class-page.php:287
+#: plugins/beyondwords-import-tool/src/class-page.php:303
+#: plugins/beyondwords-import-tool/src/class-page.php:304
+msgid "Copy failed records to clipboard"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:289
+#: plugins/beyondwords-import-tool/src/class-page.php:306
+msgid "Copied!"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:296
+#: src/settings/class-fields.php:88
+#: src/site-health/class-site-health.php:112
+msgid "Project ID"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:297
+#: src/editor/components/content-id/class-content-id.php:67
+#: src/editor/components/content-id/index.js:150
+msgid "Content ID"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:309
+msgid "Import Another File"
+msgstr ""
+
+#: plugins/beyondwords-import-tool/src/class-page.php:315
+msgid "Try Again"
+msgstr ""
+
+#: plugins/speechkit-export-tool/src/class-page.php:36
+#: plugins/speechkit-export-tool/src/class-page.php:37
+#: plugins/speechkit-export-tool/src/class-page.php:54
+msgid "Export SpeechKit Data"
+msgstr ""
+
+#: plugins/speechkit-export-tool/src/class-page.php:55
+msgid "This tool helps site owners export a sample of their SpeechKit data."
+msgstr ""
+
+#: plugins/speechkit-export-tool/src/class-page.php:56
+msgid "The exported file should be sent to the SpeechKit team to enable them to replicate your SpeechKit data."
+msgstr ""
+
+#: plugins/speechkit-export-tool/src/class-page.php:57
+msgid "It is safe for you to send this file using email, because no sensitive information is present in the file."
+msgstr ""
+
+#: plugins/speechkit-export-tool/src/class-page.php:61
+msgid "Download Export File"
+msgstr ""
+
+#: src/api/class-client.php:239
+msgid "None of the selected posts had valid BeyondWords audio data."
+msgstr ""
+
+#: src/api/class-client.php:245
+msgid "Batch delete can only be performed on audio belonging a single project."
+msgstr ""
+
+#. translators: %s is replaced with the support email link
+#: src/api/class-client.php:624
+#, php-format
+msgid "API request error. Please contact %s."
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:40
+msgid "BeyondWords audio details. Use this data to embed an audio player using the BeyondWords JavaScript SDK."
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:43
+msgid "BeyondWords source ID"
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:47
+msgid "BeyondWords project ID"
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:51
+msgid "BeyondWords content ID"
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:55
+msgid "BeyondWords legacy podcast ID"
+msgstr ""
+
+#: src/compatibility/class-wpgraphql.php:78
+msgid "BeyondWords audio details"
+msgstr ""
+
+#: src/editor/classic/class-metabox.php:91
+#: src/editor/components/settings-panel/player-section.js:87
+msgid "Player"
+msgstr ""
+
+#: src/editor/classic/class-metabox.php:110
+#: src/editor/components/settings-panel/content-section.js:60
+msgid "Content"
+msgstr ""
+
+#: src/editor/classic/class-metabox.php:115
+#: src/editor/components/settings-panel/format-section.js:90
+msgid "Format"
+msgstr ""
+
+#: src/editor/classic/class-metabox.php:120
+#: src/editor/components/select-voice/class-select-voice.php:353
+#: src/editor/components/settings-panel/voice-section.js:259
+#: src/editor/components/settings-panel/voice-section.js:277
+msgid "Voice"
+msgstr ""
+
+#: src/editor/classic/class-metabox.php:125
+#: src/editor/components/data-panel/index.js:15
+msgid "Data"
 msgstr ""
 
 #. translators: %s is replaced with the link to the BeyondWords dashboard
-#: src/Component/Post/Metabox/Metabox.php:162
+#: src/editor/classic/class-metabox.php:182
+#, php-format
 msgid "Listen to content saved as “Pending” in the %s."
 msgstr ""
 
-#: src/Component/Post/Metabox/Metabox.php:166
-#: src/Component/Settings/Languages/Languages.php:121
-#: src/Component/Settings/Settings.php:268
+#: src/editor/classic/class-metabox.php:186
 msgid "BeyondWords dashboard"
 msgstr ""
 
 #. translators: %s is replaced with the link to the support email address
-#: src/Component/Post/Metabox/Metabox.php:242
+#: src/editor/classic/class-metabox.php:284
+#, php-format
 msgid "Need help? Email our support team on %s"
 msgstr ""
 
-#: src/Component/Post/Metabox/Metabox.php:256
+#: src/editor/classic/class-metabox.php:303
 msgid "To create audio, resolve the error above then select ‘Update’ with ‘Generate audio’ checked."
 msgstr ""
 
-#: src/Component/Post/Panel/Inspect/Inspect.php:151
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:286
+#: src/editor/components/add-player/class-add-player.php:118
+msgid "Player placeholder: The position of the audio player."
+msgstr ""
+
+#: src/editor/components/content-id/class-content-id.php:85
+#: src/editor/components/content-id/index.js:168
+msgid "Fetch"
+msgstr ""
+
+#: src/editor/components/generate-audio/class-generate-audio.php:138
+#: src/editor/components/block-attributes/addControls.js:54
+#: src/editor/components/generate-audio/index.js:199
+msgid "Generation enabled"
+msgstr ""
+
+#: src/editor/components/generate-audio/class-generate-audio.php:139
+#: src/editor/components/block-attributes/addControls.js:55
+#: src/editor/components/generate-audio/index.js:200
+msgid "Generation disabled"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:84
+#: src/editor/components/inspect-panel/index.js:126
+msgid "Inspect"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:115
+#: src/editor/components/inspect-panel/index.js:253
+msgid "Copy"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:129
+#: src/editor/components/inspect-panel/index.js:265
 msgid "Remove"
 msgstr ""
 
-#: src/Component/Post/Panel/Inspect/Inspect.php:285
+#: src/editor/components/inspect-panel/class-inspect-panel.php:160
+msgid "Name"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:161
+#: src/editor/components/inspect-panel/class-inspect-panel.php:201
+msgid "Value"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:186
+msgid "Key"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:269
 msgid "Copied using the Classic Editor"
 msgstr ""
 
-#: src/Component/Post/PlayerStyle/PlayerStyle.php:65
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:71
-#: build/index.js:1
-#: src/Component/Post/PlayerStyle/index.js:51
-msgid "Player style"
+#: src/editor/components/inspect-panel/class-inspect-panel.php:359
+msgid "Invalid Project ID"
 msgstr ""
 
-#: src/Component/Posts/BulkEdit/BulkEdit.php:79
+#: src/editor/components/inspect-panel/class-inspect-panel.php:369
+msgid "Invalid Content ID"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:382
+msgid "Could not connect to BeyondWords API"
+msgstr ""
+
+#. translators: %d is replaced with the error code.
+#: src/editor/components/inspect-panel/class-inspect-panel.php:397
+#, php-format
+msgid "BeyondWords REST API returned error code %d"
+msgstr ""
+
+#: src/editor/components/inspect-panel/class-inspect-panel.php:412
+msgid "Invalid response from BeyondWords API"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:65
+#: src/editor/components/select-voice/class-select-voice.php:361
+#: src/editor/components/settings-panel/voice-section.js:206
+msgid "Select a voice"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:66
+#: src/editor/components/select-voice/class-select-voice.php:289
+#: src/editor/components/settings-panel/voice-section.js:198
+msgid "Select a model"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:67
+#: src/editor/components/select-voice/class-select-voice.php:470
+#: src/editor/components/settings-panel/helpers.js:132
+msgid "Legacy"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:71
+#: src/editor/components/select-voice/class-select-voice.php:490
+#: src/editor/components/settings-panel/helpers.js:46
+msgid "v3"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:72
+#: src/editor/components/select-voice/class-select-voice.php:491
+#: src/editor/components/settings-panel/helpers.js:47
+msgid "Multilingual v2"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:73
+#: src/editor/components/select-voice/class-select-voice.php:492
+#: src/editor/components/settings-panel/helpers.js:48
+msgid "Flash v2.5"
+msgstr ""
+
+#: src/editor/components/select-voice/class-assets.php:74
+#: src/editor/components/select-voice/class-select-voice.php:493
+#: src/editor/components/settings-panel/helpers.js:49
+msgid "Turbo v2.5"
+msgstr ""
+
+#: src/editor/components/select-voice/class-select-voice.php:130
+#: src/editor/components/settings-panel/voice-section.js:226
+msgid "Customize"
+msgstr ""
+
+#: src/editor/components/select-voice/class-select-voice.php:224
+#: src/editor/components/settings-panel/voice-section.js:234
+msgid "Language"
+msgstr ""
+
+#: src/editor/components/select-voice/class-select-voice.php:232
+#: src/editor/components/settings-panel/voice-section.js:160
+msgid "Select a language…"
+msgstr ""
+
+#: src/editor/components/select-voice/class-select-voice.php:281
+#: src/editor/components/settings-panel/voice-section.js:248
+msgid "Model"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-assets.php:64
+#: src/editor/components/settings-fields/class-settings-fields.php:205
+#: src/site-health/class-site-health.php:229
+#: src/site-health/class-site-health.php:237
+#: src/editor/components/settings-panel/helpers.js:190
+msgid "None"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-assets.php:65
+#: src/editor/components/settings-fields/class-settings-fields.php:213
+#: src/editor/components/settings-panel/helpers.js:195
+msgid "Audio (post)"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-assets.php:66
+#: src/editor/components/settings-fields/class-settings-fields.php:219
+#: src/editor/components/settings-panel/helpers.js:201
+msgid "Audio (script)"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-assets.php:67
+#: src/editor/components/settings-fields/class-settings-fields.php:228
+#: src/editor/components/settings-panel/helpers.js:210
+msgid "Video (post)"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-assets.php:68
+#: src/editor/components/settings-fields/class-settings-fields.php:234
+#: src/editor/components/settings-panel/helpers.js:216
+msgid "Video (script)"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:92
+#: src/editor/components/settings-panel/helpers.js:26
+msgid "Project default"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:107
+#: src/editor/components/settings-panel/helpers.js:141
+msgid "Post"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:111
+#: src/editor/components/settings-panel/helpers.js:142
+msgid "Script"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:115
+#: src/editor/components/settings-panel/helpers.js:144
+msgid "Post + script"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:131
+#: src/editor/components/settings-panel/helpers.js:152
+msgid "Audio"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:135
+#: src/editor/components/settings-panel/helpers.js:153
+msgid "Video"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:139
+#: src/editor/components/settings-panel/helpers.js:155
+msgid "Audio + video"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:363
+#: src/editor/components/settings-panel/content-section.js:65
+msgid "Source"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:370
+#: src/editor/components/settings-panel/content-section.js:75
+msgid "Script template"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:404
+#: src/editor/components/settings-panel/format-section.js:94
+msgid "Output"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:411
+#: src/editor/components/settings-panel/format-section.js:105
+msgid "Video template"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:422
+#: src/editor/components/settings-panel/format-section.js:114
+msgid "Video size"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:446
+#: src/editor/components/settings-panel/player-section.js:67
+msgid "Embed"
+msgstr ""
+
+#: src/editor/components/settings-fields/class-settings-fields.php:450
+#: src/editor/components/settings-panel/player-section.js:68
+msgid "Pick which generated asset is shown on this post. All other generated assets stay available in BeyondWords."
+msgstr ""
+
+#: src/post/class-content.php:41
+#: src/post/class-content.php:77
+#: src/post/class-content.php:116
+#: src/post/class-content.php:138
+#: src/post/class-content.php:181
+msgid "Post Not Found"
+msgstr ""
+
+#: src/posts-list/class-bulk-edit.php:74
 msgid "— No change —"
 msgstr ""
 
-#: src/Component/Posts/BulkEdit/BulkEdit.php:81
-#: src/Component/Posts/BulkEdit/BulkEdit.php:179
+#: src/posts-list/class-bulk-edit.php:75
+#: src/posts-list/class-bulk-edit.php:239
+msgid "Generate audio"
+msgstr ""
+
+#: src/posts-list/class-bulk-edit.php:76
+#: src/posts-list/class-bulk-edit.php:240
 msgid "Delete audio"
 msgstr ""
 
+#: src/posts-list/class-bulk-edit.php:119
+msgid "Sorry, you are not allowed to bulk edit BeyondWords audio."
+msgstr ""
+
+#: src/posts-list/class-bulk-edit.php:126
+msgid "Missing bulk-edit action or selected posts."
+msgstr ""
+
+#: src/posts-list/class-bulk-edit.php:137
+msgid "Unrecognised bulk-edit action."
+msgstr ""
+
+#: src/posts-list/class-bulk-edit.php:214
+msgid "Error while bulk deleting audio. Please contact support with reference BULK-NO-RESPONSE."
+msgstr ""
+
 #. translators: %d is replaced with the number of posts processed
-#: src/Component/Posts/BulkEdit/BulkEdit.php:310
+#: src/posts-list/class-notices.php:46
+#, php-format
 msgid "Audio was requested for %d post."
 msgid_plural "Audio was requested for %d posts."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d is replaced with the number of posts processed
-#: src/Component/Posts/BulkEdit/BulkEdit.php:346
+#: src/posts-list/class-notices.php:73
+#, php-format
 msgid "Audio was deleted for %d post."
 msgid_plural "Audio was deleted for %d posts."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d is replaced with the number of posts that were skipped
-#: src/Component/Posts/BulkEdit/BulkEdit.php:382
+#: src/posts-list/class-notices.php:100
+#, php-format
 msgid "%d post failed, check for errors in the BeyondWords column below."
 msgid_plural "%d posts failed, check for errors in the BeyondWords column below."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Component/Settings/ApiKey/ApiKey.php:50
-msgid "BeyondWords API key"
+#: src/settings/class-fields.php:80
+msgid "API key"
 msgstr ""
 
-#: src/Component/Settings/ApiKey/ApiKey.php:90
-msgid "Please enter the BeyondWords API key. This can be found in your project settings."
+#: src/settings/class-fields.php:111
+#: src/site-health/class-site-health.php:102
+msgid "Integration method"
 msgstr ""
 
-#: src/Component/Settings/Languages/Languages.php:67
-msgid "Languages"
+#: src/settings/class-fields.php:148
+msgid "Excerpt"
 msgstr ""
 
-#. translators: %s is replaced with the link to the BeyondWords dashboard
-#: src/Component/Settings/Languages/Languages.php:117
-msgid "The default voice for audio is determined by the project settings in your %s."
-msgstr ""
-
-#: src/Component/Settings/Languages/Languages.php:128
-msgid "Add languages here to use voices other than the default project voice."
-msgstr ""
-
-#: src/Component/Settings/Languages/Languages.php:133
-msgid "The voices will be available to select on the Post Edit screen."
-msgstr ""
-
-#. translators: %s is replaced with the "playerStyle setting" link
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:111
-msgid "The default player style (%s) for the audio player. This can be overridden for each post."
-msgstr ""
-
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:114
-msgid "playerStyle setting"
-msgstr ""
-
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:134
-msgid "Standard"
-msgstr ""
-
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:138
-msgid "Small"
-msgstr ""
-
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:142
-msgid "Large"
-msgstr ""
-
-#: src/Component/Settings/PlayerStyle/PlayerStyle.php:146
-msgid "Video"
-msgstr ""
-
-#: src/Component/Settings/PlayerUI/PlayerUI.php:62
-#: src/Component/SiteHealth/SiteHealth.php:102
+#: src/settings/class-fields.php:156
+#: src/site-health/class-site-health.php:138
 msgid "Player UI"
 msgstr ""
 
-#. translators: %s is replaced with the "headless mode" link
-#: src/Component/Settings/PlayerUI/PlayerUI.php:100
-msgid "Enable or disable the player, or set it to %s."
+#: src/settings/class-fields.php:171
+msgid "Please enter the BeyondWords API key. This can be found in your project settings."
 msgstr ""
 
-#: src/Component/Settings/PlayerUI/PlayerUI.php:103
-msgid "headless mode"
-msgstr ""
-
-#: src/Component/Settings/PlayerUI/PlayerUI.php:123
-msgid "Enabled"
-msgstr ""
-
-#: src/Component/Settings/PlayerUI/PlayerUI.php:124
-msgid "Headless"
-msgstr ""
-
-#: src/Component/Settings/PlayerUI/PlayerUI.php:125
-msgid "Disabled"
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:75
-#: src/Component/SiteHealth/SiteHealth.php:97
-msgid "Player version"
-msgstr ""
-
-#. translators: %s is replaced with the player version from the BeyondWords API
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:115
-msgid "The player version on this WordPress site doesn’t match the “%s” player in your BeyondWords account. Saving the WordPress plugin settings will update your BeyondWords account to keep the player version in sync."
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:119
-msgid "Your BeyondWords account is currently using another player."
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:147
-msgid "We sync changes to the player version with your Beyondwords account when these settings are saved."
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:155
-msgid "If caching is enabled you may need to clear the cache to change the player version for existing posts."
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:259
-msgid "There was an error syncing the player version with your BeyondWords account. The versions may be different. Sign in to your BeyondWords dashboard and change the player version there if you need them to be in sync."
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:280
-msgid "Latest"
-msgstr ""
-
-#: src/Component/Settings/PlayerVersion/PlayerVersion.php:281
-msgid "Legacy"
-msgstr ""
-
-#: src/Component/Settings/IncludeExcerpt/IncludeExcerpt.php:55
-#: src/Component/SiteHealth/SiteHealth.php:107
-msgid "Process excerpts"
-msgstr ""
-
-#: src/Component/Settings/IncludeExcerpt/IncludeExcerpt.php:82
-msgid "Use excerpts for summaries"
-msgstr ""
-
-#: src/Component/Settings/IncludeExcerpt/IncludeExcerpt.php:87
-msgid "Summaries are read aloud in-between titles and body content."
-msgstr ""
-
-#: src/Component/Settings/Preselect/Preselect.php:61
-#: src/Component/SiteHealth/SiteHealth.php:113
-msgid "Preselect ‘Generate audio’"
-msgstr ""
-
-#: src/Component/Settings/Preselect/Preselect.php:83
-msgid "No compatible post types found. This plugin will only work with post types that support custom fields."
-msgstr ""
-
-#: src/Component/Settings/ProjectId/ProjectId.php:50
-#: src/Core/Core.php:533
-msgid "BeyondWords project ID"
-msgstr ""
-
-#: src/Component/Settings/ProjectId/ProjectId.php:90
+#: src/settings/class-fields.php:184
 msgid "Please enter your BeyondWords project ID. This can be found in your project settings."
 msgstr ""
 
-#: src/Component/Settings/Settings.php:98
-msgid "Basic settings"
+#. translators: %s is the link text "Magic Embed"
+#: src/settings/class-fields.php:251
+#, php-format
+msgid "REST API is the default integration. Choose %s if your theme/plugins prevent BeyondWords from saving content via the REST API — for example on sites using a page builder."
 msgstr ""
 
-#: src/Component/Settings/Settings.php:107
-msgid "Player settings"
+#: src/settings/class-fields.php:254
+#: src/settings/class-fields.php:339
+msgid "Magic Embed"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:115
-msgid "Content settings"
+#: src/settings/class-fields.php:275
+msgid "Include the post excerpt at the start of generated audio and video."
 msgstr ""
 
-#: src/Component/Settings/Settings.php:123
-msgid "‘Generate audio’ settings"
+#. translators: %s is the link text "headless mode"
+#: src/settings/class-fields.php:297
+#, php-format
+msgid "Enable or disable the player, or set it to %s."
 msgstr ""
 
-#: src/Component/Settings/Settings.php:143
-msgid "The details we need to authenticate your BeyondWords account. For more options, head to your BeyondWords dashboard."
+#: src/settings/class-fields.php:300
+msgid "headless mode"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:164
-msgid "Upgrade to the latest player version for the newest features."
+#: src/settings/class-fields.php:338
+msgid "REST API"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:185
-msgid "By default, BeyondWords will process your titles and body content into audio."
+#: src/settings/class-fields.php:350
+msgid "Enabled"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:206
-msgid "The ‘Generate audio’ checkbox in the BeyondWords sidebar will be automatically checked for selected post types. The default setting can be manually overridden."
+#: src/settings/class-fields.php:351
+msgid "Headless"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:214
-msgid "Uncheck a post type to view its Categories. You can then set defaults at a category level. Make sure to check all relevant boxes."
+#: src/settings/class-fields.php:352
+msgid "Disabled"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:223
-msgid "The default WordPress ‘Categories’ taxonomy is currently the only taxonomy supported."
+#: src/settings/class-preselect.php:104
+#: src/site-health/class-site-health.php:143
+msgid "Preselect ‘Generate audio’"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:237
+#: src/settings/class-preselect.php:380
+msgid "No compatible post types found. BeyondWords requires post types that support a title, an editor, and custom fields."
+msgstr ""
+
+#: src/settings/class-preselect.php:451
+msgid "All"
+msgstr ""
+
+#: src/settings/class-settings.php:49
+#: src/settings/class-settings.php:78
+msgid "BeyondWords Settings"
+msgstr ""
+
+#: src/settings/class-settings.php:105
+msgid "Save changes"
+msgstr ""
+
+#: src/settings/class-settings.php:122
 msgid "Settings"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:254
-msgid "BeyondWords settings"
-msgstr ""
-
-#. translators: %s is replaced with a "let us know" link
-#: src/Component/Settings/Settings.php:282
-msgid "It looks like you tried the \"Latest\" player and switched back to the \"Legacy\" player. If you experienced any issues switching player please %s so we can help."
-msgstr ""
-
-#: src/Component/Settings/Settings.php:285
-msgid "WordPress support: Latest player"
-msgstr ""
-
-#: src/Component/Settings/Settings.php:286
-msgid "let us know"
-msgstr ""
-
-#: src/Component/Settings/Settings.php:299
-msgid "The player will appear before the first part of <code>the_content()</code> by default. You can change the location via the WordPress Editor."
-msgstr ""
-
-#. translators: %s is replaced with a "plugin settings" link
-#: src/Component/Settings/Settings.php:343
-#: src/Component/Settings/Settings.php:386
+#. translators: %s is the "plugin settings" link
+#: src/settings/class-settings.php:144
+#, php-format
 msgid "To use BeyondWords, please update the %s."
 msgstr ""
 
-#: src/Component/Settings/Settings.php:347
-#: src/Component/Settings/Settings.php:390
+#: src/settings/class-settings.php:148
 msgid "plugin settings"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:397
+#: src/settings/class-settings.php:154
 msgid "Don’t have a BeyondWords account yet?"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:405
+#: src/settings/class-settings.php:161
 msgid "Sign up free"
 msgstr ""
 
-#: src/Component/Settings/Settings.php:514
-msgid "Please check and re-enter your BeyondWords API key and project ID. They appear to be invalid."
+#. translators: %s is the link to the WordPress plugin repo
+#: src/settings/class-settings.php:194
+#, php-format
+msgid "Happy with our work? Help us spread the word with a rating on the %s."
 msgstr ""
 
-#: src/Component/Settings/SettingsUpdated/SettingsUpdated.php:50
-msgid "Settings Updated"
+#: src/settings/class-settings.php:198
+msgid "WordPress Plugin Repo"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:87
+#: src/settings/class-tabs.php:90
+msgid "Authentication"
+msgstr ""
+
+#: src/settings/class-tabs.php:91
+msgid "Integration"
+msgstr ""
+
+#: src/settings/class-tabs.php:92
+msgid "Preferences"
+msgstr ""
+
+#. translators: %s is replaced with the BeyondWords REST API response debug data
+#: src/settings/class-utils.php:167
+#, php-format
+msgid "We were unable to validate your BeyondWords REST API connection.<br />Please check your project ID and API key, save changes, and contact us for support if this message remains.<br /><br />BeyondWords REST API Response:<br />%s"
+msgstr ""
+
+#: src/site-health/class-site-health.php:97
+msgid "Compatible post types"
+msgstr ""
+
+#: src/site-health/class-site-health.php:107
 msgid "API Key"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:92
-msgid "Project ID"
+#: src/site-health/class-site-health.php:132
+msgid "Include excerpt"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:119
-msgid "Allowed post types"
+#: src/site-health/class-site-health.php:133
+msgid "Yes"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:124
-msgid "Supported post types"
+#: src/site-health/class-site-health.php:133
+msgid "No"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:129
-msgid "Settings updated"
-msgstr ""
-
-#: src/Component/SiteHealth/SiteHealth.php:136
-msgid "Registered filters"
-msgstr ""
-
-#: src/Component/SiteHealth/SiteHealth.php:137
-#: src/Component/SiteHealth/SiteHealth.php:145
-msgid "None"
-msgstr ""
-
-#: src/Component/SiteHealth/SiteHealth.php:144
-msgid "Registered deprecated filters"
-msgstr ""
-
-#: src/Component/SiteHealth/SiteHealth.php:172
-#: src/Component/SiteHealth/SiteHealth.php:177
+#: src/site-health/class-site-health.php:159
+#: src/site-health/class-site-health.php:166
 msgid "Plugin version"
 msgstr ""
 
-#: src/Component/SiteHealth/SiteHealth.php:205
+#. translators: 1: Current plugin version, 2: Database plugin version
+#: src/site-health/class-site-health.php:169
+#, php-format
+msgid "Version mismatch: file: %1$s / db: %2$s"
+msgstr ""
+
+#: src/site-health/class-site-health.php:185
 msgid "REST API URL"
 msgstr ""
 
-#: src/Core/ApiClient.php:145
-msgid "None of the selected posts had valid BeyondWords audio data."
+#: src/site-health/class-site-health.php:200
+#: src/site-health/class-site-health.php:208
+msgid "Communication with REST API"
 msgstr ""
 
-#: src/Core/ApiClient.php:149
-msgid "Batch delete can only be performed on audio belonging a single project."
+#: src/site-health/class-site-health.php:201
+msgid "BeyondWords API is reachable"
 msgstr ""
 
-#. translators: %s is replaced with the support email link
-#: src/Core/ApiClient.php:489
-msgid "API request error. Please contact %s."
+#. translators: 1: The IP address the REST API resolves to. 2: The error returned by the lookup.
+#: src/site-health/class-site-health.php:211
+#, php-format
+msgid "Unable to reach BeyondWords API at %1$s: %2$s"
 msgstr ""
 
-#. translators: %s is replaced with the reason that JSON parsing failed
-#: src/Core/ApiClient.php:501
-msgid "Unable to parse JSON in BeyondWords API response. Reason: %s."
+#: src/site-health/class-site-health.php:228
+msgid "Registered filters"
 msgstr ""
 
-#. translators: %d is replaced with number of BeyondWords errors
-#: src/Core/Core.php:499
-msgid "%d BeyondWords error found."
-msgid_plural "%d BeyondWords errors found."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Core/Core.php:510
-msgid "Check the BeyondWords column for more details."
+#: src/site-health/class-site-health.php:236
+msgid "Registered deprecated filters"
 msgstr ""
 
-#: src/Core/Core.php:530
-msgid "BeyondWords audio details. Use this data to embed an audio player using the BeyondWords JavaScript SDK."
+#: src/site-health/class-site-health.php:249
+msgid "Date Activated"
 msgstr ""
 
-#: src/Core/Core.php:537
-msgid "BeyondWords content ID"
+#: src/site-health/class-site-health.php:254
+msgid "Review Notice Dismissed"
 msgstr ""
 
-#: src/Core/Core.php:541
-msgid "BeyondWords legacy podcast ID"
+#: src/site-health/class-site-health.php:266
+msgid "Undefined"
 msgstr ""
 
-#: src/Core/Core.php:559
-msgid "BeyondWords audio details"
+#: src/editor/components/add-player/index.js:39
+msgid "The BeyondWords audio player will appear here."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Status/index.js:21
-msgid "Status"
+#: src/editor/components/block-attributes/addControls.js:50
+msgid "Disable generation"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/BlockAttributes/addControls.js:45
-msgid "Disable audio processing"
+#: src/editor/components/block-attributes/addControls.js:51
+msgid "Enable generation"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/BlockAttributes/addControls.js:46
-msgid "Enable audio processing"
+#: src/editor/components/content-id/classic-metabox.js:303
+msgid "Content fetched and saved successfully."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/BlockAttributes/addControls.js:48
-msgid "Audio processing enabled"
+#: src/editor/components/content-id/classic-metabox.js:315
+msgid "Failed to save fetched content."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/BlockAttributes/addControls.js:49
-msgid "Audio processing disabled"
+#: src/editor/components/content-id/classic-metabox.js:327
+#: src/editor/components/content-id/classic-metabox.js:339
+#: src/editor/components/content-id/index.js:91
+#: src/editor/components/content-id/index.js:128
+msgid "Failed to fetch content. Please check the Content ID."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/BlockAttributes/addControls.js:93
-msgid "Segment marker"
+#: src/editor/components/help-panel/index.js:16
+msgid "Help"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/OpenSidebar/index.js:15
-msgid "Open the"
+#: src/editor/components/help-panel/index.js:36
+msgid "Setup guide"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/OpenSidebar/index.js:22
-msgid "BeyondWords sidebar"
+#: src/editor/components/help-panel/index.js:41
+msgid "Need help? Email our support team."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/OpenSidebar/index.js:24
-msgid "for additional options and features."
+#: src/editor/components/help-panel/index.js:46
+msgid "Email BeyondWords"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:180
+#: src/editor/components/inspect-panel/helpers.js:56
 msgid "Deprecated"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:196
+#: src/editor/components/inspect-panel/helpers.js:58
 msgid "System"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:198
+#: src/editor/components/inspect-panel/helpers.js:60
 msgid "Copied using the Block Editor"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:285
+#: src/editor/components/inspect-panel/index.js:115
+msgid "Copied data to clipboard."
+msgstr ""
+
+#: src/editor/components/inspect-panel/index.js:264
 msgid "Restore"
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:364
+#: src/editor/components/inspect-panel/index.js:344
 msgid "The BeyondWords data for this post will be removed when the post is saved."
 msgstr ""
 
-#: build/index.js:1
-#: src/Component/Post/Panel/Inspect/index.js:380
-msgid "Unable to remove the BeyondWords data. Please email our support team."
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/PendingNotice/index.js:23
-msgid "Listen to content saved as “Pending” in the BeyondWords dashboard."
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/PendingNotice/index.js:29
-msgid "BeyondWords dashboard."
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/PlayAudio/index.js:118
-msgid "🔊 There was an error playing the audio. Please try again."
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/SelectVoice/index.js:82
-msgid "Language"
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/SelectVoice/index.js:85
-msgid "Project default"
-msgstr ""
-
-#: build/index.js:1
-#: src/Component/Post/SelectVoice/index.js:102
-msgid "Voice"
-msgstr ""
-
-#: src/Component/Post/Panel/Inspect/js/inspect.js:13
+#: src/editor/components/inspect-panel/js/inspect.js:36
 msgid "Remove all BeyondWords data when the post is saved?"
 msgstr ""
 
-#: build/Component/Post/AddPlayer/block.json
-#: src/Component/Post/AddPlayer/block.json
+#: src/editor/components/open-sidebar/index.js:15
+msgid "Open the"
+msgstr ""
+
+#: src/editor/components/open-sidebar/index.js:22
+msgid "BeyondWords sidebar"
+msgstr ""
+
+#: src/editor/components/open-sidebar/index.js:24
+msgid "for additional options and features."
+msgstr ""
+
+#: src/editor/components/pending-notice/index.js:23
+msgid "Listen to content saved as “Pending” in the BeyondWords dashboard."
+msgstr ""
+
+#: src/editor/components/pending-notice/index.js:29
+msgid "BeyondWords dashboard."
+msgstr ""
+
+#: src/editor/components/preview-panel/index.js:63
+msgid "Preview"
+msgstr ""
+
+#: src/editor/components/add-player/block.json
 msgctxt "block title"
 msgid "BeyondWords"
 msgstr ""
 
-#: build/Component/Post/AddPlayer/block.json
-#: src/Component/Post/AddPlayer/block.json
+#: src/editor/components/add-player/block.json
 msgctxt "block description"
 msgid "Embed the BeyondWords audio player. This will override the default player location."
 msgstr ""
 
-#: build/Component/Post/AddPlayer/block.json
-#: src/Component/Post/AddPlayer/block.json
+#: src/editor/components/add-player/block.json
 msgctxt "block keyword"
 msgid "audio"
 msgstr ""
 
-#: build/Component/Post/AddPlayer/block.json
-#: src/Component/Post/AddPlayer/block.json
+#: src/editor/components/add-player/block.json
 msgctxt "block keyword"
 msgid "text-to-speech"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-dev-2.0",
+  "version": "7.0.0-dev-3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beyondwords-wordpress-plugin",
-      "version": "7.0.0-dev-2.0",
+      "version": "7.0.0-dev-3.0",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/api-fetch": "^7.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-dev-2.0",
+  "version": "7.0.0-dev-3.0",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 7.0.0-dev-2.0
+Stable tag: 7.0.0-dev-3.0
 Requires at least: 5.9
 Requires PHP: 8.0
 Tested up to: 7.0

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare( strict_types = 1 );
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           7.0.0-dev-2.0
+ * Version:           7.0.0-dev-3.0
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -32,7 +32,7 @@ require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-dev-2.0');
+define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-dev-3.0');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/editor/components/block-attributes/addControls.js
+++ b/src/editor/components/block-attributes/addControls.js
@@ -47,12 +47,12 @@ const withBeyondwordsBlockControls = createHigherOrderComponent(
 				: 'controls-volumeoff';
 
 			const buttonLabel = !! beyondwordsAudio
-				? __( 'Disable audio processing', 'speechkit' )
-				: __( 'Enable audio processing', 'speechkit' );
+				? __( 'Disable generation', 'speechkit' )
+				: __( 'Enable generation', 'speechkit' );
 
 			const toggleLabel = !! beyondwordsAudio
-				? __( 'Audio processing enabled', 'speechkit' )
-				: __( 'Audio processing disabled', 'speechkit' );
+				? __( 'Generation enabled', 'speechkit' )
+				: __( 'Generation disabled', 'speechkit' );
 
 			const toggleBeyondwordsAudio = () => {
 				setAttributes( { beyondwordsAudio: ! beyondwordsAudio } );

--- a/src/editor/components/generate-audio/class-generate-audio.php
+++ b/src/editor/components/generate-audio/class-generate-audio.php
@@ -48,13 +48,16 @@ class GenerateAudio {
 	}
 
 	/**
-	 * Enqueue the classic-editor term-gated preselect script.
+	 * Enqueue the classic-editor Generate audio script.
 	 *
-	 * Only needed for the classic editor (the block editor handles preselect in
-	 * React) and only for post types configured with `terms` mode — `all`/`off`
-	 * need no live JS, as the server renders the correct initial checkbox state.
+	 * Classic editor only — the block editor handles this in React. The script
+	 * keeps the state-reflecting "Generation enabled/disabled" caption in step
+	 * with the checkbox, so it loads for every compatible post type. When the
+	 * post type is configured with `terms` mode it also carries the term data
+	 * needed to live-update the checkbox as matching terms are ticked.
 	 *
 	 * @since 7.0.0
+	 * @since 7.0.0 Always enqueued (for the caption); preselect data is optional.
 	 *
 	 * @param string $hook Current admin page hook.
 	 */
@@ -73,17 +76,6 @@ class GenerateAudio {
 			return;
 		}
 
-		if ( \BeyondWords\Settings\Preselect::MODE_TERMS !== \BeyondWords\Settings\Preselect::get_mode( $post_type ) ) {
-			return;
-		}
-
-		$terms = \BeyondWords\Settings\Preselect::get_selected_terms( $post_type );
-
-		// Nothing to watch — no point loading the script.
-		if ( empty( $terms ) ) {
-			return;
-		}
-
 		wp_register_script(
 			'beyondwords-metabox--generate-audio',
 			BEYONDWORDS__PLUGIN_URI . 'src/editor/components/generate-audio/classic-metabox.js',
@@ -92,14 +84,22 @@ class GenerateAudio {
 			true
 		);
 
-		wp_localize_script(
-			'beyondwords-metabox--generate-audio',
-			'beyondwordsPreselect',
-			[
-				'mode'  => \BeyondWords\Settings\Preselect::MODE_TERMS,
-				'terms' => $terms,
-			]
-		);
+		// Term-gated preselect additionally needs the watched terms — only in
+		// `terms` mode, and only when there is something to watch.
+		if ( \BeyondWords\Settings\Preselect::MODE_TERMS === \BeyondWords\Settings\Preselect::get_mode( $post_type ) ) {
+			$terms = \BeyondWords\Settings\Preselect::get_selected_terms( $post_type );
+
+			if ( ! empty( $terms ) ) {
+				wp_localize_script(
+					'beyondwords-metabox--generate-audio',
+					'beyondwordsPreselect',
+					[
+						'mode'  => \BeyondWords\Settings\Preselect::MODE_TERMS,
+						'terms' => $terms,
+					]
+				);
+			}
+		}
 
 		wp_enqueue_script( 'beyondwords-metabox--generate-audio' );
 	}
@@ -131,6 +131,12 @@ class GenerateAudio {
 		wp_nonce_field( 'beyondwords_generate_audio', 'beyondwords_generate_audio_nonce' );
 
 		$generate_audio = \BeyondWords\Post\Meta::has_generate_audio( $post->ID );
+
+		// State-reflecting caption: the label reads out the current state. The
+		// data attributes let classic-metabox.js keep it in step as the checkbox
+		// is toggled (the block editor toggle behaves the same way).
+		$label_enabled  = __( 'Generation enabled', 'speechkit' );
+		$label_disabled = __( 'Generation disabled', 'speechkit' );
 		?>
 		<!--  checkbox -->
 		<p id="beyondwords-metabox-generate-audio">
@@ -141,7 +147,13 @@ class GenerateAudio {
 				value="1"
 				<?php checked( $generate_audio ); ?>
 			/>
-			<?php esc_html_e( 'Generate audio', 'speechkit' ); ?>
+			<label for="beyondwords_generate_audio">
+				<span
+					id="beyondwords-generate-audio-label"
+					data-label-enabled="<?php echo esc_attr( $label_enabled ); ?>"
+					data-label-disabled="<?php echo esc_attr( $label_disabled ); ?>"
+				><?php echo esc_html( $generate_audio ? $label_enabled : $label_disabled ); ?></span>
+			</label>
 		</p>
 		<?php
 	}

--- a/src/editor/components/generate-audio/classic-metabox.js
+++ b/src/editor/components/generate-audio/classic-metabox.js
@@ -1,14 +1,19 @@
 /* global beyondwordsPreselect */
 
 /*
- * Classic-editor term-gated preselect.
+ * Classic-editor Generate audio behaviours.
  *
- * When the publisher has chosen to preselect "Generate audio" only for posts
- * with specific hierarchical taxonomy terms, keep the checkbox in step as the
- * editor ticks/unticks those terms. The server sets the correct initial state
- * on page load (via Preselect::should_preselect_for_post); this only handles
- * live changes — and stops once the user toggles Generate audio themselves, so
- * a deliberate choice is never clobbered (mirrors the block editor).
+ * 1. State-reflecting caption — keep the "Generation enabled/disabled" label in
+ *    step with the checkbox as it is ticked/unticked (mirrors the block editor
+ *    toggle). The server renders the correct initial caption on page load.
+ *
+ * 2. Term-gated preselect (only when configured) — when the publisher has chosen
+ *    to preselect "Generate audio" only for posts with specific hierarchical
+ *    taxonomy terms, keep the checkbox in step as the editor ticks/unticks those
+ *    terms. The server sets the correct initial state on page load (via
+ *    Preselect::should_preselect_for_post); this only handles live changes — and
+ *    stops once the user toggles the checkbox themselves, so a deliberate choice
+ *    is never clobbered (mirrors the block editor).
  *
  * Vanilla JS — no jQuery. Listens via event delegation so terms added through
  * the "+ Add New Category" UI are covered too.
@@ -16,14 +21,36 @@
 ( function () {
 	'use strict';
 
+	const generateAudioCheckbox = () =>
+		document.getElementById( 'beyondwords_generate_audio' );
+
+	/* ---- 1. State-reflecting caption ---- */
+
+	const captionEl = () =>
+		document.getElementById( 'beyondwords-generate-audio-label' );
+
+	const syncCaption = () => {
+		const caption = captionEl();
+		const checkbox = generateAudioCheckbox();
+		if ( ! caption || ! checkbox ) {
+			return;
+		}
+		const label = checkbox.checked
+			? caption.getAttribute( 'data-label-enabled' )
+			: caption.getAttribute( 'data-label-disabled' );
+		if ( label !== null ) {
+			caption.textContent = label;
+		}
+	};
+
+	/* ---- 2. Term-gated preselect (optional) ---- */
+
 	const data =
 		typeof beyondwordsPreselect !== 'undefined'
 			? beyondwordsPreselect
 			: null;
 
-	if ( ! data || data.mode !== 'terms' || ! data.terms ) {
-		return;
-	}
+	const termGating = !! ( data && data.mode === 'terms' && data.terms );
 
 	// The classic metabox input name for a taxonomy's term checkboxes.
 	const inputNameFor = ( taxonomy ) =>
@@ -31,16 +58,17 @@
 			? 'post_category[]'
 			: `tax_input[${ taxonomy }][]`;
 
-	const watched = Object.keys( data.terms ).map( ( taxonomy ) => ( {
-		inputName: inputNameFor( taxonomy ),
-		wanted: new Set( ( data.terms[ taxonomy ] || [] ).map( String ) ),
-	} ) );
+	const watched = termGating
+		? Object.keys( data.terms ).map( ( taxonomy ) => ( {
+				inputName: inputNameFor( taxonomy ),
+				wanted: new Set(
+					( data.terms[ taxonomy ] || [] ).map( String )
+				),
+		  } ) )
+		: [];
 
 	// Once the editor toggles Generate audio by hand, stop auto-managing it.
 	let userToggled = false;
-
-	const generateAudioCheckbox = () =>
-		document.getElementById( 'beyondwords_generate_audio' );
 
 	// Does any currently-ticked term match the preselect rule (OR semantics)?
 	const anyTermMatches = () =>
@@ -53,13 +81,14 @@
 			);
 		} );
 
-	const sync = () => {
+	const syncFromTerms = () => {
 		if ( userToggled ) {
 			return;
 		}
 		const checkbox = generateAudioCheckbox();
 		if ( checkbox ) {
 			checkbox.checked = anyTermMatches();
+			syncCaption();
 		}
 	};
 
@@ -68,17 +97,24 @@
 		target.type === 'checkbox' &&
 		watched.some( ( { inputName } ) => target.name === inputName );
 
+	/* ---- Wire up ---- */
+
+	// Align the caption with the server-rendered checkbox state up front.
+	syncCaption();
+
 	document.addEventListener( 'change', ( event ) => {
 		const target = event.target;
 
-		// A manual toggle of Generate audio freezes auto-management.
+		// A manual toggle of Generate audio updates the caption and (when
+		// term-gating) freezes auto-management.
 		if ( target && target.id === 'beyondwords_generate_audio' ) {
 			userToggled = true;
+			syncCaption();
 			return;
 		}
 
-		if ( isWatchedInput( target ) ) {
-			sync();
+		if ( termGating && isWatchedInput( target ) ) {
+			syncFromTerms();
 		}
 	} );
 } )();

--- a/src/editor/components/generate-audio/index.js
+++ b/src/editor/components/generate-audio/index.js
@@ -83,7 +83,7 @@ export function GenerateAudio( { wrapper } ) {
 
 	const { editPost } = useDispatch( 'core/editor' );
 
-	const { checked, hasContent } = useSelect( ( select ) => {
+	const { checked } = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
 			getCurrentPostAttribute,
@@ -184,11 +184,6 @@ export function GenerateAudio( { wrapper } ) {
 				explicit !== undefined && explicit !== null
 					? explicit
 					: getShouldPreselect(),
-			hasContent: Boolean(
-				savedMeta.beyondwords_content_id ||
-					savedMeta.beyondwords_podcast_id ||
-					savedMeta.speechkit_podcast_id
-			),
 		};
 	}, [] );
 
@@ -198,9 +193,11 @@ export function GenerateAudio( { wrapper } ) {
 		editPost( { meta: { [ META_KEY ]: ! checked ? '1' : '0' } } );
 	};
 
-	const label = hasContent
-		? __( 'Update audio', 'speechkit' )
-		: __( 'Generate audio', 'speechkit' );
+	// State-reflecting caption: the toggle reads out its current state rather
+	// than the action it performs.
+	const label = checked
+		? __( 'Generation enabled', 'speechkit' )
+		: __( 'Generation disabled', 'speechkit' );
 
 	return (
 		<Wrapper>

--- a/src/editor/components/select-voice/class-assets.php
+++ b/src/editor/components/select-voice/class-assets.php
@@ -64,7 +64,7 @@ class Assets {
 				'projectId'        => (string) get_option( 'beyondwords_project_id', '' ),
 				'selectVoice'      => __( 'Select a voice', 'speechkit' ),
 				'selectModel'      => __( 'Select a model', 'speechkit' ),
-				'standardModel'    => __( 'Standard', 'speechkit' ),
+				'standardModel'    => __( 'Legacy', 'speechkit' ),
 				'elevenLabs'       => \BeyondWords\Editor\Components\SelectVoice::ELEVENLABS_SERVICE,
 				'defaultModelId'   => \BeyondWords\Editor\Components\SelectVoice::DEFAULT_ELEVENLABS_VOICE_MODEL_ID,
 				'voiceModelLabels' => [

--- a/src/editor/components/select-voice/class-select-voice.php
+++ b/src/editor/components/select-voice/class-select-voice.php
@@ -467,7 +467,7 @@ class SelectVoice {
 		if ( $has_standard ) {
 			$models[] = [
 				'key'   => self::STANDARD_MODEL_KEY,
-				'label' => __( 'Standard', 'speechkit' ),
+				'label' => __( 'Legacy', 'speechkit' ),
 			];
 		}
 

--- a/src/editor/components/select-voice/classic-metabox.js
+++ b/src/editor/components/select-voice/classic-metabox.js
@@ -31,7 +31,7 @@
 		( data && data.defaultModelId ) || 'eleven_multilingual_v2';
 	const SELECT_VOICE = ( data && data.selectVoice ) || 'Select a voice';
 	const SELECT_MODEL = ( data && data.selectModel ) || 'Select a model';
-	const STANDARD_MODEL = ( data && data.standardModel ) || 'Standard';
+	const STANDARD_MODEL = ( data && data.standardModel ) || 'Legacy';
 	const MODEL_LABELS = ( data && data.voiceModelLabels ) || {};
 
 	// Bucket key for voices without an ElevenLabs model_id (e.g. standard voices).

--- a/src/editor/components/settings-panel/helpers.js
+++ b/src/editor/components/settings-panel/helpers.js
@@ -129,7 +129,7 @@ export function getLanguageModels( voices ) {
 	if ( hasStandard ) {
 		models.push( {
 			key: STANDARD_MODEL_KEY,
-			label: __( 'Standard', 'speechkit' ),
+			label: __( 'Legacy', 'speechkit' ),
 		} );
 	}
 

--- a/src/editor/components/settings-panel/helpers.test.js
+++ b/src/editor/components/settings-panel/helpers.test.js
@@ -122,7 +122,7 @@ describe( 'getLanguageModels', () => {
 			'Multilingual v2',
 			'Flash v2.5',
 			'v3',
-			'Standard',
+			'Legacy',
 		] );
 	} );
 
@@ -138,7 +138,7 @@ describe( 'getLanguageModels', () => {
 
 	it( 'returns a single Standard bucket for non-ElevenLabs voices only', () => {
 		expect( getLanguageModels( [ { id: 1, name: 'Ada' } ] ) ).toEqual( [
-			{ key: STANDARD_MODEL_KEY, label: 'Standard' },
+			{ key: STANDARD_MODEL_KEY, label: 'Legacy' },
 		] );
 	} );
 

--- a/tests/cypress/e2e/block-editor/add-post.cy.js
+++ b/tests/cypress/e2e/block-editor/add-post.cy.js
@@ -146,7 +146,7 @@ context( 'Block Editor: Add Post', () => {
 							cy.openBeyondwordsEditorPanel();
 
 							// Checkbox must stay unchecked despite preselect being enabled
-							cy.getBlockEditorCheckbox( 'Generate audio' ).should(
+							cy.getGenerateAudioCheckbox().should(
 								'not.be.checked'
 							);
 
@@ -177,7 +177,7 @@ context( 'Block Editor: Add Post', () => {
 
 						cy.openBeyondwordsEditorPanel();
 
-						cy.getBlockEditorCheckbox( 'Update audio' ).should(
+						cy.getGenerateAudioCheckbox().should(
 							'be.checked'
 						);
 

--- a/tests/cypress/e2e/block-editor/generate-audio.cy.js
+++ b/tests/cypress/e2e/block-editor/generate-audio.cy.js
@@ -29,9 +29,7 @@ context( 'Block Editor: Generate Audio', () => {
 			cy.openBeyondwordsEditorPanel();
 
 			// Sidebar checkbox should be checked via preselect
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 			// Open pre-publish panel
 			cy.get( '.editor-post-publish-button__button' ).click();
@@ -53,18 +51,14 @@ context( 'Block Editor: Generate Audio', () => {
 			// Preselect is applied via a useEffect, so the box starts unchecked
 			// for a tick before flipping on. Wait for it to settle, otherwise an
 			// uncheck races the effect and is undone.
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 			// Toggle the input directly — clicking the CheckboxControl label
 			// double-fires the change event and lands back on checked.
-			cy.getBlockEditorCheckbox( 'Generate audio' ).uncheck( {
+			cy.getGenerateAudioCheckbox().uncheck( {
 				force: true,
 			} );
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'not.be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
 			// Open pre-publish panel
 			cy.get( '.editor-post-publish-button__button' ).click();
@@ -88,9 +82,7 @@ context( 'Block Editor: Generate Audio', () => {
 				cy.openBeyondwordsEditorPanel();
 
 				// Sidebar checkbox should be checked via preselect
-				cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-					'be.checked'
-				);
+				cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 				// Open pre-publish panel
 				cy.get( '.editor-post-publish-button__button' ).click();
@@ -153,9 +145,7 @@ context( 'Block Editor: Generate Audio', () => {
 
 			cy.openBeyondwordsEditorPanel();
 
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'not.be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 		} );
 
 		it( 'saved generate_audio=0 is not overridden in pre-publish panel', () => {
@@ -176,9 +166,7 @@ context( 'Block Editor: Generate Audio', () => {
 				cy.openBeyondwordsEditorPanel();
 
 				// Sidebar should respect saved '0' despite preselect
-				cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-					'not.be.checked'
-				);
+				cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
 				// Open pre-publish panel — should also respect saved '0'
 				cy.get( '.editor-post-publish-button__button' ).click();
@@ -199,9 +187,7 @@ context( 'Block Editor: Generate Audio', () => {
 
 			// Default preselect for 'post' is mode 'all' → box shows checked
 			// (derived from the setting, not written to meta).
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 			cy.window().then( ( win ) => {
 				const editor = win.wp.data.select( 'core/editor' );
@@ -248,18 +234,14 @@ context( 'Block Editor: Generate Audio', () => {
 			setPreselect( {} ); // 'post' absent → off.
 			cy.createPost( { postType: { slug: 'post' } } );
 			cy.openBeyondwordsEditorPanel();
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'not.be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 		} );
 
 		it( 'All selected → Generate audio is preselected', () => {
 			setPreselect( { post: { mode: 'all' } } );
 			cy.createPost( { postType: { slug: 'post' } } );
 			cy.openBeyondwordsEditorPanel();
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 		} );
 
 		it( 'Terms selected → preselected only when the post has a matching term', () => {
@@ -270,9 +252,7 @@ context( 'Block Editor: Generate Audio', () => {
 			cy.openBeyondwordsEditorPanel();
 
 			// No matching term → not preselected.
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'not.be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
 			// Add the matching term → preselected.
 			cy.window().then( ( win ) => {
@@ -280,9 +260,7 @@ context( 'Block Editor: Generate Audio', () => {
 					.dispatch( 'core/editor' )
 					.editPost( { categories: [ newsId ] } );
 			} );
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 			// Remove it → not preselected (bidirectional).
 			cy.window().then( ( win ) => {
@@ -290,9 +268,7 @@ context( 'Block Editor: Generate Audio', () => {
 					.dispatch( 'core/editor' )
 					.editPost( { categories: [] } );
 			} );
-			cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-				'not.be.checked'
-			);
+			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 		} );
 	} );
 
@@ -319,9 +295,7 @@ context( 'Block Editor: Generate Audio', () => {
 				cy.openBeyondwordsEditorPanel();
 
 				// beyondwords_generate_audio=0 should take precedence
-				cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-					'not.be.checked'
-				);
+				cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 			} );
 		} );
 
@@ -342,9 +316,7 @@ context( 'Block Editor: Generate Audio', () => {
 				cy.openBeyondwordsEditorPanel();
 
 				// Should fall back to speechkit_generate_audio=1
-				cy.getBlockEditorCheckbox( 'Generate audio' ).should(
-					'be.checked'
-				);
+				cy.getGenerateAudioCheckbox().should( 'be.checked' );
 			} );
 		} );
 	} );

--- a/tests/cypress/e2e/block-editor/select-voice.cy.js
+++ b/tests/cypress/e2e/block-editor/select-voice.cy.js
@@ -22,7 +22,7 @@ context( 'Block Editor: Select Voice', () => {
 		'Multilingual v2',
 		'v3',
 		'Flash v2.5',
-		'Standard',
+		'Legacy',
 	];
 
 	// Only test priority post types
@@ -104,7 +104,7 @@ context( 'Block Editor: Select Voice', () => {
 					.should( 'have.text', 'English (British)' );
 				cy.getBlockEditorSelect( 'Model' )
 					.find( 'option:selected' )
-					.should( 'have.text', 'Standard' );
+					.should( 'have.text', 'Legacy' );
 				cy.getBlockEditorSelect( 'Voice' )
 					.find( 'option:selected' )
 					.should( 'have.text', 'Ollie (Multilingual)' );

--- a/tests/cypress/e2e/block-editor/settings-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/settings-panel.cy.js
@@ -134,7 +134,7 @@ context( 'Block Editor: Settings panel', () => {
 							'Multilingual v2',
 							'v3',
 							'Flash v2.5',
-							'Standard',
+							'Legacy',
 						] );
 					} );
 				cy.get( '.beyondwords--voice' ).should( 'not.exist' );

--- a/tests/cypress/e2e/classic-editor/select-voice.cy.js
+++ b/tests/cypress/e2e/classic-editor/select-voice.cy.js
@@ -70,7 +70,7 @@ context( 'Classic Editor: Select Voice', () => {
 							'Multilingual v2',
 							'v3',
 							'Flash v2.5',
-							'Standard',
+							'Legacy',
 						] );
 					} );
 
@@ -82,7 +82,7 @@ context( 'Classic Editor: Select Voice', () => {
 				);
 
 				// Standard model → only the non-ElevenLabs voices.
-				cy.get( 'select#beyondwords_model' ).select( 'Standard' );
+				cy.get( 'select#beyondwords_model' ).select( 'Legacy' );
 				cy.get( '#beyondwords-metabox-select-voice--voice-id' ).should(
 					'be.visible'
 				);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -218,8 +218,8 @@ Cypress.Commands.add( 'getSiteHealthValue', ( label, ...args ) => {
 } );
 
 // Use the className selector instead of the label text — the GenerateAudio
-// label flips between "Create" and "Update" based on whether the post
-// already has a beyondwords_content_id.
+// caption flips between "Generation enabled" and "Generation disabled" to
+// reflect the toggle state, so it can't be used to locate the control.
 const GENERATE_AUDIO_CHECKBOX =
 	'.beyondwords--generate-audio input[type="checkbox"]';
 const GENERATE_AUDIO_LABEL = '.beyondwords--generate-audio label';
@@ -350,6 +350,12 @@ Cypress.Commands.add( 'getBlockEditorCheckbox', ( text, ...args ) => {
 		.closest( '.beyondwords-toggle' )
 		.find( 'input[type="checkbox"]' )
 		.then( ( $el ) => cy.wrap( $el ) );
+} );
+
+// The GenerateAudio caption is state-reflecting ("Generation enabled/disabled"),
+// so locate its checkbox by the stable className rather than by label text.
+Cypress.Commands.add( 'getGenerateAudioCheckbox', () => {
+	return cy.get( GENERATE_AUDIO_CHECKBOX );
 } );
 
 Cypress.Commands.add( 'getBlockEditorSelect', ( text, ...args ) => {

--- a/tests/phpunit/editor/components/generate-audio/test-generate-audio.php
+++ b/tests/phpunit/editor/components/generate-audio/test-generate-audio.php
@@ -82,11 +82,12 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * 'all' mode needs no live JS — the server renders the initial state.
+     * 'all' mode still enqueues the script — the state-reflecting caption needs
+     * it — but carries no term-gating preselect payload.
      *
      * @test
      */
-    public function admin_enqueue_scripts_skips_for_all_mode()
+    public function admin_enqueue_scripts_enqueues_without_preselect_for_all_mode()
     {
         global $current_screen, $post;
         $current_screen = \WP_Screen::get('post');
@@ -99,7 +100,11 @@ class GenerateAudioTest extends TestCase
 
         GenerateAudio::admin_enqueue_scripts('post.php');
 
-        $this->assertFalse(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
+        $this->assertTrue(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
+
+        // No term-gating payload in 'all' mode.
+        $data = wp_scripts()->get_data('beyondwords-metabox--generate-audio', 'data');
+        $this->assertStringNotContainsString('beyondwordsPreselect', (string) $data);
 
         wp_delete_post($post->ID, true);
     }
@@ -131,11 +136,12 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * 'terms' mode with no usable terms has nothing to watch — skip the script.
+     * 'terms' mode with no usable terms still enqueues the script (for the
+     * caption) but adds no term-gating payload.
      *
      * @test
      */
-    public function admin_enqueue_scripts_skips_when_terms_empty()
+    public function admin_enqueue_scripts_enqueues_without_preselect_when_terms_empty()
     {
         global $current_screen, $post;
         $current_screen = \WP_Screen::get('post');
@@ -148,7 +154,10 @@ class GenerateAudioTest extends TestCase
 
         GenerateAudio::admin_enqueue_scripts('post.php');
 
-        $this->assertFalse(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
+        $this->assertTrue(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
+
+        $data = wp_scripts()->get_data('beyondwords-metabox--generate-audio', 'data');
+        $this->assertStringNotContainsString('beyondwordsPreselect', (string) $data);
 
         wp_delete_post($post->ID, true);
     }
@@ -388,6 +397,56 @@ class GenerateAudioTest extends TestCase
 
         $this->assertDoesNotMatchRegularExpression(
             '/id="beyondwords_generate_audio"[^>]*checked/s',
+            $html
+        );
+
+        delete_option('beyondwords_preselect');
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * The caption reads out the checked state and exposes both label variants
+     * as data attributes for classic-metabox.js to swap between when toggled.
+     *
+     * @test
+     */
+    public function element_caption_reflects_checked_state()
+    {
+        $post = self::factory()->post->create_and_get(['post_type' => 'post']);
+        update_option('beyondwords_preselect', ['post' => ['mode' => 'all']]);
+
+        $html = $this->capture_output(function () use ($post) {
+            GenerateAudio::element($post);
+        });
+
+        // Both label variants are exposed as data attributes.
+        $this->assertStringContainsString('data-label-enabled="Generation enabled"', $html);
+        $this->assertStringContainsString('data-label-disabled="Generation disabled"', $html);
+
+        // The rendered caption reads out the (checked) state.
+        $this->assertMatchesRegularExpression(
+            '/id="beyondwords-generate-audio-label"[^>]*>Generation enabled</s',
+            $html
+        );
+
+        delete_option('beyondwords_preselect');
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     */
+    public function element_caption_reads_disabled_when_unchecked()
+    {
+        $post = self::factory()->post->create_and_get(['post_type' => 'post']);
+        update_option('beyondwords_preselect', []);
+
+        $html = $this->capture_output(function () use ($post) {
+            GenerateAudio::element($post);
+        });
+
+        $this->assertMatchesRegularExpression(
+            '/id="beyondwords-generate-audio-label"[^>]*>Generation disabled</s',
             $html
         );
 

--- a/tests/phpunit/editor/components/select-voice/test-select-voice.php
+++ b/tests/phpunit/editor/components/select-voice/test-select-voice.php
@@ -97,7 +97,7 @@ class SelectVoiceTest extends TestCase
 
         $modelOptions = $crawler->filter('#beyondwords_model option')->each(fn ($node) => $node->text());
         $this->assertSame(
-            ['Select a model', 'Multilingual v2', 'v3', 'Flash v2.5', 'Standard'],
+            ['Select a model', 'Multilingual v2', 'v3', 'Flash v2.5', 'Legacy'],
             $modelOptions
         );
 
@@ -148,7 +148,7 @@ class SelectVoiceTest extends TestCase
 
         $modelOptions = $crawler->filter('#beyondwords_model option')->each(fn ($node) => $node->text());
         $this->assertSame(
-            ['Select a model', 'Multilingual v2', 'v3', 'Flash v2.5', 'Standard'],
+            ['Select a model', 'Multilingual v2', 'v3', 'Flash v2.5', 'Legacy'],
             $modelOptions
         );
         $this->assertSame(
@@ -260,7 +260,7 @@ class SelectVoiceTest extends TestCase
             array_column($models, 'key')
         );
         $this->assertSame(
-            ['Multilingual v2', 'Flash v2.5', 'v3', 'Standard'],
+            ['Multilingual v2', 'Flash v2.5', 'v3', 'Legacy'],
             array_column($models, 'label')
         );
 


### PR DESCRIPTION
## What

Minor relabelling of the block/classic editor settings:

1. **Post-level "Generate audio" toggle** (block + classic editor) now reads out its state — **"Generation enabled"** / **"Generation disabled"** — instead of the action-oriented "Generate audio" / "Update audio".
2. **Per-block control** in the block editor: inspector toggle **"Audio processing enabled/disabled" → "Generation enabled/disabled"**, and the block-toolbar button tooltip **"Enable/Disable audio processing" → "Enable/Disable generation"**.
3. **Model dropdown**: the **"Standard"** bucket label → **"Legacy"** (block editor, classic-editor localisation, and REST responses).

## Why

Makes the toggles read as state rather than an action (matching the per-block toggle's existing pattern), and renames the legacy voice model bucket to match product terminology.

## How

- Block-editor post toggle ([`generate-audio/index.js`](../blob/claude/angry-roentgen-c52f01/src/editor/components/generate-audio/index.js)) now derives its caption from the `checked` state; the `hasContent`/"Update audio" branch is removed.
- Classic-editor metabox ([`class-generate-audio.php`](../blob/claude/angry-roentgen-c52f01/src/editor/components/generate-audio/class-generate-audio.php)) renders the state caption in a `<label>` with `data-label-enabled/disabled` attributes. [`classic-metabox.js`](../blob/claude/angry-roentgen-c52f01/src/editor/components/generate-audio/classic-metabox.js) keeps that caption in step with the checkbox and now **always enqueues** for compatible post types (term-gated preselect data remains optional / `terms`-mode-only).
- Model label changed in `settings-panel/helpers.js`, `select-voice/class-assets.php`, `select-voice/class-select-voice.php` (and the `classic-metabox.js` fallback). **The internal `standard` bucket key is unchanged** — display label only.

## Tests

- **jest**: full suite passes (37/37); `helpers.test.js` label expectations updated.
- **PHPUnit**: `test-select-voice.php` label expectations → "Legacy"; `test-generate-audio.php` — the two "skips enqueue" tests now assert *always-enqueue-without-preselect*, plus new caption-rendering coverage.
- **Cypress**: the caption text now flips with state, so specs locate the checkbox via a new stable `getGenerateAudioCheckbox()` command instead of by label text; `'Standard'` → `'Legacy'` in the model-dropdown assertions.

Verified locally: `php -l` clean, `lint:js ./src` clean, jest green. Cypress specs couldn't be run in the worktree (needs wp-env) — a `cypress:run` on the affected block/classic editor specs is the final confirmation.

## Reviewer notes

- **`languages/speechkit.pot`** still lists the old strings — it's a generated artifact, so please run `composer translate` to pick up `Generation enabled/disabled`, `Enable/Disable generation`, and `Legacy`.
- Out-of-scope "Generate audio" strings were intentionally left as-is: the Preferences → *Preselect 'Generate audio'* settings field and the posts-list bulk action (different features, not the editor toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)