### PR TITLE
Require symfony/dom-crawler >=5.4.52 to fix CVE-2026-45071

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://beyondwords.io",
     "require": {
         "php": ">=8.0",
-        "symfony/dom-crawler": "^5.4"
+        "symfony/dom-crawler": "^5.4.52"
     },
     "require-dev": {
         "automattic/vipwpcs": "^3.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c0912e0055f9ba3113168a2f00d749f",
+    "content-hash": "2690e7080ec599808f87a8ceff2508c7",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,8 @@ Release date: tbc
 * [#544](https://github.com/beyondwords-io/wordpress-plugin/pull/544) Prevent a `TypeError` in the deferred audio-generation cron when a post is deleted.
 * [#543](https://github.com/beyondwords-io/wordpress-plugin/pull/543) Guard a null languages API result in the classic editor voice select.
 * [#542](https://github.com/beyondwords-io/wordpress-plugin/pull/542) Surface a `WP_Error` from `get_content()` instead of a fatal `TypeError`.
+* [#588](https://github.com/beyondwords-io/wordpress-plugin/pull/588) Ship `symfony/dom-crawler` 5.4.52 to fix CVE-2026-45071 (XXE / local file disclosure).
+    * The composer constraint now floors at the patched release, so a vulnerable version can no longer be bundled.
 
 **Deprecations**
 


### PR DESCRIPTION
## Summary

[#587](https://github.com/beyondwords-io/wordpress-plugin/issues/587) reports that released plugin builds bundle `symfony/dom-crawler` v5.4.48, which is vulnerable to [CVE-2026-45071](https://symfony.com/blog/cve-2026-45071-xxe-local-file-disclosure-in-domcrawler-addxmlcontent-via-validateonparse-true) (HIGH — XXE / local file disclosure via `Crawler::addXmlContent()`; patched in 5.4.52).

The release ZIP bundles whatever `composer.lock` pinned at tag time. The lock moved to v5.4.52 in #534 (June), but every release to date — including the latest v6.3.0 — was tagged before that, so all shipped builds carry the vulnerable v5.4.48. Meanwhile `composer.json` still allowed `^5.4`, so nothing prevented a future `composer update` from resolving back into the vulnerable range.

## Changes

- `composer.json`: floor the constraint at the patched release — `"symfony/dom-crawler": "^5.4.52"` — so vulnerable versions can never be resolved again.
- `composer.lock`: content-hash refreshed via `composer update symfony/dom-crawler`; the locked version stays v5.4.52 (the latest 5.4.x). `composer validate` passes and `composer audit` reports no advisories.
- `readme.txt`: changelog entry under the unreleased 7.0.0 notes.

## Exploitability context

The plugin itself only passes post HTML to the `Crawler` constructor ([class-player.php:215](https://github.com/beyondwords-io/wordpress-plugin/blob/main/src/player/class-player.php#L215)) and never calls the vulnerable `addXmlContent()` XML path, so direct exploitability through the plugin is low. But the vulnerable library ships inside the plugin ZIP where scanners flag it and any other code on the site could autoload it, so it needs to go regardless.

## Note for release planning

This PR fixes the next release cut from `main` (7.0.0). The 6.x line remains vulnerable until a release ships with the updated lock — since `main` is mid-7.0.0-beta, consider cutting a v6.3.1 hotfix from the `v6.3.0` tag with just this dependency bump so current stable users get the fix without waiting for 7.0.0.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)