### PR TITLE
fix: validate Content ID charset to block API path/query injection

### DIFF
--- a/src/api/class-client.php
+++ b/src/api/class-client.php
@@ -125,7 +125,7 @@ class Client {
 			return false;
 		}
 
-		$url = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, $content_id );
+		$url = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, rawurlencode( (string) $content_id ) );
 
 		return self::call_api( 'GET', $url );
 	}
@@ -170,7 +170,7 @@ class Client {
 			return false;
 		}
 
-		$url      = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, $content_id );
+		$url      = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, rawurlencode( (string) $content_id ) );
 		$body     = \BeyondWords\Post\Content::get_content_params( $post_id );
 		$response = self::call_api( 'PUT', $url, $body, $post_id );
 
@@ -192,7 +192,7 @@ class Client {
 			return false;
 		}
 
-		$url      = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, $content_id );
+		$url      = sprintf( '%s/projects/%d/content/%s', \BeyondWords\Core\Urls::get_api_url(), $project_id, rawurlencode( (string) $content_id ) );
 		$response = self::call_api( 'DELETE', $url, '', $post_id );
 
 		if ( 204 !== wp_remote_retrieve_response_code( $response ) ) {

--- a/src/editor/components/content-id/class-content-id.php
+++ b/src/editor/components/content-id/class-content-id.php
@@ -117,10 +117,15 @@ class ContentId {
 		}
 
 		if ( isset( $_POST['beyondwords_content_id'] ) ) {
+			// Content IDs are interpolated into BeyondWords API URL paths, so they
+			// need a stricter charset than sanitize_text_field() alone allows —
+			// see \BeyondWords\Post\Meta::sanitize_content_id().
 			update_post_meta(
 				$post_id,
 				'beyondwords_content_id',
-				sanitize_text_field( wp_unslash( $_POST['beyondwords_content_id'] ) )
+				\BeyondWords\Post\Meta::sanitize_content_id(
+					sanitize_text_field( wp_unslash( $_POST['beyondwords_content_id'] ) )
+				)
 			);
 		}
 

--- a/src/post/class-meta.php
+++ b/src/post/class-meta.php
@@ -180,6 +180,34 @@ class Meta {
 	}
 
 	/**
+	 * Sanitize a BeyondWords Content ID.
+	 *
+	 * Content IDs are BeyondWords-issued numeric IDs or UUIDs, so the only valid
+	 * characters are alphanumerics and hyphens — the same `[a-zA-Z0-9\-]+` charset
+	 * the plugin's own inspect REST route enforces. Anything outside that set is
+	 * rejected (blanked) rather than stored, because the Content ID is later
+	 * interpolated into BeyondWords API URL paths in \BeyondWords\Api\Client, where
+	 * characters such as `/`, `.`, `?`, `#` and `&` would let a crafted value steer
+	 * an authenticated, organization-API-key-scoped request to an attacker-chosen
+	 * endpoint (path/query injection).
+	 *
+	 * Used both directly by the classic-editor save handler and as the
+	 * `sanitize_callback` for the `beyondwords_content_id` post meta, so the
+	 * block-editor / REST write path is validated identically.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param mixed $content_id Raw submitted Content ID.
+	 *
+	 * @return string Sanitized Content ID, or '' when the value is invalid.
+	 */
+	public static function sanitize_content_id( $content_id ): string {
+		$content_id = sanitize_text_field( (string) $content_id );
+
+		return preg_match( '/^[a-zA-Z0-9-]*$/', $content_id ) ? $content_id : '';
+	}
+
+	/**
 	 * Get the (legacy) Podcast ID for a WordPress Post.
 	 *
 	 * Over time there have been various approaches to storing the Podcast ID.

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -327,7 +327,16 @@ class Sync {
 			];
 
 			foreach ( $keys as $key ) {
-				register_meta( 'post', $key, $options );
+				$meta_options = $options;
+
+				// Content IDs are interpolated into BeyondWords API URL paths, so
+				// the block-editor / REST write path needs the same strict charset
+				// validation as the classic editor — see Meta::sanitize_content_id().
+				if ( 'beyondwords_content_id' === $key ) {
+					$meta_options['sanitize_callback'] = [ \BeyondWords\Post\Meta::class, 'sanitize_content_id' ];
+				}
+
+				register_meta( 'post', $key, $meta_options );
 			}
 		}
 	}

--- a/tests/phpunit/api/test-client.php
+++ b/tests/phpunit/api/test-client.php
@@ -877,6 +877,38 @@ class ClientTest extends TestCase
     }
 
     /**
+     * The Content ID is charset-validated before storage, but Client must still
+     * defensively rawurlencode() it so any value that reaches the URL builder
+     * can't inject extra path or query segments into the authenticated request.
+     *
+     * @test
+     */
+    public function get_content_rawurlencodes_the_content_id()
+    {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $captured_url = null;
+        $filter = function ($preempt, $args, $url) use (&$captured_url) {
+            $captured_url = $url;
+            return $preempt;
+        };
+        add_filter('pre_http_request', $filter, 1, 3);
+
+        Client::get_content('a/b?c=1');
+
+        remove_filter('pre_http_request', $filter, 1);
+
+        // The slash and query characters are percent-encoded, so the URL keeps
+        // its intended `/content/<id>` shape instead of gaining an attacker path.
+        $this->assertStringContainsString('/content/a%2Fb%3Fc%3D1', (string) $captured_url);
+        $this->assertStringNotContainsString('/content/a/b?c=1', (string) $captured_url);
+
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
      * @test
      *
      * A transport-level failure (DNS error, timeout, refused/blocked connection)

--- a/tests/phpunit/editor/components/content-id/test-content-id.php
+++ b/tests/phpunit/editor/components/content-id/test-content-id.php
@@ -170,6 +170,25 @@ class ContentIdTest extends TestCase
                 'postValue' => 'abc<b>def</b>ghi',
                 'expect'    => 'abcdefghi',
             ],
+            // A crafted Content ID must not be able to inject path/query segments
+            // into the authenticated BeyondWords API URL — see the fix in
+            // Meta::sanitize_content_id().
+            'Path traversal + query blanked' => [
+                'postValue' => 'x/../../projects/999/content/abc?force=1',
+                'expect'    => '',
+            ],
+            'Forward slash blanked' => [
+                'postValue' => 'a/b',
+                'expect'    => '',
+            ],
+            'Query string blanked' => [
+                'postValue' => 'abc?force=1',
+                'expect'    => '',
+            ],
+            'Ampersand blanked' => [
+                'postValue' => 'a&b',
+                'expect'    => '',
+            ],
         ];
     }
 

--- a/tests/phpunit/player/renderer/test-javascript.php
+++ b/tests/phpunit/player/renderer/test-javascript.php
@@ -57,13 +57,18 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * Stored-XSS regression: dangerous characters in a param value must never
-     * break out of the single-quoted onload='...' attribute, whatever the payload.
+     * Stored-XSS regression: dangerous characters in a Content ID must never
+     * break out of the single-quoted onload='...' attribute, whatever the value.
+     *
+     * Content IDs are now charset-validated on save (Meta::sanitize_content_id),
+     * so a hostile value can only reach the renderer via a raw row — legacy data,
+     * a direct DB write, or a future regression. We store one straight in the DB,
+     * bypassing the meta sanitiser, to keep the renderer's output-escaping second
+     * line of defence under test.
      *
      * Asserts the security *property* — one intact <script> and the value survives
      * as inert JSON data — rather than a specific escaping mechanism, so it stays
-     * valid if the escaping strategy is ever refactored. The injected value reaches
-     * the renderer via `beyondwords_content_id`, the documented editor/REST sink.
+     * valid if the escaping strategy is ever refactored.
      *
      * @test
      * @dataProvider dangerousContentIdProvider
@@ -74,9 +79,12 @@ class JavascriptTest extends TestCase
             'post_title' => 'JavascriptTest::render_neutralises_a_dangerous_content_id',
             'meta_input' => [
                 'beyondwords_project_id' => BEYONDWORDS_TESTS_PROJECT_ID,
-                'beyondwords_content_id' => $payload,
             ],
         ]);
+
+        // The meta sanitiser would blank this value, so store it raw to simulate
+        // a legacy/externally-written row reaching the renderer.
+        $this->store_raw_content_id($post->ID, $payload);
 
         $html = Javascript::render($post);
 
@@ -101,10 +109,31 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * Payloads that survive sanitize_text_field() (the meta sanitiser registered
-     * for beyondwords_content_id) — quotes, ampersands and Unicode. It strips
-     * < > tags, so tag-based payloads can only reach the renderer via a filter;
-     * those are covered by render_neutralises_dangerous_sdk_params_from_filter().
+     * Write a Content ID straight into post meta, bypassing the
+     * Meta::sanitize_content_id() callback registered on the meta key, to
+     * reproduce a hostile value that predates or otherwise circumvents input
+     * validation so the renderer's output escaping stays under test.
+     */
+    private function store_raw_content_id($post_id, $value)
+    {
+        global $wpdb;
+
+        $wpdb->insert($wpdb->postmeta, [
+            'post_id'    => $post_id,
+            'meta_key'   => 'beyondwords_content_id',
+            'meta_value' => $value,
+        ]);
+
+        wp_cache_delete($post_id, 'post_meta');
+    }
+
+    /**
+     * Values that would break out of, or corrupt, the onload attribute if the
+     * renderer didn't neutralise them — quotes, ampersands and Unicode. They no
+     * longer survive the beyondwords_content_id meta sanitiser (which blanks
+     * anything outside [a-zA-Z0-9-]), so the test injects them via a raw DB write
+     * to isolate the renderer's own output-escaping defence. Tag-based payloads
+     * are covered by render_neutralises_dangerous_sdk_params_from_filter().
      */
     public function dangerousContentIdProvider()
     {

--- a/tests/phpunit/post/test-meta.php
+++ b/tests/phpunit/post/test-meta.php
@@ -186,6 +186,45 @@ class MetaTest extends TestCase
     }
 
     /**
+     * A Content ID is interpolated into BeyondWords API URL paths, so only the
+     * `[a-zA-Z0-9\-]+` charset the inspect REST route allows may be stored —
+     * anything with path/query characters is blanked to defeat URL injection.
+     *
+     * @test
+     * @dataProvider sanitize_content_id_provider
+     *
+     * @param mixed  $input    Raw submitted Content ID.
+     * @param string $expected Expected sanitized value.
+     */
+    public function sanitize_content_id($input, $expected)
+    {
+        $this->assertSame($expected, Meta::sanitize_content_id($input));
+    }
+
+    public function sanitize_content_id_provider()
+    {
+        return [
+            // Legitimate values pass through unchanged.
+            'UUID'                    => ['9279c9e0-e0b5-4789-9040-f44478ed3e9e', '9279c9e0-e0b5-4789-9040-f44478ed3e9e'],
+            'numeric id'              => ['1234567', '1234567'],
+            'all-zero UUID'           => ['00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000'],
+            'empty string'           => ['', ''],
+            'surrounding whitespace'  => ['  9279c9e0-e0b5  ', '9279c9e0-e0b5'],
+            // Anything outside [a-zA-Z0-9-] is blanked.
+            'path traversal + query'  => ['x/../../projects/999/content/abc?force=1', ''],
+            'forward slash'           => ['abc/def', ''],
+            'dot segment'             => ['abc.def', ''],
+            'query string'            => ['abc?force=1', ''],
+            'fragment'                => ['abc#frag', ''],
+            'ampersand'               => ['a&b', ''],
+            'colon'                   => ['abc:def', ''],
+            'underscore'              => ['content_id', ''],
+            'space'                   => ['a b', ''],
+            'script tag'              => ['<script>alert(1)</script>', ''],
+        ];
+    }
+
+    /**
      * Get API response body from post meta field.
      *
      * @test
@@ -300,11 +339,13 @@ class MetaTest extends TestCase
             'post_title' => 'MetaTest:removeAllBeyondwordsMetadata',
         ]);
 
-        // Set all BeyondWords meta keys
+        // Set all BeyondWords meta keys. Use a hyphen rather than an underscore so
+        // the value survives beyondwords_content_id's strict sanitiser
+        // (Meta::sanitize_content_id) while remaining valid for every other key.
         $beyondwordsKeys = Utils::get_post_meta_keys('all');
 
         foreach ($beyondwordsKeys as $key) {
-            update_post_meta($postId, $key, 'test_value');
+            update_post_meta($postId, $key, 'test-value');
         }
 
         // Set a non-BeyondWords meta key that should NOT be removed

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -565,7 +565,9 @@ class SyncTest extends TestCase
                 'beyondwords_generate_audio'        => 'beyondwords_generate_audio',
                 'beyondwords_disabled'              => 'beyondwords_disabled',
                 'beyondwords_error_message'         => 'beyondwords_error_message',
-                'beyondwords_content_id'            => 'beyondwords_content_id',
+                // Content ID is charset-validated on save (Meta::sanitize_content_id),
+                // so it needs a valid value here rather than the meta-key placeholder.
+                'beyondwords_content_id'            => BEYONDWORDS_TESTS_CONTENT_ID,
                 'beyondwords_podcast_id'            => 'beyondwords_podcast_id',
                 'beyondwords_preview_token'         => 'beyondwords_preview_token',
                 'beyondwords_project_id'            => 'beyondwords_project_id',
@@ -590,7 +592,7 @@ class SyncTest extends TestCase
         $this->assertSame('beyondwords_error_message', get_post_meta($postId, 'beyondwords_error_message', true));
 
         $this->assertArrayHasKey('beyondwords_content_id', $meta);
-        $this->assertSame('beyondwords_content_id', get_post_meta($postId, 'beyondwords_content_id', true));
+        $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID, get_post_meta($postId, 'beyondwords_content_id', true));
 
         $this->assertArrayHasKey('beyondwords_podcast_id', $meta);
         $this->assertSame('beyondwords_podcast_id', get_post_meta($postId, 'beyondwords_podcast_id', true));
@@ -618,6 +620,33 @@ class SyncTest extends TestCase
 
         $this->assertArrayHasKey('_speechkit_text', $meta);
         $this->assertSame('_speechkit_text', get_post_meta($postId, '_speechkit_text', true));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * The beyondwords_content_id meta is registered with a strict sanitize
+     * callback so the block-editor / REST write path can't persist a Content ID
+     * that would inject path or query segments into an authenticated BeyondWords
+     * API URL (see Meta::sanitize_content_id).
+     *
+     * @test
+     */
+    public function register_meta_sanitizes_content_id_on_write()
+    {
+        Sync::register_meta();
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'SyncTest::registerMetaSanitizesContentIdOnWrite',
+        ]);
+
+        // A crafted value with URL path/query characters is blanked on save.
+        update_post_meta($postId, 'beyondwords_content_id', 'x/../../projects/999/content/abc?force=1');
+        $this->assertSame('', get_post_meta($postId, 'beyondwords_content_id', true));
+
+        // A legitimate UUID Content ID is stored unchanged.
+        update_post_meta($postId, 'beyondwords_content_id', BEYONDWORDS_TESTS_CONTENT_ID);
+        $this->assertSame(BEYONDWORDS_TESTS_CONTENT_ID, get_post_meta($postId, 'beyondwords_content_id', true));
 
         wp_delete_post($postId, true);
     }


### PR DESCRIPTION
## Summary

Fixes an **authenticated API path/query injection** via an unvalidated Content ID. A WordPress user with `edit_post` (author, or contributor on their own draft) could store a crafted `beyondwords_content_id` and steer authenticated, organization-API-key-scoped requests to arbitrary BeyondWords API endpoints.

### The vulnerability

`beyondwords_content_id` was persisted with only `sanitize_text_field()`, which permits `/`, `.`, `?`, `#` and `&`. That value was later read back verbatim and interpolated **unencoded** into API URL paths:

```php
sprintf( '%s/projects/%d/content/%s', $api_url, $project_id, $content_id )
```

in `Client::get_content()`, `update_audio()` and `delete_audio()`. Because `Client::filter_http_request_args()` attaches the org `X-Api-Key` header to any outbound URL that starts with the API base — and path-suffix manipulation preserves that prefix — a value such as:

```
x/../../projects/999/content/abc?force=1
```

resolves (after cURL dot-segment normalization) to an attacker-chosen endpoint under the API host, with the org key attached, letting an author-level user read/update/delete content in other projects of the organization. Both write paths were affected: the classic-editor metabox (`ContentId::save()`) and the block-editor/REST meta write (`Sync::register_meta()`, `sanitize_callback => sanitize_text_field`). The plugin's own inspect REST route already documented the intended charset as `[a-zA-Z0-9\-]+`.

## What changed

Defense at three layers (per the advisory):

1. **New shared validator** — `Meta::sanitize_content_id()`: `sanitize_text_field()` + a strict `^[a-zA-Z0-9-]*$` gate (the same charset the inspect REST route enforces), blanking anything else.
2. **Both write paths** routed through it — `ContentId::save()` (classic editor) and the `beyondwords_content_id` `sanitize_callback` in `Sync::register_meta()` (block editor / REST). Only that one meta key gets the strict callback; others keep `sanitize_text_field`.
3. **Defense-in-depth at the sink** — `rawurlencode( (string) $content_id )` at the three `Client` URL builders. Transparent for legitimate IDs (numeric / UUID), so no behavior change for valid callers. (`batch_delete` already sends IDs in a JSON body, not a URL path — unchanged.)

Follows WordPress-VIP standards — input is unslashed + sanitized, and **no `phpcs:ignore` was added**.

## Reviewer notes

- The `register_meta` `sanitize_callback` applies globally, so the strict gate takes effect on every `beyondwords_content_id` write (including `update_post_meta`), not just REST. API-issued IDs (UUIDs/numeric) pass through unchanged.
- Three **pre-existing** tests needed small adjustments for the now-stricter meta contract, documented inline:
  - The stored-XSS renderer test now **raw-writes** its payload to the DB (bypassing the sanitizer) so it still exercises the renderer's output-escaping — that second line of defense is preserved.
  - Two placeholder Content IDs containing underscores (`'beyondwords_content_id'`, `'test_value'`) were changed to charset-valid values.

## Testing

- `phpcs` (full `WordPress-VIP-Go` scope): **clean** (exit 0).
- **Full PHPUnit suite: `OK — 662 tests, 2079 assertions`**, 0 failures. Ran the whole suite (not just changed files) because the `register_meta` callback registers globally.
- New tests: `sanitize_content_id` unit provider; `ContentId::save` injection cases; a `Sync` test proving `update_post_meta` blanks a crafted ID end-to-end; a `Client` test asserting the URL is `%2F`/`%3F`-encoded.
- Per project guidance, the full Cypress suite was **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
