### PR TITLE
fix: prevent stored XSS via Content ID in classic editor player embed

### DIFF
--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -219,31 +219,54 @@ class Metabox {
 		$content_id    = \BeyondWords\Post\Meta::get_content_id( $post->ID );
 		$preview_token = \BeyondWords\Post\Meta::get_preview_token( $post->ID );
 
-        // phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		/*
+		 * Build the player SDK config as a PHP array, then JSON-encode it for the
+		 * inline `onload` handler instead of concatenating the values by hand.
+		 *
+		 * The Content ID is editable post meta (Meta::get_content_id) and the
+		 * preview token is supplied by the REST API, so both are untrusted in this
+		 * output context. The HEX flags escape ' " < > & inside every string value
+		 * as \uXXXX, so a value cannot break out of the JS string literal, the
+		 * single-quoted attribute, or the surrounding <script> markup; the
+		 * structural JSON quotes are left intact so the spread object literal stays
+		 * valid JavaScript, and esc_attr() below encodes those for the attribute.
+		 * Mirrors \BeyondWords\Player\Renderer\Javascript::render().
+		 */
+		$config = [
+			'projectId'        => (int) $project_id,
+			'previewToken'     => (string) $preview_token,
+			'adverts'          => [],
+			'analyticsConsent' => 'none',
+			'introsOutros'     => [],
+			'playerStyle'      => 'small',
+			'widgetStyle'      => 'none',
+		];
+
+		if ( ! empty( $content_id ) ) {
+			$config['contentId'] = (string) $content_id;
+		} else {
+			$config['sourceId'] = (string) $post->ID;
+		}
+
+		$onload = sprintf(
+			'const player = new BeyondWords.Player({ target: this.parentElement, ...%s });',
+			wp_json_encode(
+				$config,
+				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			)
+		);
+
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		?>
 		<div id="beyondwords-metabox-player" style="margin: 13px 0;">
 		<script defer
 			src='<?php echo esc_url( \BeyondWords\Core\Urls::get_js_sdk_url() ); ?>'
-			onload='const player = new BeyondWords.Player({
-				target: this.parentElement,
-				projectId: <?php echo esc_attr( $project_id ); ?>,
-				<?php if ( ! empty( $content_id ) ) : ?>
-				contentId: "<?php echo esc_attr( $content_id ); ?>",
-				<?php else : ?>
-				sourceId: "<?php echo esc_attr( $post->ID ); ?>",
-				<?php endif; ?>
-				previewToken: "<?php echo esc_attr( $preview_token ); ?>",
-				adverts: [],
-				analyticsConsent: "none",
-				introsOutros: [],
-				playerStyle: "small",
-				widgetStyle: "none",
-			});'
+			onload='<?php echo esc_attr( $onload ); ?>'
 		>
 		</script>
 		</div>
 		<?php
-        // phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 
 	/**

--- a/tests/phpunit/editor/classic/test-metabox.php
+++ b/tests/phpunit/editor/classic/test-metabox.php
@@ -161,6 +161,65 @@ class MetaboxTest extends TestCase
     }
 
     /**
+     * A crafted Content ID must not break out of the inline player onload handler.
+     *
+     * Regression test for a stored XSS. The Content ID is editable post meta,
+     * saved with only sanitize_text_field() (which keeps double quotes), and was
+     * emitted into the `onload` JS string with esc_attr(). esc_attr() encodes `"`
+     * as `&quot;`, but the browser HTML-decodes the attribute before compiling the
+     * handler, so `&quot;` became a real `"` that closed the JS string literal and
+     * ran the rest of the value as code. player_embed() now JSON-encodes the
+     * config with the HEX flags, so an injected quote is hex-encoded and stays
+     * inside the string literal instead of closing it.
+     *
+     * @test
+     */
+    public function player_embed_neutralises_content_id_xss()
+    {
+        $payload = '"});alert(document.domain);({"';
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'MetaboxTest::player_embed_neutralises_content_id_xss',
+        ]);
+
+        // Set the meta after creation so no save_post handler can overwrite the
+        // payload before we render — this keeps the assertions meaningful.
+        update_post_meta($postId, 'beyondwords_project_id', 12345);
+        update_post_meta($postId, 'beyondwords_content_id', $payload);
+
+        $html = $this->capture_output(function () use ($postId) {
+            Metabox::player_embed($postId);
+        });
+
+        $crawler = new Crawler($html);
+
+        // The injected markup must not spawn extra elements: exactly one player <script>.
+        $script = $crawler->filter('#beyondwords-metabox-player script');
+        $this->assertCount(1, $script);
+
+        // Crawler::attr() returns the HTML-decoded attribute — exactly what the
+        // browser hands to the JS engine when the onload handler fires.
+        $onload = $script->attr('onload');
+
+        // The Content ID is still passed to the player, but wp_json_encode() has
+        // hex-encoded its quotes so they stay inside the JS string literal. Assert
+        // the exact encoded value (structural quotes included) is present verbatim.
+        $encoded = wp_json_encode(
+            $payload,
+            JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+        );
+        $this->assertStringContainsString($encoded, $onload);
+
+        // The raw break-out sequence (a bare " closing the string) must be absent.
+        $this->assertStringNotContainsString('"});alert(document.domain)', $onload);
+
+        // The player is still initialised with the real (decoded) Content ID value.
+        $this->assertStringContainsString('new BeyondWords.Player(', $onload);
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
      * @test
      * @dataProvider errors_provider
      */


### PR DESCRIPTION
## Summary

Fixes a **stored XSS** in the classic-editor BeyondWords metabox. `Metabox::player_embed()` rendered the audio-preview player by hand-concatenating the **Content ID** (and preview token) into an inline `onload='...'` JS string escaped only with `esc_attr()`.

`esc_attr()` encodes `"` as `&quot;`, but the browser HTML-decodes an attribute value **before** compiling the event handler — so the decoded `"` closed the JS string literal and ran the remainder of the value as code.

The Content ID is editable post meta, saved by `ContentId::save()` with only `sanitize_text_field()` (which does **not** strip double quotes). So a user with `edit_post` could set the Data → Content ID field to:

```
"});alert(document.domain);({"
```

That non-empty value makes `Meta::has_content()` return `true`, so on the next classic-editor render `player_embed()` emitted the payload into the `onload` handler and it executed in the wp-admin session of **any** user (including higher-privileged Editors/Administrators) who later opened that post — a persistent admin-side XSS / privilege-escalation vector.

## The fix

`src/editor/classic/class-metabox.php` — build the player config as a PHP array and emit it via `wp_json_encode()` with `JSON_HEX_QUOT | JSON_HEX_APOS | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES`, wrapped in `esc_attr()`:

- The HEX flags escape `' " < > &` inside every string value as `\uXXXX`, so a value cannot break out of the JS string literal, the single-quoted attribute, or the surrounding `<script>` markup.
- The structural JSON quotes stay intact, so the spread object literal remains valid JavaScript; `esc_attr()` then encodes those for the HTML attribute.

This is **defense-in-depth** and a direct mirror of the plugin's own already-vetted frontend renderer, `Player\Renderer\Javascript::render()`. Runtime behaviour (target element, integer `projectId`, `contentId`/`sourceId` branch, preview token, static player options) is unchanged. No `phpcs:ignore` was added.

## Verification

- **End-to-end browser simulation** — generated the real escaped HTML in PHP, then HTML-decoded and `eval`'d it in Node as a browser would: `alert()` never fires, the payload lands as an inert `contentId` **string**, `projectId` stays a number.
- **PHPCS** — clean (`WordPress-VIP-Go` ruleset, full `src/`, 44 files, 0 violations).
- **PHPUnit** — full `MetaboxTest` suite green (**12 tests, 64 assertions**), including the `render_meta_box_content` cases that render the player through `player_embed()` (no behavioral regression).
- **Regression test** — added `MetaboxTest::player_embed_neutralises_content_id_xss`, confirmed to **fail on the pre-fix code and pass on the fix**.

## Reviewer notes

- `previewToken` flows through the same sink and is now equally hardened, though it is API-supplied rather than directly attacker-controlled. `projectId`/`sourceId` were always integers and were never independently exploitable.
- The change is intentionally minimal and idiomatic — it reuses the exact `wp_json_encode(... HEX flags ...) + esc_attr()` pattern already established for the front-end player, rather than introducing a new escaping approach.
