### PR TITLE
fix: close the v7 migration gate on pre-release builds

### DIFF
--- a/src/core/class-updater.php
+++ b/src/core/class-updater.php
@@ -2,9 +2,9 @@
 /**
  * Plugin update routines.
  *
- * Runs on every page load; cheap when nothing's changed (the version compare
- * short-circuits). Each migration is gated on a version bump so it executes
- * exactly once per upgrade path.
+ * Runs on every page load; cheap when nothing's changed because `run()` bails
+ * as soon as the recorded version matches this build. Each migration is gated
+ * on a version bump so it executes at most once per upgrade path.
  *
  * @package BeyondWords\Core
  * @since   3.0.0
@@ -27,10 +27,23 @@ class Updater {
 	/**
 	 * Run any pending migrations and update the recorded plugin version.
 	 *
-	 * Always runs — version checks inside skip the migrations on no-op upgrades.
+	 * Bails immediately once the recorded version matches this build, so the
+	 * migrations run at most once per version change instead of on every
+	 * request. That guard — not the per-migration `version_compare` gates — is
+	 * what makes the common path cheap: a pre-release build such as
+	 * `7.0.0-beta.1` compares `< 7.0.0`, so those gates never close on it and
+	 * would otherwise re-run the v7 migrations (~40 uncached queries plus a slow
+	 * postmeta JOIN) on every page load, front end included.
 	 */
 	public static function run(): void {
 		$version = get_option( 'beyondwords_version', '1.0.0' );
+
+		// Already up to date: nothing to migrate, and the version write below
+		// would be a no-op. Bail before touching the database. This is the hot
+		// path — it runs on every request once the plugin has booted once.
+		if ( BEYONDWORDS__PLUGIN_VERSION === $version ) {
+			return;
+		}
 
 		if ( version_compare( $version, '3.0.0', '<' ) ) {
 			self::migrate_settings();
@@ -61,8 +74,9 @@ class Updater {
 	 * `[ 'mode' => 'all' ]` or `[ 'mode' => 'terms', 'terms' => [...] ]`.
 	 *
 	 * Reuses the tolerant readers on `Preselect`, so it is idempotent: already
-	 * mode-based values pass through unchanged. The `-dev` plugin version keeps
-	 * the `< 7.0.0` gate firing on every load, so the no-op path matters.
+	 * mode-based values pass through unchanged. Pre-release builds compare
+	 * `< 7.0.0`, so this can re-run once on each dev-version bump — idempotency
+	 * keeps those re-runs safe.
 	 *
 	 * @since 7.0.0
 	 */

--- a/tests/phpunit/core/test-updater.php
+++ b/tests/phpunit/core/test-updater.php
@@ -223,4 +223,59 @@ class UpdaterTest extends TestCase
         wp_delete_post($embedPost, true);
         wp_delete_post($untouchedPost, true);
     }
+
+    /**
+     * The migration gate must close once the recorded version matches this
+     * build — otherwise the pre-release `< 7.0.0` comparison keeps the v7
+     * migrations firing on every request.
+     *
+     * @test
+     */
+    public function run_is_a_noop_once_the_recorded_version_matches_this_build()
+    {
+        // Simulate an install that has already booted this exact build.
+        update_option('beyondwords_version', BEYONDWORDS__PLUGIN_VERSION);
+
+        // A post still carrying the legacy opt-out flag. If run() re-executed
+        // the v7 block it would strip this flag and set Embed = None; the
+        // version guard must leave it untouched.
+        $post = self::factory()->post->create();
+        update_post_meta($post, 'beyondwords_disabled', '1');
+
+        Updater::run();
+
+        // Migration did not run: legacy flag preserved, no Embed written.
+        $this->assertSame('1', get_post_meta($post, 'beyondwords_disabled', true));
+        $this->assertSame('', get_post_meta($post, 'beyondwords_embed', true));
+
+        wp_delete_post($post, true);
+        delete_option('beyondwords_version');
+    }
+
+    /**
+     * When the recorded version predates a migration, run() must execute it and
+     * normalise the stored version to this build.
+     *
+     * @test
+     */
+    public function run_migrates_and_records_the_version_when_outdated()
+    {
+        update_option('beyondwords_version', '6.0.0');
+
+        $post = self::factory()->post->create();
+        update_post_meta($post, 'beyondwords_disabled', '1');
+
+        Updater::run();
+
+        // v7 migration ran: legacy flag converted to Embed = None and removed.
+        $this->assertSame('none', get_post_meta($post, 'beyondwords_embed', true));
+        $this->assertSame('', get_post_meta($post, 'beyondwords_disabled', true));
+
+        // Stored version normalised to this build, so the next run() is a no-op.
+        $this->assertSame(BEYONDWORDS__PLUGIN_VERSION, get_option('beyondwords_version'));
+
+        wp_delete_post($post, true);
+        delete_option('beyondwords_version');
+        delete_option('beyondwords_date_activated');
+    }
 }


### PR DESCRIPTION
## Problem

`Updater::run()` runs on **every request** (via `Plugin::init()` at plugin-include time). The v7 migration block is gated on `version_compare( $version, '7.0.0', '<' )`, but the shipped build is a pre-release — currently `7.0.0-beta.1`. `run()` writes that same suffixed string back into `beyondwords_version`, and **every pre-release suffix compares `< '7.0.0'`**, so the gate never closed.

The result, on every single page load (anonymous front-end traffic included):

- `delete_deprecated_options()` — 39 `delete_option()`/`delete_site_option()` calls; WP core's `delete_option()` issues a `SELECT autoload ...` even when the option doesn't exist.
- `migrate_disabled_to_embed_none()` — a `WP_Query` with an unindexed `meta_value` postmeta JOIN (`WordPress.DB.SlowDBQuery` pattern).
- `migrate_preselect_format()` — an extra option read.

That's ~40 uncached primary-DB SELECTs plus a slow postmeta scan per request — a direct WordPress VIP performance violation (worse on large publisher DBs, and 39 network-meta lookups per request on multisite).

`version_compare('7.0.0-beta.1', '7.0.0', '<') === true` — verified with `php -r`. (The bug was originally reported against `7.0.0-dev-2.0`; identical defect — any `-dev`/`-beta`/`-rc` suffix triggers it.)

## Fix

Add a version-equality early return at the top of `run()`:

```php
if ( BEYONDWORDS__PLUGIN_VERSION === $version ) {
    return;
}
```

Once a build has booted once and recorded its own version, the next request bails before touching the database.

Chosen over the alternative one-shot `beyondwords_migrated_7_0_0` flag because it's strictly better: it short-circuits the **entire** migration chain on the hot path (not just the v7 block), adds no new option, and self-heals **every future** pre-release gate. Migrations still run exactly once per version change, and all three v7 migrations are idempotent, so the rare beta→beta re-run is safe.

Also corrected three now-inaccurate comments: the file header, the `run()` docblock, and the `migrate_preselect_format()` docblock that explicitly claimed the gate "fires on every load".

No `phpcs:ignore` added; the pre-existing one on the meta_query is untouched (that query now runs only once per upgrade, as a migration should).

## Tests

Two new `UpdaterTest` regression tests:

- `run_is_a_noop_once_the_recorded_version_matches_this_build` — proves the gate closes (a post's legacy `beyondwords_disabled` flag is left untouched).
- `run_migrates_and_records_the_version_when_outdated` — proves the real upgrade path still migrates and normalises the stored version.

## Verification

- **phpcs** (`WordPress-VIP-Go` standard): clean, zero errors/warnings on `class-updater.php`.
- **PHPUnit** `UpdaterTest`: **8/8 pass, 29 assertions** (6 pre-existing + 2 new).
- Cypress suite not run (per repo guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)