### PR TITLE
fix: enforce per-post edit_post capability in bulk audio handlers

### DIFF
--- a/src/posts-list/class-bulk-edit.php
+++ b/src/posts-list/class-bulk-edit.php
@@ -264,6 +264,29 @@ class BulkEdit {
 			$redirect
 		);
 
+		// Only operate on posts the current user is actually allowed to edit. Core
+		// routes custom bulk actions through this filter after only a coarse
+		// edit_posts check, so without this per-post guard a crafted request could
+		// force (billable) audio generation on another author's posts. Mirrors the
+		// capability filter in save_bulk_edit().
+		$object_ids = array_values(
+			array_filter(
+				$object_ids,
+				static fn( $post_id ): bool => current_user_can( 'edit_post', $post_id )
+			)
+		);
+
+		// A capable user may still have selected only posts they cannot edit; treat
+		// that as a clean no-op reporting a zero count.
+		if ( empty( $object_ids ) ) {
+			$redirect = add_query_arg( 'beyondwords_bulk_generated', 0, $redirect );
+			$redirect = add_query_arg( 'beyondwords_bulk_failed', 0, $redirect );
+
+			$nonce = wp_create_nonce( 'beyondwords_bulk_edit_result' );
+
+			return add_query_arg( 'beyondwords_bulk_edit_result_nonce', $nonce, $redirect );
+		}
+
 		sort( $object_ids );
 
 		$generated = 0;
@@ -314,6 +337,28 @@ class BulkEdit {
 			],
 			$redirect
 		);
+
+		// Only operate on posts the current user is actually allowed to edit. Core
+		// routes custom bulk actions through this filter after only a coarse
+		// edit_posts check, so without this per-post guard a crafted request could
+		// remotely delete audio and wipe plugin meta on another author's posts.
+		// Mirrors the capability filter in save_bulk_edit().
+		$object_ids = array_values(
+			array_filter(
+				$object_ids,
+				static fn( $post_id ): bool => current_user_can( 'edit_post', $post_id )
+			)
+		);
+
+		// Bail before the remote batch-delete when nothing editable remains, so an
+		// empty selection cannot trigger an API call (or the BULK-NO-RESPONSE error).
+		if ( empty( $object_ids ) ) {
+			$redirect = add_query_arg( 'beyondwords_bulk_deleted', 0, $redirect );
+
+			$nonce = wp_create_nonce( 'beyondwords_bulk_edit_result' );
+
+			return add_query_arg( 'beyondwords_bulk_edit_result_nonce', $nonce, $redirect );
+		}
 
 		sort( $object_ids );
 

--- a/tests/phpunit/posts-list/test-bulk-edit.php
+++ b/tests/phpunit/posts-list/test-bulk-edit.php
@@ -24,6 +24,11 @@ final class BulkEditTest extends TestCase
         // Your tear down methods here.
         unset($_POST, $_REQUEST);
 
+        // The redirect handlers gate on current_user_can( 'edit_post', ... ), so
+        // several tests log a user in. Reset it so state cannot leak into sibling
+        // test classes.
+        wp_set_current_user(0);
+
         // Then...
         parent::tearDown();
     }
@@ -149,6 +154,10 @@ final class BulkEditTest extends TestCase
      */
     public function handle_bulk_generate_action()
     {
+        // The handler now filters $object_ids by current_user_can( 'edit_post' ),
+        // so run as an administrator who can edit every selected post.
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
         // Set up API credentials for integration test
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
@@ -232,6 +241,10 @@ final class BulkEditTest extends TestCase
      */
     public function handle_bulk_generate_action_with_no_api_credentials()
     {
+        // The handler now filters $object_ids by current_user_can( 'edit_post' ),
+        // so run as an administrator who can edit every selected post.
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
         // Test error handling when API credentials are missing
         // This tests the failure path where posts cannot be generated
 
@@ -276,5 +289,244 @@ final class BulkEditTest extends TestCase
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);
         }
+    }
+
+    /**
+     * A user with `edit_posts` may still lack `edit_post` for an individual post
+     * they do not own. Core routes custom bulk actions through this filter after
+     * only the coarse edit_posts gate, so the redirect-based generate handler must
+     * itself drop posts the user cannot edit — only the editable post is flagged
+     * for generation and counted. Mirrors the AJAX coverage in test-bulk-edit-ajax.php.
+     *
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_generate_action_skips_posts_the_user_cannot_edit()
+    {
+        $authorId      = self::factory()->user->create(['role' => 'author']);
+        $otherAuthorId = self::factory()->user->create(['role' => 'author']);
+
+        wp_set_current_user($authorId);
+
+        $ownPostId = self::factory()->post->create([
+            'post_author' => $authorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::generate-skip::own',
+        ]);
+
+        $otherPostId = self::factory()->post->create([
+            'post_author' => $otherAuthorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::generate-skip::other',
+        ]);
+
+        // Intercept the create-audio request with a benign success so generation
+        // completes hermetically, without a real network call.
+        $mockHttp = function () {
+            return [
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'body'     => '{}',
+                'headers'  => [],
+                'cookies'  => [],
+            ];
+        };
+        add_filter('pre_http_request', $mockHttp, 10, 3);
+
+        $redirect = BulkEdit::handle_bulk_generate_action(
+            'https://example.com/wp-admin/edit.php',
+            'beyondwords_generate_audio',
+            [$ownPostId, $otherPostId]
+        );
+
+        remove_filter('pre_http_request', $mockHttp, 10);
+
+        // Only the editable post is flagged for generation.
+        $this->assertSame('1', get_post_meta($ownPostId, 'beyondwords_generate_audio', true));
+        $this->assertEmpty(get_post_meta($otherPostId, 'beyondwords_generate_audio', true));
+
+        // generated + failed counts only the one editable post.
+        $query = parse_url($redirect, PHP_URL_QUERY);
+        parse_str($query, $args);
+        $this->assertEquals(
+            1,
+            (int)$args['beyondwords_bulk_generated'] + (int)$args['beyondwords_bulk_failed']
+        );
+
+        wp_delete_post($ownPostId, true);
+        wp_delete_post($otherPostId, true);
+    }
+
+    /**
+     * When the per-post filter removes every selected post, the generate handler
+     * must be a clean no-op: a zero count, no post mutated, and no API request.
+     *
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_generate_action_is_a_noop_when_no_editable_posts_remain()
+    {
+        $authorId      = self::factory()->user->create(['role' => 'author']);
+        $otherAuthorId = self::factory()->user->create(['role' => 'author']);
+
+        wp_set_current_user($authorId);
+
+        $otherPostId = self::factory()->post->create([
+            'post_author' => $otherAuthorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::generate-noop::other',
+        ]);
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this no-op test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $redirect = BulkEdit::handle_bulk_generate_action(
+            'https://example.com/wp-admin/edit.php',
+            'beyondwords_generate_audio',
+            [$otherPostId]
+        );
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $query = parse_url($redirect, PHP_URL_QUERY);
+        parse_str($query, $args);
+
+        $this->assertEquals(0, $args['beyondwords_bulk_generated']);
+        $this->assertEquals(0, $args['beyondwords_bulk_failed']);
+        $this->assertArrayHasKey('beyondwords_bulk_edit_result_nonce', $args);
+        $this->assertFalse($httpAttempted, 'No API request should be made when no editable posts remain.');
+        $this->assertEmpty(get_post_meta($otherPostId, 'beyondwords_generate_audio', true));
+
+        wp_delete_post($otherPostId, true);
+    }
+
+    /**
+     * On the delete branch the per-post `edit_post` filter must drop posts the
+     * user cannot edit, so the API batch-delete request only ever carries the
+     * editable post's content — and only that post's meta is cleared.
+     *
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_delete_action_skips_posts_the_user_cannot_edit()
+    {
+        $authorId      = self::factory()->user->create(['role' => 'author']);
+        $otherAuthorId = self::factory()->user->create(['role' => 'author']);
+
+        wp_set_current_user($authorId);
+
+        $ownPostId = self::factory()->post->create([
+            'post_author' => $authorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::delete-skip::own',
+        ]);
+        update_post_meta($ownPostId, 'beyondwords_project_id', 12345);
+        update_post_meta($ownPostId, 'beyondwords_content_id', 'own-content-aaa');
+
+        $otherPostId = self::factory()->post->create([
+            'post_author' => $otherAuthorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::delete-skip::other',
+        ]);
+        update_post_meta($otherPostId, 'beyondwords_project_id', 12345);
+        update_post_meta($otherPostId, 'beyondwords_content_id', 'other-content-bbb');
+
+        $requests = [];
+        $mockHttp = function ($preempt, $args, $url) use (&$requests) {
+            if (str_contains($url, '/content/batch_delete')) {
+                $requests[] = $args['body'] ?? '';
+                return [
+                    'response' => ['code' => 200, 'message' => 'OK'],
+                    'body'     => '{}',
+                    'headers'  => [],
+                    'cookies'  => [],
+                ];
+            }
+
+            return $preempt;
+        };
+        add_filter('pre_http_request', $mockHttp, 10, 3);
+
+        $redirect = BulkEdit::handle_bulk_delete_action(
+            'https://example.com/wp-admin/edit.php',
+            'beyondwords_delete_audio',
+            [$ownPostId, $otherPostId]
+        );
+
+        remove_filter('pre_http_request', $mockHttp, 10);
+
+        // Exactly one batch-delete request, carrying only the editable post's content.
+        $this->assertCount(1, $requests);
+        $this->assertStringContainsString('own-content-aaa', $requests[0]);
+        $this->assertStringNotContainsString('other-content-bbb', $requests[0]);
+
+        // Only the editable post's meta is cleared; the other post is untouched.
+        $this->assertSame('', get_post_meta($ownPostId, 'beyondwords_content_id', true));
+        $this->assertSame('other-content-bbb', get_post_meta($otherPostId, 'beyondwords_content_id', true));
+
+        // The redirect reports exactly one deleted post.
+        $query = parse_url($redirect, PHP_URL_QUERY);
+        parse_str($query, $args);
+        $this->assertEquals(1, $args['beyondwords_bulk_deleted']);
+
+        wp_delete_post($ownPostId, true);
+        wp_delete_post($otherPostId, true);
+    }
+
+    /**
+     * When the per-post filter removes every selected post, the delete handler
+     * must be a clean no-op: a zero count, no API request, and — critically — no
+     * BULK-NO-RESPONSE error from handing an empty batch to the API.
+     *
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_delete_action_is_a_noop_when_no_editable_posts_remain()
+    {
+        $authorId      = self::factory()->user->create(['role' => 'author']);
+        $otherAuthorId = self::factory()->user->create(['role' => 'author']);
+
+        wp_set_current_user($authorId);
+
+        $otherPostId = self::factory()->post->create([
+            'post_author' => $otherAuthorId,
+            'post_status' => 'publish',
+            'post_title'  => 'BulkEditTest::delete-noop::other',
+        ]);
+        update_post_meta($otherPostId, 'beyondwords_project_id', 12345);
+        update_post_meta($otherPostId, 'beyondwords_content_id', 'noop-content-id');
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this no-op test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $redirect = BulkEdit::handle_bulk_delete_action(
+            'https://example.com/wp-admin/edit.php',
+            'beyondwords_delete_audio',
+            [$otherPostId]
+        );
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $query = parse_url($redirect, PHP_URL_QUERY);
+        parse_str($query, $args);
+
+        // Zero deleted, no error surfaced, and no API request attempted.
+        $this->assertEquals(0, $args['beyondwords_bulk_deleted']);
+        $this->assertArrayNotHasKey('beyondwords_bulk_error', $args);
+        $this->assertFalse($httpAttempted, 'No API delete should be attempted when no editable posts remain.');
+        $this->assertSame('noop-content-id', get_post_meta($otherPostId, 'beyondwords_content_id', true));
+
+        wp_delete_post($otherPostId, true);
     }
 }


### PR DESCRIPTION
## Summary

The redirect-based bulk actions in `src/posts-list/class-bulk-edit.php` mutated and remotely deleted BeyondWords audio **without a per-post capability check**, allowing a low-privilege user to act on posts they cannot edit.

`handle_bulk_generate_action()` and `handle_bulk_delete_action()` are wired to the `handle_bulk_actions-edit-{post_type}` filter. WordPress core routes custom bulk actions through that filter after only `check_admin_referer('bulk-posts')` and the **coarse** `current_user_can($ptype->cap->edit_posts)` gate at the top of `edit.php` — it never checks per-post `edit_post` for custom actions (only for built-ins like trash). Both handlers then acted on every submitted ID.

The AJAX sibling `save_bulk_edit()` in the same class already filters IDs by `current_user_can('edit_post', $id)` (with a comment explaining exactly this risk); the redirect handlers omitted the equivalent guard.

## Impact

A Contributor or Author (both hold `edit_posts`, so they can load `edit.php` and read the `bulk-posts` nonce from their own list-table form) could craft:

```
edit.php?action=beyondwords_delete_audio&post[]=<another-author's-post-ID>&_wpnonce=<their-bulk-posts-nonce>
```

Core `intval()`s the IDs and passes them straight to the filter. The result was a privilege-boundary violation on content the user cannot edit:

- **Delete**: a remote batch-delete to the BeyondWords API + wipe of all ~38 `beyondwords_*`/`speechkit_*` meta keys per post (irreversible).
- **Generate**: `beyondwords_generate_audio` meta writes + billable API generation/regeneration.

The list-table UI hides checkboxes for uneditable posts, but the crafted request bypasses that.

## Fix

At the top of both handlers, filter the IDs exactly like the AJAX path:

```php
$object_ids = array_values(
    array_filter(
        $object_ids,
        static fn( $post_id ): bool => current_user_can( 'edit_post', $post_id )
    )
);
```

…and bail with a zero-count redirect when nothing editable remains. On the delete path this also prevents handing an empty batch to the API (which would otherwise surface a spurious `BULK-NO-RESPONSE` error).

## Tests

`tests/phpunit/posts-list/test-bulk-edit.php`:

- **Added 4 tests** for the per-post filtering on both redirect handlers — a "skips posts the user cannot edit" case (author vs. another author's published post; asserts only the editable post is flagged/deleted and, for delete, that the API request carries only the editable post's content) and a "no-op when no editable posts remain" case (zero count, no API request) for each.
- **Fixed 2 existing integration tests** that invoked the handlers as user 0 — now correctly rejected by the new gate — to run as an administrator, plus a `wp_set_current_user(0)` reset in `tearDown`.

## Verification

- `npm run phpcs` (WordPress-VIP-Go): **clean**, no `phpcs:ignore` added.
- PHPUnit `--filter BulkEdit`: **27 tests, 110 assertions, all pass** (4 new tests, 2 fixed integration tests, and all existing AJAX-path coverage). Full Cypress suite not run.

## Reviewer notes

- This closes the redirect-handler gap so it matches the guard the AJAX path already had. Nonce verification is still handled upstream by core's `check_admin_referer('bulk-posts')`, so no nonce change was needed here.
- Behaviour for a normal capable user (e.g. an editor/admin selecting posts they can edit) is unchanged.
