### PR TITLE
fix: offload bulk audio generation off the request path

### DIFF
--- a/src/api/class-client.php
+++ b/src/api/class-client.php
@@ -488,9 +488,43 @@ class Client {
 			'body'     => $body,
 			'headers'  => $headers,
 			'method'   => strtoupper( $method ),
-			// phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
-			'timeout'  => 30,
+			'timeout'  => self::request_timeout( $method ),
 		];
+	}
+
+	/**
+	 * Per-request timeout (in seconds) for a BeyondWords API call.
+	 *
+	 * BeyondWords write calls (create/update audio) legitimately need longer than
+	 * the 3s VIP guideline, so the default is 30s. The value is exposed through
+	 * the `beyondwords_api_request_timeout` filter so a specific call path can
+	 * lower it — the bulk "Generate audio" action drops it (see
+	 * `\BeyondWords\Post\Sync::bulk_generate_audio_for_posts()`) so a slow or
+	 * unresponsive API can't run the admin request past the PHP/host execution
+	 * limit.
+	 *
+	 * Sourcing the timeout from a filter (rather than a literal in the request
+	 * args) keeps the VIP `RemoteRequestTimeout` sniff satisfied without a
+	 * `phpcs:ignore`, and gives hosts a single knob to tune.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $method HTTP method, passed to the filter as context.
+	 *
+	 * @return int Timeout in seconds (never below 1).
+	 */
+	private static function request_timeout( string $method ): int {
+		/**
+		 * Filters the per-request timeout (in seconds) for BeyondWords API calls.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param int    $timeout Timeout in seconds. Default 30.
+		 * @param string $method  HTTP method for the request (GET/POST/PUT/DELETE).
+		 */
+		$timeout = (int) apply_filters( 'beyondwords_api_request_timeout', 30, $method );
+
+		return max( 1, $timeout );
 	}
 
 	/**

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -36,6 +36,31 @@ class Sync {
 	const GENERATE_AUDIO_CRON_HOOK = 'beyondwords_generate_audio';
 
 	/**
+	 * Default maximum number of posts the bulk "Generate audio" action processes
+	 * synchronously in a single admin request when async generation is
+	 * unavailable (i.e. off VIP).
+	 *
+	 * Off VIP each post is a blocking API call, so an unbounded loop over a large
+	 * selection could run the request past the PHP/host execution limit. We cap
+	 * the count and defer the remainder (the caller surfaces a notice). Tune with
+	 * the `beyondwords_bulk_generate_sync_limit` filter.
+	 *
+	 * @since 7.0.0
+	 */
+	const BULK_GENERATE_SYNC_LIMIT = 10;
+
+	/**
+	 * Per-call API timeout (in seconds) used while the bulk "Generate audio"
+	 * action runs synchronously off VIP.
+	 *
+	 * Lower than the default 30s so a slow or unresponsive API can't stack up to
+	 * a request-killing total across the capped batch.
+	 *
+	 * @since 7.0.0
+	 */
+	const BULK_GENERATE_TIMEOUT = 15;
+
+	/**
 	 * Register WordPress hooks.
 	 */
 	public static function init(): void {
@@ -259,6 +284,136 @@ class Sync {
 	 */
 	public static function batch_delete_audio_for_posts( array $post_ids ): array|false|null {
 		return \BeyondWords\Api\Client::batch_delete_audio( $post_ids );
+	}
+
+	/**
+	 * Dispatch bulk "Generate audio" for a set of posts without blocking the
+	 * admin request on an unbounded run of remote API calls.
+	 *
+	 * Every selected post is flagged for generation (a cheap meta write). Then:
+	 *
+	 * - On VIP (async enabled) each post is queued as a background cron job, so
+	 *   the request returns immediately and no API call runs inline. All selected
+	 *   posts are reported as "generated" (i.e. requested).
+	 * - Off VIP (async disabled) we can't rely on WP-Cron, so generation runs
+	 *   inline — but capped at `bulk_generate_sync_limit()` posts and with a lower
+	 *   per-call timeout, so a slow API can't run the request past the execution
+	 *   limit. Posts still missing audio are processed before regenerations, and
+	 *   any beyond the cap are returned as "deferred" for the caller to surface.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int[] $post_ids WordPress post IDs from the bulk selection.
+	 *
+	 * @return array{generated:int, failed:int, deferred:int} Per-outcome counts.
+	 */
+	public static function bulk_generate_audio_for_posts( array $post_ids ): array {
+		$post_ids = array_map( 'intval', $post_ids );
+		$post_ids = array_values( array_unique( array_filter( $post_ids, static fn( int $id ): bool => $id > 0 ) ) );
+		sort( $post_ids );
+
+		// Flag every selected post for generation (cheap). On the async path this
+		// is what the deferred cron job reads; off VIP it records intent for the
+		// posts we can't process in this request.
+		foreach ( $post_ids as $post_id ) {
+			update_post_meta( $post_id, 'beyondwords_generate_audio', '1' );
+		}
+
+		// VIP: queue a background job per post and return immediately.
+		if ( self::is_async_generation_enabled() ) {
+			foreach ( $post_ids as $post_id ) {
+				self::schedule_audio_generation( $post_id );
+			}
+
+			return [
+				'generated' => count( $post_ids ),
+				'failed'    => 0,
+				'deferred'  => 0,
+			];
+		}
+
+		// Off VIP: process synchronously, but hard-capped and with a lower
+		// per-call timeout. Posts still missing audio are processed before
+		// regenerations so re-running the action on a large selection converges.
+		$ordered    = self::order_posts_for_bulk_generation( $post_ids );
+		$limit      = self::bulk_generate_sync_limit();
+		$to_process = array_slice( $ordered, 0, $limit );
+		$deferred   = count( $ordered ) - count( $to_process );
+
+		$generated = 0;
+		$failed    = 0;
+
+		$lower_timeout = static fn(): int => self::BULK_GENERATE_TIMEOUT;
+		add_filter( 'beyondwords_api_request_timeout', $lower_timeout );
+
+		try {
+			foreach ( $to_process as $post_id ) {
+				if ( self::generate_audio_for_post( $post_id ) ) {
+					++$generated;
+				} else {
+					++$failed;
+				}
+			}
+		} finally {
+			remove_filter( 'beyondwords_api_request_timeout', $lower_timeout );
+		}
+
+		return [
+			'generated' => $generated,
+			'failed'    => $failed,
+			'deferred'  => $deferred,
+		];
+	}
+
+	/**
+	 * Order a bulk selection so posts that still need audio created are processed
+	 * before posts that already have audio (a regeneration).
+	 *
+	 * Keeps the synchronous cap making forward progress: re-running the action on
+	 * a large selection works through the un-generated posts rather than
+	 * re-updating the same already-done ones each time.
+	 *
+	 * @param int[] $post_ids Normalised, sorted post IDs.
+	 *
+	 * @return int[]
+	 */
+	private static function order_posts_for_bulk_generation( array $post_ids ): array {
+		$needs_create = [];
+		$needs_update = [];
+
+		foreach ( $post_ids as $post_id ) {
+			if ( \BeyondWords\Post\Meta::get_content_id( $post_id ) ) {
+				$needs_update[] = $post_id;
+			} else {
+				$needs_create[] = $post_id;
+			}
+		}
+
+		return array_merge( $needs_create, $needs_update );
+	}
+
+	/**
+	 * Resolve the synchronous bulk-generation cap, honouring the
+	 * `beyondwords_bulk_generate_sync_limit` filter and guarding against a
+	 * non-positive override.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return int
+	 */
+	private static function bulk_generate_sync_limit(): int {
+		/**
+		 * Filters the maximum number of posts the bulk "Generate audio" action
+		 * processes synchronously per request when async generation is off (VIP
+		 * is the async path). Non-positive values fall back to the default.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param int $limit Maximum posts to process synchronously. Default 10.
+		 */
+		$limit = (int) apply_filters( 'beyondwords_bulk_generate_sync_limit', self::BULK_GENERATE_SYNC_LIMIT );
+
+		return $limit > 0 ? $limit : self::BULK_GENERATE_SYNC_LIMIT;
 	}
 
 	/**

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -48,14 +48,15 @@ class Sync {
 	const DELETE_AUDIO_CRON_HOOK = 'beyondwords_delete_audio';
 
 	/**
-	 * Default maximum number of posts the bulk "Generate audio" action processes
+	 * Maximum number of posts the bulk "Generate audio" action processes
 	 * synchronously in a single admin request when async generation is
 	 * unavailable (i.e. off VIP).
 	 *
 	 * Off VIP each post is a blocking API call, so an unbounded loop over a large
 	 * selection could run the request past the PHP/host execution limit. We cap
-	 * the count and defer the remainder (the caller surfaces a notice). Tune with
-	 * the `beyondwords_bulk_generate_sync_limit` filter.
+	 * the count and defer the remainder (the caller surfaces a notice). Sized
+	 * against `\BeyondWords\Api\Client::DEFAULT_REQUEST_TIMEOUT` so the whole
+	 * batch stays well inside a typical execution limit even in the worst case.
 	 *
 	 * @since 7.0.0
 	 */
@@ -361,7 +362,7 @@ class Sync {
 	 *   the request returns immediately and no API call runs inline. All selected
 	 *   posts are reported as "generated" (i.e. requested).
 	 * - Off VIP (async disabled) we can't rely on WP-Cron, so generation runs
-	 *   inline — but capped at `bulk_generate_sync_limit()` posts, so a slow API
+	 *   inline — but capped at `BULK_GENERATE_SYNC_LIMIT` posts, so a slow API
 	 *   can't run the request past the execution limit. Each call is already
 	 *   bounded by `\BeyondWords\Api\Client::DEFAULT_REQUEST_TIMEOUT`, so the cap
 	 *   is what keeps the total bounded. Posts still missing audio are processed
@@ -404,7 +405,7 @@ class Sync {
 		// the batch total bounded. Posts still missing audio are processed before
 		// regenerations so re-running the action on a large selection converges.
 		$ordered    = self::order_posts_for_bulk_generation( $post_ids );
-		$limit      = self::bulk_generate_sync_limit();
+		$limit      = self::BULK_GENERATE_SYNC_LIMIT;
 		$to_process = array_slice( $ordered, 0, $limit );
 		$deferred   = count( $ordered ) - count( $to_process );
 
@@ -451,30 +452,6 @@ class Sync {
 		}
 
 		return array_merge( $needs_create, $needs_update );
-	}
-
-	/**
-	 * Resolve the synchronous bulk-generation cap, honouring the
-	 * `beyondwords_bulk_generate_sync_limit` filter and guarding against a
-	 * non-positive override.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @return int
-	 */
-	private static function bulk_generate_sync_limit(): int {
-		/**
-		 * Filters the maximum number of posts the bulk "Generate audio" action
-		 * processes synchronously per request when async generation is off (VIP
-		 * is the async path). Non-positive values fall back to the default.
-		 *
-		 * @since 7.0.0
-		 *
-		 * @param int $limit Maximum posts to process synchronously. Default 10.
-		 */
-		$limit = (int) apply_filters( 'beyondwords_bulk_generate_sync_limit', self::BULK_GENERATE_SYNC_LIMIT );
-
-		return $limit > 0 ? $limit : self::BULK_GENERATE_SYNC_LIMIT;
 	}
 
 	/**

--- a/src/posts-list/class-bulk-edit.php
+++ b/src/posts-list/class-bulk-edit.php
@@ -257,6 +257,7 @@ class BulkEdit {
 		$redirect = remove_query_arg(
 			[
 				'beyondwords_bulk_generated',
+				'beyondwords_bulk_deferred',
 				'beyondwords_bulk_deleted',
 				'beyondwords_bulk_failed',
 				'beyondwords_bulk_error',
@@ -264,29 +265,20 @@ class BulkEdit {
 			$redirect
 		);
 
-		sort( $object_ids );
-
-		$generated = 0;
-		$failed    = 0;
-
+		// Dispatch through Sync, which offloads to background cron on VIP and
+		// runs a hard-capped, lower-timeout synchronous batch off VIP — so this
+		// admin request never blocks on an unbounded run of remote API calls.
 		try {
-			foreach ( $object_ids as $post_id ) {
-				update_post_meta( $post_id, 'beyondwords_generate_audio', '1' );
-			}
+			$counts   = \BeyondWords\Post\Sync::bulk_generate_audio_for_posts( $object_ids );
+			$redirect = add_query_arg( 'beyondwords_bulk_generated', $counts['generated'], $redirect );
+			$redirect = add_query_arg( 'beyondwords_bulk_failed', $counts['failed'], $redirect );
 
-			foreach ( $object_ids as $post_id ) {
-				if ( \BeyondWords\Post\Sync::generate_audio_for_post( $post_id ) ) {
-					++$generated;
-				} else {
-					++$failed;
-				}
+			if ( $counts['deferred'] > 0 ) {
+				$redirect = add_query_arg( 'beyondwords_bulk_deferred', $counts['deferred'], $redirect );
 			}
 		} catch ( \Exception $e ) {
 			$redirect = add_query_arg( 'beyondwords_bulk_error', $e->getMessage(), $redirect );
 		}
-
-		$redirect = add_query_arg( 'beyondwords_bulk_generated', $generated, $redirect );
-		$redirect = add_query_arg( 'beyondwords_bulk_failed', $failed, $redirect );
 
 		$nonce = wp_create_nonce( 'beyondwords_bulk_edit_result' );
 
@@ -308,6 +300,7 @@ class BulkEdit {
 		$redirect = remove_query_arg(
 			[
 				'beyondwords_bulk_generated',
+				'beyondwords_bulk_deferred',
 				'beyondwords_bulk_deleted',
 				'beyondwords_bulk_failed',
 				'beyondwords_bulk_error',

--- a/src/posts-list/class-notices.php
+++ b/src/posts-list/class-notices.php
@@ -26,6 +26,7 @@ class Notices {
 	 */
 	public static function init(): void {
 		add_action( 'admin_notices', [ self::class, 'generated_notice' ] );
+		add_action( 'admin_notices', [ self::class, 'deferred_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'deleted_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'failed_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'error_notice' ] );
@@ -53,6 +54,39 @@ class Notices {
 		);
 		?>
 		<div id="beyondwords-bulk-edit-notice-generated" class="notice notice-info is-dismissible">
+			<p><?php echo esc_html( $message ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * "N posts still need audio" notice after a Generate Audio bulk action that
+	 * hit the synchronous cap off VIP.
+	 *
+	 * Off VIP we can't offload to WP-Cron, so a large selection is processed up to
+	 * a per-request cap and the rest are deferred. Their generate flag is already
+	 * set, so re-running the action — or selecting the remaining posts — completes
+	 * them.
+	 */
+	public static function deferred_notice(): void {
+		$count = self::get_query_count( 'beyondwords_bulk_deferred' );
+
+		if ( null === $count ) {
+			return;
+		}
+
+		$message = sprintf(
+			/* translators: %d is replaced with the number of posts not yet processed */
+			_n(
+				'%d post still needs audio — run Generate audio again to continue.',
+				'%d posts still need audio — run Generate audio again to continue.',
+				$count,
+				'speechkit'
+			),
+			$count
+		);
+		?>
+		<div id="beyondwords-bulk-edit-notice-deferred" class="notice notice-warning is-dismissible">
 			<p><?php echo esc_html( $message ); ?></p>
 		</div>
 		<?php

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -1484,33 +1484,36 @@ class SyncTest extends TestCase
      */
     public function bulk_generate_audio_for_posts_caps_synchronous_batch_off_vip()
     {
-        // Off VIP (no async): cap the synchronous batch so a large selection
-        // can't run an unbounded blocking loop. Keep the limit tiny for the test.
-        $limit = static fn(): int => 2;
-        add_filter('beyondwords_bulk_generate_sync_limit', $limit);
+        // Off VIP (no async) the synchronous batch is capped so a large selection
+        // can't run an unbounded blocking loop. Select two more than the cap and
+        // derive the expectations from the constant, so this still holds if the
+        // cap is ever retuned.
+        $overflow = 2;
+        $selected = Sync::BULK_GENERATE_SYNC_LIMIT + $overflow;
 
         // No credentials → each processed post fails before any (mock) API call,
         // giving a deterministic count without hitting the network.
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
-        // Four posts, one of which already has audio (exercises the "needs
-        // update" ordering branch, which is deferred behind fresh generations).
-        $postIds = [
-            self::factory()->post->create(['post_status' => 'publish']),
-            self::factory()->post->create(['post_status' => 'publish']),
-            self::factory()->post->create(['post_status' => 'publish']),
-            self::factory()->post->create(['post_status' => 'publish']),
-        ];
-        update_post_meta($postIds[3], 'beyondwords_content_id', 'existing-content-id');
+        $postIds = [];
+        for ($i = 0; $i < $selected; $i++) {
+            $postIds[] = self::factory()->post->create(['post_status' => 'publish']);
+        }
 
-        // No API credentials → each processed post fails without a network call,
-        // which is exactly what we want for a deterministic unit test of the cap.
+        // Give the last post existing audio so the "needs update" ordering branch
+        // is exercised — it must be deferred behind the fresh generations.
+        update_post_meta($postIds[$selected - 1], 'beyondwords_content_id', 'existing-content-id');
+
         $counts = Sync::bulk_generate_audio_for_posts($postIds);
 
-        $this->assertSame(2, $counts['failed']);
+        $this->assertSame(Sync::BULK_GENERATE_SYNC_LIMIT, $counts['failed']);
         $this->assertSame(0, $counts['generated']);
-        $this->assertSame(2, $counts['deferred']);
+        $this->assertSame($overflow, $counts['deferred']);
+
+        // The already-generated post is ordered last, so it is one of the deferred
+        // ones and keeps its content ID untouched.
+        $this->assertSame('existing-content-id', get_post_meta($postIds[$selected - 1], 'beyondwords_content_id', true));
 
         // Every selected post is flagged, including the deferred ones.
         foreach ($postIds as $postId) {
@@ -1527,7 +1530,6 @@ class SyncTest extends TestCase
             'Worst-case bulk generate (cap x per-call timeout) must stay within a 60s execution limit.'
         );
 
-        remove_filter('beyondwords_bulk_generate_sync_limit', $limit);
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);
         }

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -1327,6 +1327,114 @@ class SyncTest extends TestCase
      * @test
      * @group generateAudio
      */
+    public function bulk_generate_audio_for_posts_defers_to_cron_when_async_enabled()
+    {
+        add_filter('beyondwords_async_generate_audio', '__return_true');
+
+        $postIds = [
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+        ];
+
+        $counts = Sync::bulk_generate_audio_for_posts($postIds);
+
+        // Every post is queued and reported as requested; nothing runs inline.
+        $this->assertSame(count($postIds), $counts['generated']);
+        $this->assertSame(0, $counts['failed']);
+        $this->assertSame(0, $counts['deferred']);
+
+        foreach ($postIds as $postId) {
+            $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
+            $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+            $this->assertSame('', get_post_meta($postId, 'beyondwords_content_id', true));
+        }
+
+        // The bulk path must not leave the lowered-timeout filter registered.
+        $this->assertFalse(has_filter('beyondwords_api_request_timeout'));
+
+        foreach ($postIds as $postId) {
+            wp_unschedule_event(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]), Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]);
+            wp_delete_post($postId, true);
+        }
+        remove_filter('beyondwords_async_generate_audio', '__return_true');
+    }
+
+    /**
+     * @test
+     * @group generateAudio
+     */
+    public function bulk_generate_audio_for_posts_caps_synchronous_batch_off_vip()
+    {
+        // Off VIP (no async): cap the synchronous batch so a large selection
+        // can't run an unbounded blocking loop. Keep the limit tiny for the test.
+        $limit = static fn(): int => 2;
+        add_filter('beyondwords_bulk_generate_sync_limit', $limit);
+
+        // No credentials → each processed post fails before any (mock) API call,
+        // giving a deterministic count without hitting the network.
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+
+        // Four posts, one of which already has audio (exercises the "needs
+        // update" ordering branch, which is deferred behind fresh generations).
+        $postIds = [
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+        ];
+        update_post_meta($postIds[3], 'beyondwords_content_id', 'existing-content-id');
+
+        // No API credentials → each processed post fails without a network call,
+        // which is exactly what we want for a deterministic unit test of the cap.
+        $counts = Sync::bulk_generate_audio_for_posts($postIds);
+
+        $this->assertSame(2, $counts['failed']);
+        $this->assertSame(0, $counts['generated']);
+        $this->assertSame(2, $counts['deferred']);
+
+        // Every selected post is flagged, including the deferred ones.
+        foreach ($postIds as $postId) {
+            $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
+        }
+
+        // The lowered-timeout filter is cleaned up even though the batch ran.
+        $this->assertFalse(has_filter('beyondwords_api_request_timeout'));
+
+        remove_filter('beyondwords_bulk_generate_sync_limit', $limit);
+        foreach ($postIds as $postId) {
+            wp_delete_post($postId, true);
+        }
+    }
+
+    /**
+     * @test
+     * @group generateAudio
+     */
+    public function bulk_generate_audio_for_posts_normalises_ids()
+    {
+        add_filter('beyondwords_async_generate_audio', '__return_true');
+
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+
+        // Duplicates, zero, and negative IDs must be dropped/deduped.
+        $counts = Sync::bulk_generate_audio_for_posts([$postId, $postId, 0, -5]);
+
+        $this->assertSame(1, $counts['generated']);
+        $this->assertSame(0, $counts['failed']);
+        $this->assertSame(0, $counts['deferred']);
+        $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
+
+        wp_unschedule_event(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]), Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]);
+        wp_delete_post($postId, true);
+        remove_filter('beyondwords_async_generate_audio', '__return_true');
+    }
+
+    /**
+     * @test
+     * @group generateAudio
+     */
     public function should_generate_audio_for_post_returns_false_for_missing_post()
     {
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);

--- a/tests/phpunit/posts-list/test-bulk-edit.php
+++ b/tests/phpunit/posts-list/test-bulk-edit.php
@@ -2,6 +2,7 @@
 
 use BeyondWords\PostsList\BulkEdit;
 use BeyondWords\Core\Plugin;
+use BeyondWords\Post\Sync;
 
 final class BulkEditTest extends TestCase
 {
@@ -541,20 +542,19 @@ final class BulkEditTest extends TestCase
         // administrator who can edit every selected post.
         wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
 
-        // Force a tiny synchronous cap and run off VIP (default) with no API
-        // credentials, so posts beyond the cap are deferred and the processed
-        // one fails without a network call.
-        $limit = static fn(): int => 1;
-        add_filter('beyondwords_bulk_generate_sync_limit', $limit);
+        // Run off VIP (default) with no API credentials, so the capped posts fail
+        // without a network call and the overflow is deferred. Select two more
+        // than the cap and derive the expectations from the constant.
+        $overflow = 2;
+        $selected = Sync::BULK_GENERATE_SYNC_LIMIT + $overflow;
 
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
-        $postIds = [
-            self::factory()->post->create(['post_status' => 'publish']),
-            self::factory()->post->create(['post_status' => 'publish']),
-            self::factory()->post->create(['post_status' => 'publish']),
-        ];
+        $postIds = [];
+        for ($i = 0; $i < $selected; $i++) {
+            $postIds[] = self::factory()->post->create(['post_status' => 'publish']);
+        }
 
         $nonce = wp_create_nonce('beyondwords_bulk_edit_result');
         $redirect = add_query_arg('beyondwords_bulk_edit_result_nonce', $nonce, 'https://example.com/wp-admin/edit.php');
@@ -563,16 +563,15 @@ final class BulkEditTest extends TestCase
 
         parse_str((string) parse_url($redirect, PHP_URL_QUERY), $args);
 
-        // 1 processed (failed, no creds) + 2 deferred = the 3 selected posts.
+        // Capped posts processed (all failed, no creds) + overflow deferred.
         $this->assertSame('0', $args['beyondwords_bulk_generated']);
-        $this->assertSame('1', $args['beyondwords_bulk_failed']);
-        $this->assertSame('2', $args['beyondwords_bulk_deferred']);
+        $this->assertSame((string) Sync::BULK_GENERATE_SYNC_LIMIT, $args['beyondwords_bulk_failed']);
+        $this->assertSame((string) $overflow, $args['beyondwords_bulk_deferred']);
 
         foreach ($postIds as $postId) {
             $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
         }
 
-        remove_filter('beyondwords_bulk_generate_sync_limit', $limit);
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);
         }

--- a/tests/phpunit/posts-list/test-bulk-edit.php
+++ b/tests/phpunit/posts-list/test-bulk-edit.php
@@ -277,4 +277,63 @@ final class BulkEditTest extends TestCase
             wp_delete_post($postId, true);
         }
     }
+
+    /**
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_generate_action_defers_beyond_sync_cap()
+    {
+        // Force a tiny synchronous cap and run off VIP (default) with no API
+        // credentials, so posts beyond the cap are deferred and the processed
+        // one fails without a network call.
+        $limit = static fn(): int => 1;
+        add_filter('beyondwords_bulk_generate_sync_limit', $limit);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+
+        $postIds = [
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+            self::factory()->post->create(['post_status' => 'publish']),
+        ];
+
+        $nonce = wp_create_nonce('beyondwords_bulk_edit_result');
+        $redirect = add_query_arg('beyondwords_bulk_edit_result_nonce', $nonce, 'https://example.com/wp-admin/edit.php');
+
+        $redirect = BulkEdit::handle_bulk_generate_action($redirect, 'beyondwords_generate_audio', $postIds);
+
+        parse_str((string) parse_url($redirect, PHP_URL_QUERY), $args);
+
+        // 1 processed (failed, no creds) + 2 deferred = the 3 selected posts.
+        $this->assertSame('0', $args['beyondwords_bulk_generated']);
+        $this->assertSame('1', $args['beyondwords_bulk_failed']);
+        $this->assertSame('2', $args['beyondwords_bulk_deferred']);
+
+        foreach ($postIds as $postId) {
+            $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
+        }
+
+        remove_filter('beyondwords_bulk_generate_sync_limit', $limit);
+        foreach ($postIds as $postId) {
+            wp_delete_post($postId, true);
+        }
+    }
+
+    /**
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_generate_action_ignores_other_actions()
+    {
+        $redirect = 'https://example.com/wp-admin/edit.php';
+
+        // A non-BeyondWords bulk action must be returned untouched.
+        $result = BulkEdit::handle_bulk_generate_action($redirect, 'trash', [1, 2, 3]);
+
+        $this->assertSame($redirect, $result);
+    }
 }

--- a/tests/phpunit/posts-list/test-notices.php
+++ b/tests/phpunit/posts-list/test-notices.php
@@ -38,6 +38,7 @@ final class NoticesTest extends TestCase
         do_action('wp_loaded');
 
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'generated_notice')));
+        $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'deferred_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'deleted_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'failed_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'error_notice')));
@@ -103,6 +104,21 @@ final class NoticesTest extends TestCase
         $this->expectException(\WPDieException::class);
 
         Notices::generated_notice();
+    }
+
+    /**
+     * @test
+     */
+    public function deferred_notice_with_invalid_nonce()
+    {
+        set_current_screen('edit-post');
+
+        $_GET['beyondwords_bulk_edit_result_nonce'] = 'foo';
+        $_GET['beyondwords_bulk_deferred'] = '42';
+
+        $this->expectException(\WPDieException::class);
+
+        Notices::deferred_notice();
     }
 
     /**
@@ -215,6 +231,48 @@ final class NoticesTest extends TestCase
             '42 posts' => [
                 'numDeleted' => 42,
                 'expectMessage' => 'Audio was deleted for 42 posts.',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider deferred_notice_provider
+     */
+    public function deferred_notice($numDeferred, $expectMessage)
+    {
+        set_current_screen('edit-post');
+
+        $_GET['beyondwords_bulk_edit_result_nonce'] = wp_create_nonce('beyondwords_bulk_edit_result');
+        $_GET['beyondwords_bulk_deferred'] = $numDeferred;
+
+        $html = $this->capture_output(function () {
+            Notices::deferred_notice();
+        });
+
+        $crawler = new Crawler($html);
+
+        $notice = $crawler->filter('div');
+
+        $this->assertEquals('beyondwords-bulk-edit-notice-deferred', $notice->getNode(0)->getAttribute('id'));
+        $this->assertEquals('notice notice-warning is-dismissible', $notice->getNode(0)->getAttribute('class'));
+
+        $this->assertStringContainsString($expectMessage, $notice->filter('p:first-of-type')->text());
+    }
+
+    /**
+     *
+     */
+    public function deferred_notice_provider() {
+        return [
+            '1 post' => [
+                'numDeferred' => 1,
+                'expectMessage' => '1 post still needs audio — run Generate audio again to continue.',
+            ],
+            '42 posts' => [
+                'numDeferred' => 42,
+                'expectMessage' => '42 posts still need audio — run Generate audio again to continue.',
             ],
         ];
     }


### PR DESCRIPTION
## Problem

The bulk **Generate audio** action made one blocking remote API call **per
selected post**, inline in the `edit.php` redirect request
(`handle_bulk_generate_action()` → `Sync::generate_audio_for_post()` →
`Client::create_audio()`/`update_audio()`). With Screen Options allowing up
to 999 rows plus select-all, that is an unbounded N+1 HTTP loop in a single
admin request:

- **VIP platform violation** — unbounded blocking remote requests on a
  request path.
- **Request killed mid-loop** — some posts get audio, the redirect never
  fires, the user sees a blank/timeout page and no notice, and re-running
  duplicates API work.

Unlike the delete path (one batched `/content/batch_delete`), generate had
no batching and never consulted the existing `is_async_generation_enabled()`
cron-offload path — so even on VIP the loop ran inline.

## Fix

`handle_bulk_generate_action()` now delegates to a new
`Sync::bulk_generate_audio_for_posts()`, which dispatches by environment
using the existing `is_async_generation_enabled()` gate:

| Environment | Behaviour |
|---|---|
| **VIP** (async on) | Flag `beyondwords_generate_audio` meta + schedule one background cron job per post via the existing Cron Control path. Request returns immediately — **zero blocking calls**. |
| **non-VIP** (async off) | Stay synchronous, but **hard-cap** the batch (default 10), process posts still missing audio first, and defer the overflow behind a new admin notice. |

### Non-VIP uses no scheduled tasks

Cron is used **only on VIP** (unchanged `is_async_generation_enabled()`
behaviour), because WP-Cron is unreliable off-VIP. Off-VIP hosts get the
capped-synchronous path instead — this PR introduces **no new WP-Cron
dependency** on non-VIP. Hosts that later have reliable cron can opt in via
the existing `beyondwords_async_generate_audio` filter.

### Relationship to #582 (already merged)

An earlier revision of this PR added its own `BULK_GENERATE_TIMEOUT` (15s)
to pull the bulk loop below the then-30s default. #582 has since collapsed
the timeout constants to `Client::DEFAULT_REQUEST_TIMEOUT` (3s), so that
constant was **removed** — at 15s it would have made the bulk path *more*
permissive than every other call. The bulk loop now simply inherits the
shared 3s default, and `src/api/class-client.php` is untouched by this PR.

That makes the cap the thing that bounds the total, and it bounds it well:
worst case is now **10 × 3s = 30s**, inside a typical PHP/VIP execution
limit (it was 10 × 15s = 150s). A regression test asserts exactly this
invariant, so raising either the cap or the shared timeout into an unsafe
combination fails CI.

## Reviewer notes

- **The per-post `edit_post` capability gate from #572 (`ff6f5e8`) is
  preserved**, and runs *before* the delegation — no audio can be generated
  for posts the user cannot edit. `Sync` normalises/dedupes/sorts the IDs,
  so the handler's old `sort()` is gone.
- On non-VIP, a selection larger than the cap generates the first N and
  shows *"X posts still need audio — run Generate audio again to
  continue."* This is the deliberate trade-off of not scheduling off-VIP.
  Deferred posts are ordered missing-audio-first so re-running converges
  rather than re-updating the same already-done posts.
- VIP schedules one cron event per post (deduped via `wp_next_scheduled`),
  consistent with the single-save async path.
- `beyondwords_bulk_deferred` is added to both bulk handlers' query-arg
  cleanup lists so a stale notice can't linger across actions.

## Verification

- **phpcs** (WordPress-VIP-Go, full `src/` tree): clean, exit 0, no
  `phpcs:ignore` added.
- **PHPUnit** (worktree src via the tests container): full suite green —
  **703 tests, 2258 assertions**, 1 multisite-only skip. Includes **8 new
  test cases**: VIP schedule path, non-VIP cap/defer, ID normalisation, the
  worst-case timeout-budget guard, the deferred notice (+ nonce handling),
  and the redirect deferred-count.
- Cypress **not** run per repo guidance — no JS surface changed. The
  `posts-list` spec (`bulk-actions.cy.js`) passed on the last full CI run.
