### PR TITLE
perf(player): avoid DomCrawler parse on every singular pageview

### DIFF
--- a/src/player/class-player.php
+++ b/src/player/class-player.php
@@ -65,7 +65,22 @@ class Player {
 	 * @return string
 	 */
 	public static function auto_prepend_player( $content ) {
-		if ( ! is_singular() || self::has_custom_player( $content ) ) {
+		if ( ! is_singular() ) {
+			return $content;
+		}
+
+		// Bail before the potentially expensive has_custom_player() DOM scan when
+		// no player could render anyway. This mirrors render_player()'s own early
+		// return, so returning $content here is equivalent to prepending its '' —
+		// but it spares every "player disabled / Embed: None" singular pageview
+		// the cost of parsing the post content.
+		$post = get_post();
+
+		if ( ! $post instanceof \WP_Post || ! self::is_enabled( $post ) ) {
+			return $content;
+		}
+
+		if ( self::has_custom_player( $content ) ) {
 			return $content;
 		}
 
@@ -183,9 +198,23 @@ class Player {
 			return true;
 		}
 
+		$js_sdk_url = \BeyondWords\Core\Urls::get_js_sdk_url();
+
+		// Skip the DOM parse below — expensive on large posts, yet run on every
+		// singular pageview — unless a marker substring is actually present. Both
+		// XPath queries require one of these literal strings in the markup (the
+		// attribute name, or the SDK URL inside a script `src`), so if neither
+		// appears the parse cannot match and we can bail cheaply.
+		if (
+			! str_contains( $content, 'data-beyondwords-player' )
+			&& ! str_contains( $content, $js_sdk_url )
+		) {
+			return false;
+		}
+
 		$crawler = new \Symfony\Component\DomCrawler\Crawler( $content );
 
-		$script_xpath = sprintf( '//script[@async][@defer][contains(@src, "%s")]', \BeyondWords\Core\Urls::get_js_sdk_url() );
+		$script_xpath = sprintf( '//script[@async][@defer][contains(@src, "%s")]', $js_sdk_url );
 		if ( $crawler->filterXPath( $script_xpath )->count() > 0 ) {
 			return true;
 		}

--- a/tests/phpunit/player/test-player.php
+++ b/tests/phpunit/player/test-player.php
@@ -126,6 +126,13 @@ class PlayerTest extends TestCase
         // We are now is_singular() so player should be prepended
         $this->assertSame(sprintf(self::PLAYER_HTML_FORMAT, 'auto') . $content, $output);
 
+        // Player UI = Disabled makes is_enabled() false, so auto_prepend_player()
+        // now short-circuits (before the has_custom_player() DOM scan) and returns
+        // the content unchanged — no player is prepended.
+        update_option(Fields::OPTION_PLAYER_UI, Fields::PLAYER_UI_DISABLED);
+        $this->assertSame($content, Player::auto_prepend_player($content));
+        delete_option(Fields::OPTION_PLAYER_UI);
+
         wp_reset_postdata();
 
         wp_delete_post($post->ID, true);
@@ -425,12 +432,22 @@ class PlayerTest extends TestCase
 
     public function content_provider()
     {
+        $sdkUrl = Urls::get_js_sdk_url();
+
         return [
             'No player' => [false, '<p>No player.</p>'],
             'Legacy player' => [true, '<p>Before.</p><div data-beyondwords-player="true"></div><p>After.</p>'],
             'Legacy player with contenteditable attribute' => [true, '<p>Before.</p><div data-beyondwords-player="true" contenteditable="false"></div><p>After.</p>'],
             'New player shortcode' => [true, '<p>Before.</p>[beyondwords_player]<p>After.</p>'],
             'New player shortcode with project_id attribute' => [true, '<p>Before.</p>[beyondwords_player project_id="1234"]<p>After.</p>'],
+            // SDK <script> markup counts as a custom player — this is the only path
+            // gated by the get_js_sdk_url() substring in the has_custom_player()
+            // fast-path guard, so keep it covered.
+            'JS SDK player script' => [true, '<p>Before.</p><script async defer src="' . $sdkUrl . '"></script><p>After.</p>'],
+            // The SDK URL appearing as plain text passes the cheap substring guard
+            // but must still resolve to false via the XPath — proving the guard is a
+            // pre-filter, not a replacement for the parse.
+            'SDK URL in text only, no script tag' => [false, '<p>Listen via ' . $sdkUrl . '</p>'],
         ];
     }
 }


### PR DESCRIPTION
## What & why

`Player::auto_prepend_player()` is hooked to `the_content` at priority `1000000` for **all** post types, so it runs on every uncached singular front-end request. It called `has_custom_player()` — which constructs a full `Symfony\Component\DomCrawler\Crawler` (a libxml `DOMDocument` parse of the entire, unbounded post content) plus two XPath queries — **before** `render_player()`'s cheap `Player::is_enabled()` gate.

That parse ran on the hot path even when no player could ever render — i.e. virtually every request whose content lacks a player marker:

- posts with no BeyondWords audio at all,
- post types the plugin doesn't support,
- unconfigured sites (no API key / project ID),
- Player UI = Disabled,
- Embed = None.

On large posts / high-traffic VIP sites this is measurable, avoidable render-time work on every uncached request, purely to detect a marker string that is almost always absent.

## The fix

Two cheap short-circuits ahead of the parse:

1. **`auto_prepend_player()`** now checks `get_post() instanceof WP_Post && self::is_enabled( $post )` before calling `has_custom_player()`.
2. **`has_custom_player()`** guards the `Crawler` with a `str_contains()` pre-check for `data-beyondwords-player` and the SDK URL, so the DOM parse only runs when a marker is plausibly present.

## Why it's behaviour-preserving

- The reordering in `auto_prepend_player()` mirrors `render_player()`'s own early return (`return ''` when `! $post instanceof WP_Post || ! is_enabled()`). Returning `$content` at the new gate is therefore exactly equivalent to prepending that `''`. Verified across the full `(is_singular, is_enabled, has_custom_player)` truth table — identical output in every case.
- I deliberately **did not** gate on `Base::check`/renderer eligibility (the "ideally" suggestion in the report): `render_player()` still fires the `beyondwords_player_html` filter with empty HTML when a post is enabled but no renderer matches, and short-circuiting there would silently drop that filter contract. The substring guard already makes that path cheap, so `is_enabled` is the correct gate.
- The substring guard is a sound pre-filter: both XPath queries require a literal `data-beyondwords-player` attribute name or the SDK URL in a `src` to appear in the source, so their absence guarantees no match.
- `is_enabled()` bottoms out in cached `get_post_meta()` / `get_option()` reads — far cheaper than the DOM parse it now front-runs.

## Tests

- **PHPCS** (`WordPress-VIP-Go`): clean, **no `phpcs:ignore` added**.
- **PHPUnit `PlayerTest`**: `OK (46 tests, 101 assertions)`. Added 3 regression cases:
  - the previously-untested SDK-`<script>` detection path,
  - a URL-in-text-only case (guard passes, XPath still returns `false` — proves the guard is a pre-filter, not a replacement),
  - the disabled-player short-circuit in `auto_prepend_player()`.
- Cypress suite not run (per project convention — no front-end player behaviour changed).

## Reviewer notes

- `str_contains` requires PHP ≥ 8.0, which the plugin already mandates (and already uses elsewhere, e.g. `class-sync.php`, `class-client.php`).
- No new input/output, remote calls, or nonce/capability surface — these are pure read-side short-circuits, so no new VIP sanitisation/escaping obligations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
