### PR TITLE
fix: clean every site's data on multisite uninstall

### DIFF
--- a/src/core/class-uninstaller.php
+++ b/src/core/class-uninstaller.php
@@ -3,7 +3,10 @@
  * Uninstall cleanup.
  *
  * Invoked from `uninstall.php` when WordPress removes the plugin. Deletes
- * every option, transient, and post-meta key recorded in `Utils`.
+ * every option, transient, and post-meta key recorded in `Utils`. On
+ * multisite each site is cleaned in turn, since `uninstall.php` only runs
+ * once — in the network's main-site context — and every value is stored
+ * per-site.
  *
  * @package BeyondWords\Core
  * @since   3.7.0
@@ -22,6 +25,58 @@ defined( 'ABSPATH' ) || exit;
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
 class Uninstaller {
+
+	/**
+	 * Run the full uninstall cleanup for every site on the install.
+	 *
+	 * WordPress executes `uninstall.php` a single time, in the context of the
+	 * network's main site. Every BeyondWords value — options, transients and
+	 * post-meta — is stored per-site (`update_option()` and the per-site
+	 * `options`/`postmeta` tables); the plugin never writes network/site
+	 * options. So on multisite we must visit each site in turn, otherwise only
+	 * the main site is cleaned and every subsite keeps its settings, including
+	 * the `beyondwords_api_key` secret. Single-site installs are cleaned in one
+	 * pass.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return void
+	 */
+	public static function run(): void {
+		if ( ! is_multisite() ) {
+			self::cleanup_site();
+			return;
+		}
+
+		// `number => 0` lifts the default 100-site cap so no site is skipped on
+		// large networks.
+		$site_ids = get_sites(
+			[
+				'fields' => 'ids',
+				'number' => 0,
+			]
+		);
+
+		foreach ( $site_ids as $site_id ) {
+			switch_to_blog( (int) $site_id );
+			self::cleanup_site();
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Delete every BeyondWords option, transient and post-meta value for the
+	 * current site.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return void
+	 */
+	private static function cleanup_site(): void {
+		self::cleanup_plugin_transients();
+		self::cleanup_plugin_options();
+		self::cleanup_custom_fields();
+	}
 
 	/**
 	 * Delete every BeyondWords transient.
@@ -59,10 +114,21 @@ class Uninstaller {
 		$total   = 0;
 
 		foreach ( $options as $option ) {
-			$deleted = is_multisite() ? delete_site_option( $option ) : delete_option( $option );
-
-			if ( $deleted ) {
+			// Every option is stored per-site via `update_option()`, so
+			// `delete_option()` is the correct call on both single-site and
+			// multisite. The previous `delete_site_option()`-only branch swept
+			// `wp_sitemeta` rows that were never written and left every real
+			// option — including the `beyondwords_api_key` secret — in place on
+			// multisite.
+			if ( delete_option( $option ) ) {
 				++$total;
+			}
+
+			// Defensive: a legacy install may have stored a matching network
+			// (site) option. This is network-global and idempotent, so it is a
+			// harmless no-op when nothing was stored.
+			if ( is_multisite() ) {
+				delete_site_option( $option );
 			}
 		}
 

--- a/tests/phpunit/core/test-uninstaller.php
+++ b/tests/phpunit/core/test-uninstaller.php
@@ -213,4 +213,100 @@ class UninstallerTest extends TestCase
 
         delete_transient('unrelated_transient');
     }
+
+    /**
+     * @test
+     *
+     * run() performs the whole cleanup in a single call on a single-site
+     * install: options, transients and post-meta are all removed.
+     */
+    public function run_cleans_options_transients_and_meta_on_single_site()
+    {
+        if (is_multisite()) {
+            $this->markTestSkipped('Single-site variant; multisite is covered separately.');
+        }
+
+        update_option('beyondwords_api_key', 'secret');
+        set_transient('beyondwords_languages', ['en', 'fr'], 60);
+        $postId = self::factory()->post->create([
+            'meta_input' => ['beyondwords_project_id' => '123'],
+        ]);
+
+        Uninstaller::run();
+
+        // The Uninstaller deletes transients/meta with raw SQL, so drop the
+        // caches before re-reading from the database.
+        wp_cache_flush();
+        clean_post_cache($postId);
+
+        $this->assertFalse(get_option('beyondwords_api_key'));
+        $this->assertFalse(get_transient('beyondwords_languages'));
+        $this->assertFalse(metadata_exists('post', $postId, 'beyondwords_project_id'));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     *
+     * run() must visit EVERY site on a multisite network: the API key and other
+     * per-site values must not survive on any site, not just the main one.
+     *
+     * Regression test for the multisite uninstall leak — cleanup previously
+     * called delete_site_option() (which targets wp_sitemeta) while every
+     * option is stored per-site via update_option(), so nothing was deleted and
+     * the beyondwords_api_key secret survived. Skipped on single-site installs
+     * because it needs a real network (WP_TESTS_MULTISITE=1).
+     */
+    public function run_cleans_every_site_on_multisite()
+    {
+        if (!is_multisite()) {
+            $this->markTestSkipped('Requires a multisite install (WP_TESTS_MULTISITE=1).');
+        }
+
+        $blogId  = self::factory()->blog->create();
+        $siteIds = [get_current_blog_id(), $blogId];
+
+        // Seed an option (the API key), a transient and a post-meta value on
+        // each site so we can prove all three are cleaned everywhere.
+        $postIds = [];
+        foreach ($siteIds as $siteId) {
+            switch_to_blog($siteId);
+            update_option('beyondwords_api_key', 'secret-' . $siteId);
+            set_transient('beyondwords_languages', ['en'], 60);
+            $postIds[$siteId] = self::factory()->post->create([
+                'meta_input' => ['beyondwords_project_id' => '123'],
+            ]);
+            restore_current_blog();
+        }
+
+        Uninstaller::run();
+
+        foreach ($siteIds as $siteId) {
+            switch_to_blog($siteId);
+            wp_cache_flush();
+            clean_post_cache($postIds[$siteId]);
+
+            $this->assertFalse(
+                get_option('beyondwords_api_key'),
+                "API key survived on site {$siteId}"
+            );
+            $this->assertFalse(
+                get_transient('beyondwords_languages'),
+                "Transient survived on site {$siteId}"
+            );
+            $this->assertFalse(
+                metadata_exists('post', $postIds[$siteId], 'beyondwords_project_id'),
+                "Post meta survived on site {$siteId}"
+            );
+            restore_current_blog();
+        }
+
+        // Best-effort teardown of the extra site created for this test.
+        if (function_exists('wp_delete_site')) {
+            wp_delete_site(get_site($blogId));
+        } elseif (function_exists('wpmu_delete_blog')) {
+            wpmu_delete_blog($blogId, true);
+        }
+    }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -31,9 +31,7 @@ function beyondwords_uninstall() {
 
 	require BEYONDWORDS__PLUGIN_DIR . 'vendor/autoload.php';
 
-	Uninstaller::cleanup_plugin_transients();
-	Uninstaller::cleanup_plugin_options();
-	Uninstaller::cleanup_custom_fields();
+	Uninstaller::run();
 }
 
 // phpcs:disable


### PR DESCRIPTION
## What & why

On a multisite network, deleting the plugin left **all** of its data in the database — including the `beyondwords_api_key` secret and `beyondwords_project_id`.

`Uninstaller::cleanup_plugin_options()` used `is_multisite() ? delete_site_option() : delete_option()`. But the plugin stores every option **per-site** via `update_option()` / `register_setting()` — there are no `update_site_option()` writes anywhere in `src/`. So on multisite the uninstall loop deleted `wp_sitemeta` rows that were never created and left every real option in `wp_options` / `wp_N_options`. Retaining an API secret the user believes was deleted is a data-hygiene/security concern, and the method's `0` return value silently masked the failure.

There is also a second layer: WordPress runs `uninstall.php` **once**, in the network's main-site context. So even a corrected `delete_option()` — plus the raw-SQL transient and post-meta cleanups, which operate on the per-site `$wpdb->options` / `$wpdb->postmeta` tables — would only ever clean the main site. Subsites were never iterated.

## Changes

- **`cleanup_plugin_options()`** — `delete_option()` is now the unconditional primary path (runs on both single-site and multisite), with a defensive `delete_site_option()` sweep retained on multisite for any legacy network option.
- **`Uninstaller::run()`** (new) — iterates `get_sites(['number' => 0])` + `switch_to_blog()`, cleans each site's options, transients and post-meta, then `restore_current_blog()`. `uninstall.php` now calls `run()`. The individual `cleanup_*` methods stay public with unchanged contracts.

## Notes for reviewers

- `number => 0` lifts `get_sites()`' default 100-site cap so no site is skipped on large networks.
- **No `phpcs:ignore` or ruleset change** was needed. `switch_to_blog()` is a `WordPress-VIP-Go` warning, but that ruleset already pins it to severity 3 — below the default reporting threshold of 5 — so `phpcs` stays clean.
- The same either/or pattern also exists in `Updater::delete_deprecated_options()` (`src/core/class-updater.php`). That is a separate finding and is intentionally out of scope here.

## Testing

- `npm run phpcs` — clean (exit 0, full project scan).
- `UninstallerTest` (single-site): **50 tests, 366 assertions**, all green.
- `UninstallerTest` under real multisite (`WP_MULTISITE=1`): the new `run_cleans_every_site_on_multisite` regression test passes — the API key, a transient and post-meta are removed on **both** the main site and a subsite (6 assertions across 2 sites). This test fails against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
