### PR TITLE
fix(video): send full video_settings payload so videos generate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,7 @@ Plugin version lives in two places — keep them in sync:
 - `BEYONDWORDS__PLUGIN_VERSION` constant in the same file
 - `version` in [package.json](package.json) (informational; npm publish is not used)
 
-Bump on any release. Pre-release versions use `7.0.0-dev-3.0` style (matches existing convention).
+Bump on any release. Pre-release versions use `7.0.0-dev-4.0` style (matches existing convention).
 
 ## Known issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-dev-3.0",
+  "version": "7.0.0-dev-4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beyondwords-wordpress-plugin",
-      "version": "7.0.0-dev-3.0",
+      "version": "7.0.0-dev-4.0",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/api-fetch": "^7.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-dev-3.0",
+  "version": "7.0.0-dev-4.0",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 7.0.0-dev-3.0
+Stable tag: 7.0.0-dev-4.0
 Requires at least: 5.9
 Requires PHP: 8.0
 Tested up to: 7.0

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare( strict_types = 1 );
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           7.0.0-dev-3.0
+ * Version:           7.0.0-dev-4.0
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -32,7 +32,7 @@ require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 // Define constants
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-dev-3.0');
+define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-dev-4.0');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable

--- a/src/core/class-uninstaller.php
+++ b/src/core/class-uninstaller.php
@@ -31,8 +31,17 @@ class Uninstaller {
 	public static function cleanup_plugin_transients(): int {
 		global $wpdb;
 
+		// Each transient is stored as a pair of options — `_transient_<key>` and
+		// `_transient_timeout_<key>` — so both prefixes must be swept, otherwise
+		// the timeout rows are left orphaned. (On external-object-cache hosts,
+		// e.g. VIP, there are no option rows to delete; those entries hold a TTL
+		// and self-expire.)
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-		$count = $wpdb->query( "DELETE FROM $wpdb->options WHERE `option_name` LIKE '_transient_beyondwords_%'" );
+		$count = $wpdb->query(
+			"DELETE FROM $wpdb->options
+			WHERE `option_name` LIKE '_transient_beyondwords_%'
+			OR `option_name` LIKE '_transient_timeout_beyondwords_%'"
+		);
 
 		return (int) $count;
 	}

--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -330,33 +330,11 @@ class Content {
 			}
 		}
 
-		// Output = Video or Audio + video → enable video generation. Video
-		// size filters the project's `sizes` array down to the user's pick.
+		// Output = Video or Audio + video → enable video generation.
 		$output = get_post_meta( $post_id, 'beyondwords_output', true );
 
 		if ( in_array( $output, [ 'video', 'audio_and_video' ], true ) ) {
-			$body['video_settings'] = [ 'enabled' => true ];
-
-			$video_template_id = intval(
-				get_post_meta( $post_id, 'beyondwords_video_template_id', true )
-			);
-
-			if ( $video_template_id > 0 ) {
-				$body['video_settings']['template'] = [
-					'id' => $video_template_id,
-				];
-			}
-
-			$video_size = get_post_meta( $post_id, 'beyondwords_video_size', true );
-
-			if ( $video_size ) {
-				$body['video_settings']['sizes'] = [
-					[
-						'name'    => (string) $video_size,
-						'enabled' => true,
-					],
-				];
-			}
+			$body['video_settings'] = self::get_video_settings_params( $post_id );
 		}
 
 		/**
@@ -371,6 +349,87 @@ class Content {
 		$body = apply_filters( 'beyondwords_content_params', $body, $post_id );
 
 		return (string) wp_json_encode( $body );
+	}
+
+	/**
+	 * Build the `video_settings` param sent to the BeyondWords content endpoint.
+	 *
+	 * Choosing "Video" (or "Audio + video") output opts a post into video
+	 * generation, overriding the project's default `video_settings.enabled`.
+	 *
+	 * The BeyondWords backend silently skips video generation unless the payload
+	 * carries `enabled: true` AND a non-empty `variants` array AND a non-empty
+	 * `sizes` array whose entries include `width`/`height`. Earlier versions sent
+	 * only `template.id` and `sizes[].name`/`enabled`, which left `variants` empty
+	 * server-side — so no video was ever produced.
+	 *
+	 * We mirror the BeyondWords dashboard, which sends the full object whenever a
+	 * user customises video: seed the payload from the project's default video
+	 * settings (fetched once and cached by the API client), then layer the post's
+	 * own choices on top — the chosen size becomes the only enabled size, and the
+	 * chosen video template overrides the project default. Anything the post
+	 * doesn't customise (variants, and the size dimensions) is echoed straight
+	 * from the project defaults.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int $post_id WordPress post ID.
+	 *
+	 * @return array<string, mixed> The `video_settings` param.
+	 */
+	private static function get_video_settings_params( int $post_id ): array {
+		// Fetch the defaults for the project this post publishes to — which may
+		// be a per-post override of the global project — so the variants and size
+		// dimensions match the project the content POST actually targets.
+		$project_id = \BeyondWords\Post\Meta::get_project_id( $post_id );
+		$defaults   = \BeyondWords\Api\Client::get_video_settings( is_numeric( $project_id ) ? (int) $project_id : null );
+		$defaults   = is_array( $defaults ) ? $defaults : [];
+
+		$settings = [ 'enabled' => true ];
+
+		// `variants` — echo the project defaults. The backend needs a non-empty
+		// list here or it skips generation, and the plugin exposes no per-post
+		// variant control, so the project default is the correct value to send.
+		if ( ! empty( $defaults['variants'] ) && is_array( $defaults['variants'] ) ) {
+			$settings['variants'] = array_values( $defaults['variants'] );
+		}
+
+		// `sizes` — echo the project's sizes (carrying the width/height the
+		// backend requires), toggling `enabled` to the post's chosen size when one
+		// is set, otherwise keeping each size's project default.
+		$video_size    = (string) get_post_meta( $post_id, 'beyondwords_video_size', true );
+		$default_sizes = ( isset( $defaults['sizes'] ) && is_array( $defaults['sizes'] ) ) ? $defaults['sizes'] : [];
+
+		$sizes = [];
+
+		foreach ( $default_sizes as $size ) {
+			if ( ! is_array( $size ) || ! isset( $size['name'] ) ) {
+				continue;
+			}
+
+			$sizes[] = [
+				'name'    => (string) $size['name'],
+				'width'   => (int) ( $size['width'] ?? 0 ),
+				'height'  => (int) ( $size['height'] ?? 0 ),
+				'enabled' => '' !== $video_size
+					? ( (string) $size['name'] === $video_size )
+					: (bool) ( $size['enabled'] ?? false ),
+			];
+		}
+
+		if ( ! empty( $sizes ) ) {
+			$settings['sizes'] = $sizes;
+		}
+
+		// `template` — the post's chosen video template, or omit to defer to the
+		// project default template.
+		$video_template_id = intval( get_post_meta( $post_id, 'beyondwords_video_template_id', true ) );
+
+		if ( $video_template_id > 0 ) {
+			$settings['template'] = [ 'id' => $video_template_id ];
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/tests/fixtures/wp-content/plugins/beyondwords-mock-rest-api-responses/mock-rest-api-responses.php
+++ b/tests/fixtures/wp-content/plugins/beyondwords-mock-rest-api-responses/mock-rest-api-responses.php
@@ -832,6 +832,7 @@ function beyondwords_mock_get_video_settings( $params ) {
 			'content_image_enabled'    => true,
 			'image_extraction_enabled' => true,
 			'pan_and_zoom_enabled'     => true,
+			'variants'                 => array( 'article', 'summary' ),
 			'sizes'                    => array(
 				array(
 					'name'        => 'landscape',
@@ -852,7 +853,7 @@ function beyondwords_mock_get_video_settings( $params ) {
 					'description' => '9:16',
 					'width'       => 1080,
 					'height'      => 1920,
-					'enabled'     => true,
+					'enabled'     => false,
 				),
 			),
 		)

--- a/tests/phpunit/core/test-uninstaller.php
+++ b/tests/phpunit/core/test-uninstaller.php
@@ -183,19 +183,32 @@ class UninstallerTest extends TestCase
         set_transient('beyondwords_voices_en', ['voice1'], 60);
         set_transient('unrelated_transient', 'keep-me', 60);
 
+        // Each expiring transient writes a value row AND a `_transient_timeout_`
+        // row; the cleanup must sweep both. Confirm the timeout rows exist up
+        // front so the post-cleanup assertion below isn't vacuous.
+        $timeoutsBefore = (int) $wpdb->get_var(
+            "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_beyondwords_%'"
+        );
+        $this->assertGreaterThanOrEqual(2, $timeoutsBefore);
+
         $count = Uninstaller::cleanup_plugin_transients();
 
         // The Uninstaller does a raw SQL delete; clear the object cache so the
         // next get_transient() reads from the database (not stale cache).
         wp_cache_flush();
 
-        $this->assertGreaterThanOrEqual(2, $count);
+        // 2 beyondwords transients × (value + timeout) = 4 rows deleted.
+        $this->assertGreaterThanOrEqual(4, $count);
 
+        // Neither the value rows nor the timeout rows should remain.
         $remaining = $wpdb->get_var(
-            "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_beyondwords_%'"
+            "SELECT COUNT(*) FROM {$wpdb->options}
+             WHERE option_name LIKE '_transient_beyondwords_%'
+                OR option_name LIKE '_transient_timeout_beyondwords_%'"
         );
         $this->assertSame('0', (string) $remaining);
 
+        // Unrelated transient (and its own timeout row) left untouched.
         $this->assertSame('keep-me', get_transient('unrelated_transient'));
 
         delete_transient('unrelated_transient');

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -10,11 +10,18 @@ class ContentTest extends TestCase
     {
         // Before...
         parent::setUp();
+
+        // A project id is required for Client::get_video_settings() (used when
+        // building the video_settings payload) to resolve a project and return
+        // the mocked defaults rather than false.
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
 
         // Then...
         parent::tearDown();
@@ -494,8 +501,19 @@ class ContentTest extends TestCase
 
         $this->assertArrayHasKey('video_settings', $body);
         $this->assertTrue($body['video_settings']['enabled']);
+
+        // The backend skips generation unless `variants` is non-empty, so we
+        // echo the project defaults.
+        $this->assertSame(['article', 'summary'], $body['video_settings']['variants']);
+
+        // The full project `sizes` are sent (each carrying width/height), with
+        // only the chosen size enabled.
         $this->assertSame(
-            [['name' => 'landscape', 'enabled' => true]],
+            [
+                ['name' => 'landscape', 'width' => 1920, 'height' => 1080, 'enabled' => true],
+                ['name' => 'square',    'width' => 1080, 'height' => 1080, 'enabled' => false],
+                ['name' => 'portrait',  'width' => 1080, 'height' => 1920, 'enabled' => false],
+            ],
             $body['video_settings']['sizes']
         );
 
@@ -510,6 +528,76 @@ class ContentTest extends TestCase
         $body = json_decode(Content::get_content_params($postId), true);
 
         $this->assertArrayNotHasKey('video_settings', $body);
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     *
+     * @group getContentParams
+     **/
+    public function get_content_params_video_settings_echo_project_defaults_when_no_size_picked()
+    {
+        $postId = self::factory()->post->create([
+            'post_title' => 'ContentTest::videoNoSizePicked',
+            'meta_input' => [
+                'beyondwords_output' => 'video',
+                // No beyondwords_video_size → "Project default".
+            ],
+        ]);
+
+        $body = json_decode(Content::get_content_params($postId), true);
+
+        $this->assertArrayHasKey('video_settings', $body);
+        $this->assertTrue($body['video_settings']['enabled']);
+        $this->assertSame(['article', 'summary'], $body['video_settings']['variants']);
+
+        // With no size chosen, each size keeps its project-default enabled flag.
+        $this->assertSame(
+            [
+                ['name' => 'landscape', 'width' => 1920, 'height' => 1080, 'enabled' => true],
+                ['name' => 'square',    'width' => 1080, 'height' => 1080, 'enabled' => true],
+                ['name' => 'portrait',  'width' => 1080, 'height' => 1920, 'enabled' => false],
+            ],
+            $body['video_settings']['sizes']
+        );
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     *
+     * @group getContentParams
+     *
+     * Regression test: the plugin previously sent a partial payload (only
+     * `enabled` + `template.id` + `sizes[].name`/`enabled`) which left `variants`
+     * empty server-side, so the BeyondWords backend silently skipped video
+     * generation. The full object must always carry non-empty `variants` and
+     * `sizes` whose entries include `width`/`height`.
+     **/
+    public function get_content_params_video_settings_always_carry_variants_and_sized_entries()
+    {
+        $postId = self::factory()->post->create([
+            'post_title' => 'ContentTest::videoRegression',
+            'meta_input' => [
+                'beyondwords_output' => 'audio_and_video',
+            ],
+        ]);
+
+        $video = json_decode(Content::get_content_params($postId), true)['video_settings'];
+
+        $this->assertTrue($video['enabled']);
+        $this->assertNotEmpty($video['variants']);
+        $this->assertNotEmpty($video['sizes']);
+
+        foreach ($video['sizes'] as $size) {
+            $this->assertArrayHasKey('name', $size);
+            $this->assertArrayHasKey('width', $size);
+            $this->assertArrayHasKey('height', $size);
+            $this->assertArrayHasKey('enabled', $size);
+        }
 
         wp_delete_post($postId, true);
     }


### PR DESCRIPTION
## Problem

Selecting **Video** or **Audio + video** output on a post was **not producing any video**. The plugin sent a *partial* `video_settings` object to `POST/PUT /projects/:id/content`:

```jsonc
// ❌ Before — what the plugin sent
{
  "enabled": true,
  "template": { "id": 123 },
  "sizes": [ { "name": "16:9", "enabled": true } ]
}
```

The BeyondWords backend **silently skips video generation** unless the payload has `enabled: true` **AND** a non-empty `variants` array **AND** a non-empty `sizes` array whose entries include `width`/`height`. Because the plugin never sent `variants` (and omitted `width`/`height`), the backend stored `variants: []` and generated nothing — no error was surfaced.

I confirmed this directly against the live API: posting the old partial payload results in `variants: []` and `video: []` (0 videos) even after processing completes.

## Fix

Mirror what the BeyondWords dashboard does when a user customises video in the sidebar: **send the full object**, seeded from the project's default video settings (`Client::get_video_settings()`, already cached for the editor UI) with the post's own choices layered on top.

`src/post/class-content.php` now builds `video_settings` in a dedicated `get_video_settings_params()` helper:

- **`enabled`** → always `true` (choosing Video output opts this post into video, overriding the project's default `enabled`).
- **`variants`** → echoed from the project defaults (the plugin exposes no per-post variant control, so the project default is the correct value). This is the field whose absence caused the bug.
- **`sizes`** → the project's full `sizes` array, each entry carrying `name`/`width`/`height`/`enabled`. When the post has a **Video size** chosen, that size becomes the only enabled one; otherwise each size keeps its project-default `enabled` flag.
- **`template.id`** → the post's chosen **Video template**, or omitted to defer to the project default.

The defaults are fetched for the **post's** project (`Meta::get_project_id()`), matching the project the content POST actually targets.

### The new object

```jsonc
// ✅ After — user picked size "16:9" and a video template
{
  "enabled": true,
  "variants": [ "article", "summary" ],
  "sizes": [
    { "name": "16:9", "width": 1280, "height": 720, "enabled": true  },
    { "name": "9:16", "width": 720,  "height": 1280, "enabled": false }
  ],
  "template": { "id": 123 }
}
```

```jsonc
// ✅ After — Output=Video with no size/template customisation (echoes project defaults)
{
  "enabled": true,
  "variants": [ "article", "summary" ],
  "sizes": [
    { "name": "16:9", "width": 1280, "height": 720, "enabled": true  },
    { "name": "9:16", "width": 720,  "height": 1280, "enabled": false }
  ]
}
```

When the user does **not** select Video output, `video_settings` is omitted entirely, exactly as before, so the backend keeps using the project defaults.

## Verification against the live API

I replicated the exact payload this code produces and posted it to the real API, then polled until `status: processed`:

| Payload | stored `variants` | videos generated |
| --- | --- | --- |
| Old partial (`enabled` + `template.id` + `sizes.name/enabled`) | `[]` | **0** ❌ |
| Full object, minus `variants` (isolating the cause) | `[]` | **0** ❌ |
| **New full object** (size picked + template) | `["article","summary"]` | **✅ video generated** |
| **New full object** (project defaults, no template) | `["article","summary"]` | **✅ video generated** |

The generated video honoured the payload: only the **enabled** `16:9` size was rendered (at `1280×720`, in HLS + MP4), the disabled `9:16` size was skipped, and the `summary` variant was gracefully skipped when the content had no summary. All throwaway test content was deleted afterwards.

## Tests

- Updated `get_content_params_enables_video_when_output_includes_video` to assert the full object (variants + full sized entries, only the picked size enabled).
- Added `get_content_params_video_settings_echo_project_defaults_when_no_size_picked` (no size chosen → each size keeps its project-default `enabled`).
- Added a regression test `get_content_params_video_settings_always_carry_variants_and_sized_entries` asserting `variants` is non-empty and every size carries `name`/`width`/`height`/`enabled`.
- Added `variants` to the video-settings mock (`beyondwords-mock-rest-api-responses`) to match the real API, and flipped one mock size to `enabled: false` to cover the enabled-flag echo path.

`ContentTest` (31 tests), plus `ClientTest`/`SettingsTest`/`UtilsTest`/`SettingsFieldsTest`/`InspectTest` all pass. `phpcs` passes on `src/`.

---

## Also in this PR — uninstall transient cleanup

This PR also closes a related gap in the uninstall cleanup. `Uninstaller::cleanup_plugin_transients()` deleted the `_transient_beyondwords_%` value rows but not the paired `_transient_timeout_beyondwords_%` rows — WordPress stores each expiring transient as **two** options, so the timeout rows were left orphaned on hosts without a persistent object cache. Harmless (tiny, non-autoloaded, unread) but untidy, and it affected all the plugin's API-cache transients, not just video settings.

The query now sweeps both prefixes. On external-object-cache hosts (e.g. VIP) transients aren't option rows at all — they carry a TTL and self-expire — so the query is correctly a no-op there. The existing `cleanup_plugin_transients` test is strengthened to assert the timeout rows exist before cleanup and that neither value nor timeout rows remain after. `UninstallerTest` (all tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

