### PR TITLE
fix(editor): replace Player block preview with a static placeholder

### DIFF
--- a/src/editor/components/add-player/index.js
+++ b/src/editor/components/add-player/index.js
@@ -3,15 +3,13 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps } from '@wordpress/block-editor';
-import { Disabled, Placeholder } from '@wordpress/components';
+import { Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { BeyondwordsIcon } from '../icon';
-import PlayAudio from '../play-audio';
-import { useHasPlayAudioAction } from '../play-audio/hooks';
 
 // Register the block
 registerBlockType( 'beyondwords/player', {
@@ -19,29 +17,19 @@ registerBlockType( 'beyondwords/player', {
 	edit: function Edit() {
 		const blockProps = useBlockProps();
 
-		// Mirror the sidebar Preview panel: render a live (but non-interactive)
-		// player once the post has everything the player needs, otherwise a
-		// placeholder describing where the player will appear.
-		const canPreview = useHasPlayAudioAction();
-
+		// The live player is not embedded in the editor preview — it only
+		// renders on the front end. Show a static Placeholder marking where
+		// the player will appear in the published post.
 		return (
 			<div { ...blockProps }>
-				{ canPreview ? (
-					// <Disabled> keeps the player visible and rendered but
-					// non-interactive, so the block stays selectable/movable.
-					<Disabled>
-						<PlayAudio />
-					</Disabled>
-				) : (
-					<Placeholder
-						icon={ <BeyondwordsIcon /> }
-						label={ __( 'BeyondWords', 'speechkit' ) }
-						instructions={ __(
-							'The BeyondWords audio player will appear here.',
-							'speechkit'
-						) }
-					/>
-				) }
+				<Placeholder
+					icon={ <BeyondwordsIcon /> }
+					label={ __( 'BeyondWords Player', 'speechkit' ) }
+					instructions={ __(
+						'The BeyondWords audio player will appear here.',
+						'speechkit'
+					) }
+				/>
 			</div>
 		);
 	},

--- a/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
+++ b/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
@@ -34,9 +34,8 @@ context( 'Block Editor: Insert BeyondWords Player', () => {
 						.insertBlocks( block );
 				} );
 
-				// The block renders either a live (disabled) player preview or a
-				// Placeholder depending on post state, so assert on the block
-				// wrapper, which is present in both cases.
+				// The block renders a static Placeholder (no live player is
+				// embedded in the editor), so assert on the block wrapper.
 				cy.getEditorCanvasBody()
 					.find( '.wp-block-beyondwords-player' )
 					.should( 'have.length', 1 );

--- a/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
+++ b/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
@@ -34,11 +34,34 @@ context( 'Block Editor: Insert BeyondWords Player', () => {
 						.insertBlocks( block );
 				} );
 
-				// The block renders a static Placeholder (no live player is
-				// embedded in the editor), so assert on the block wrapper.
+				// The block renders a static core Placeholder describing where
+				// the player will appear — assert on its label and instructions.
 				cy.getEditorCanvasBody()
 					.find( '.wp-block-beyondwords-player' )
 					.should( 'have.length', 1 );
+
+				cy.getEditorCanvasBody()
+					.find(
+						'.wp-block-beyondwords-player .components-placeholder__label'
+					)
+					.should( 'contain', 'BeyondWords Player' );
+
+				cy.getEditorCanvasBody()
+					.find(
+						'.wp-block-beyondwords-player .components-placeholder__instructions'
+					)
+					.should(
+						'contain',
+						'The BeyondWords audio player will appear here.'
+					);
+
+				// Guard against regressing to an in-editor live player preview:
+				// the block must not embed the player box in the editor canvas.
+				cy.getEditorCanvasBody()
+					.find(
+						'.wp-block-beyondwords-player .beyondwords-player-box-wrapper'
+					)
+					.should( 'not.exist' );
 
 				cy.publishWithConfirmation();
 				cy.viewPostViaSnackbar();


### PR DESCRIPTION
## What & why

Embedding a live BeyondWords player inside the **block editor preview** was causing problems, so this stops rendering the live player there entirely and replaces it with a static core `Placeholder`.

The `beyondwords/player` block's `edit` component now unconditionally renders:

```
[BeyondWords logo]  BeyondWords Player
The BeyondWords audio player will appear here.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
