### PR TITLE
docs: reduce inline comments to why-only; move rationale into doc/

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ local development environment.
 5. [Plugin features](./doc/plugin-features.md): An overview of the features of
 our plugin.
 6. [wp-config.php](./doc/wp-config.md): Our *wp-config.php* settings.
+7. [Async REST migration](./doc/async-rest-migration.md): API response caching
+and background (cron) audio generation on WordPress VIP.
+8. [Legacy meta migration](./doc/legacy-meta-migration.md): The v7 post-meta
+cleanup and downgrade-safety guarantees.
+9. [REST meta visibility](./doc/rest-meta-visibility.md): How BeyondWords post
+meta is exposed (or hidden) over the WordPress REST API.
+10. [Video settings payload](./doc/video-settings-payload.md): Why the plugin
+sends a full `video_settings` object to the content endpoint.
+11. [Preselect "Generate audio"](./doc/preselect-generate-audio.md): The
+setting's stored format and how the editor and save path honour it.
+12. [Settings internals](./doc/settings-internals.md): Settings-error
+transport and the API connection check.
 
 ##  Links
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,12 +2,10 @@ const { defineConfig } = require( 'cypress' );
 const util = require( 'util' );
 const exec = util.promisify( require( 'child_process' ).exec );
 
-// Track if we've done the one-time setup for this test run
 let hasSetupDatabase = false;
 
 /**
- * Helper function to execute WP-CLI commands
- * Automatically handles CI vs local environment differences
+ * Execute WP-CLI commands, handling CI vs local environment differences.
  *
  * @param {string|string[]} commands             - Single command or array of commands
  * @param {Object}          options              - Optional configuration
@@ -30,9 +28,8 @@ async function execWp( commands, options = {} ) {
 	return returnResult ? lastResult : undefined;
 }
 
-// CI sets these via env vars; locally cypress.env.json fills in the gaps.
-// We read cypress.env.json explicitly so we can keep allowCypressEnv:false
-// (Cypress 15 deprecates auto-merging cypress.env.json into Cypress.env()).
+// CI sets these via env vars; locally cypress.env.json fills the gaps — read it
+// explicitly to keep allowCypressEnv:false (Cypress 15 deprecates auto-merging).
 const localEnv = ( () => {
 	try {
 		return require( './cypress.env.json' );
@@ -93,10 +90,8 @@ function setupNodeEvents( on, config ) {
 	const apiKey = config.env.apiKey || '';
 	const projectId = ( config.expose && config.expose.projectId ) || '';
 
-	// implement node event listeners here
 	on( 'task', {
 		async setupDatabase() {
-			// One-shot per test run; bails if already set up.
 			if ( hasSetupDatabase ) {
 				// eslint-disable-next-line no-console
 				console.log(
@@ -108,7 +103,6 @@ function setupNodeEvents( on, config ) {
 			// eslint-disable-next-line no-console
 			console.log( '  - Running database setup...' );
 
-			// Reset database and activate plugins
 			await execWp( [
 				'plugin activate wp-reset',
 				'reset reset --yes',
@@ -192,7 +186,6 @@ function setupNodeEvents( on, config ) {
 				postDate = '',
 			} = options;
 
-			// Escape single quotes in title and content
 			const escapedTitle = title.replace( /'/g, "'\\''" );
 			const escapedContent = content.replace( /'/g, "'\\''" );
 
@@ -286,7 +279,6 @@ function setupNodeEvents( on, config ) {
 			const { pattern, exclude = [] } = options;
 
 			try {
-				// Get all options matching pattern
 				const listCmd = `option list --search='${ pattern }' --field=option_name`;
 				const result = await execWp( listCmd, { returnResult: true } );
 
@@ -295,7 +287,6 @@ function setupNodeEvents( on, config ) {
 					.split( '\n' )
 					.filter( Boolean );
 
-				// Delete each option (except excluded ones)
 				for ( const optionName of optionNames ) {
 					if ( ! exclude.includes( optionName ) ) {
 						await execWp( `option delete ${ optionName }` );

--- a/doc/preselect-generate-audio.md
+++ b/doc/preselect-generate-audio.md
@@ -1,0 +1,63 @@
+# Preselect "Generate audio"
+
+How the **Preselect ‘Generate audio’** setting decides whether the Generate
+Audio toggle starts checked, and how that choice is honoured at save time
+without dirtying the post. Implemented in
+[src/settings/class-preselect.php](../src/settings/class-preselect.php),
+[src/editor/components/generate-audio/](../src/editor/components/generate-audio/)
+and [src/post/class-sync.php](../src/post/class-sync.php).
+
+## Stored format (`beyondwords_preselect` option)
+
+One entry per compatible post type, each with a `mode`:
+
+```php
+[
+    'post' => [ 'mode' => 'all' ],                 // preselect for every post
+    'page' => [
+        'mode'  => 'terms',                        // gate by taxonomy terms
+        'terms' => [
+            'category' => [ 12, 34 ],
+            'genre'    => [ 56 ],
+        ],
+    ],
+    // a missing post type (or mode 'none') means never preselect
+]
+```
+
+### Legacy (pre-7.0.0) shapes
+
+`Updater::run()` migrates the old shapes on upgrade:
+
+- `'1'` for a post type meant "preselect the whole post type" → `mode: all`.
+- A bare `[ taxonomy => [ term_ids ] ]` array meant term-gating → `mode: terms`.
+
+## Editor behaviour: derive, don't write
+
+The block editor does **not** write `beyondwords_generate_audio` meta to show a
+preselected toggle — it *derives* the checked state from the Preselect setting.
+An untouched post therefore stays clean (no dirty state, no meta write) until
+the user actually changes something.
+
+The classic editor's checkbox writes an explicit `'1'`/`'0'` on save. Its
+metabox JS only handles live changes (project/taxonomy edits while the screen
+is open); the server renders the correct initial state, and the JS stops
+adjusting once the user toggles the checkbox themselves so a deliberate choice
+is never clobbered.
+
+## Save-time decision
+
+Because a preselected-but-untouched post has no meta, the generate decision
+must come from the setting at save time:
+
+1. An explicit `beyondwords_generate_audio` value always wins
+   (`'1'` = generate, `'0'` = don't).
+2. When unset, `Sync::should_generate_audio_for_post()` falls back to
+   `Preselect::should_preselect_for_post()` — but **only for editor/REST
+   saves** (`REST_REQUEST`). Programmatic and imported posts
+   (`wp_insert_post()`, WXR import, cron) keep the explicit-meta requirement so
+   a bulk import never unexpectedly generates audio.
+
+`Preselect::get()` applies an explicit default-value fallback rather than
+relying on `register_setting` defaults (those only apply where the setting is
+registered), keeping REST/cron decisions in step with what the editor displays.

--- a/doc/rest-meta-visibility.md
+++ b/doc/rest-meta-visibility.md
@@ -1,0 +1,49 @@
+# REST meta visibility
+
+How BeyondWords post meta is exposed (or hidden) over the WordPress REST API.
+Implemented in [src/post/class-sync.php](../src/post/class-sync.php)
+(`register_meta()`, `hide_private_meta_from_rest()`).
+
+## Registration model
+
+`Sync::register_meta()` registers **every** BeyondWords post-meta key, per
+compatible post type, so that:
+
+- all writes are sanitised (`sanitize_text_field`, or the strict
+  `Meta::sanitize_content_id()` charset check for `beyondwords_content_id`,
+  whose value is interpolated into API URL paths);
+- the legacy "Custom Fields" panel stays hidden via `is_protected_meta()`
+  (the block editor's panel can break when plugin meta renders there —
+  see [gutenberg#23078](https://github.com/WordPress/gutenberg/issues/23078));
+- only the keys the block editor actually reads/writes over REST get
+  `show_in_rest => true`.
+
+Secrets and internal data — the legacy `speechkit_access_key`, cached API
+responses, player/voice config — are registered `show_in_rest => false` and
+never reach the REST API.
+
+## Legacy keys still exposed (`Sync::REST_LEGACY_META_KEYS`)
+
+On a site upgraded from the legacy SpeechKit plugin, deprecated keys
+(`speechkit_project_id`, `speechkit_podcast_id`, `_speechkit_link`, …) can hold
+a post's only BeyondWords data until audio is regenerated under v7. The block
+editor reads them in the authenticated `edit` context as a fallback — the error
+notice, pending notice, play/preview controls, the "Generate audio" toggle and
+the legacy player link all depend on them (see the components under
+[src/editor/components/](../src/editor/components/)).
+
+## Hiding private meta from public REST (`Sync::REST_PRIVATE_META_KEYS`)
+
+A handful of REST-exposed keys hold secrets or internal data: BeyondWords API
+error strings, the audio preview token, and the legacy player URL.
+
+`WP_REST_Meta_Fields` returns `show_in_rest` meta in the public `view` context
+too, with **no capability check** — so an anonymous `GET /wp/v2/posts/:id`
+would disclose them. Requesting the `edit` context is itself permission-gated
+by the posts controller, so `Sync::hide_private_meta_from_rest()` keeps those
+keys only for `edit` requests and strips them from every other response —
+closing the anonymous disclosure while leaving the block editor unaffected.
+The filter is registered on `rest_api_init` so it only loads for REST requests.
+
+See also: [legacy-meta-migration.md](./legacy-meta-migration.md) for how keys
+moved between the `current` and `deprecated` sets.

--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -99,6 +99,23 @@ To run the coverage gate standalone (without re-running the suite):
 npm run composer:tests -- test:coverage-check
 ```
 
+##  Flaky-test lore
+
+Hard-won details behind some non-obvious patterns in the Cypress suite:
+
+- **`cy.getEditorCanvasBody()`** (`tests/cypress/support/commands.js`) must not
+  introduce a `.then( cy.wrap )` boundary. Pinning the resolved `<body>`
+  subject breaks Cypress's retry-ability when the block-editor iframe
+  re-renders during hydration — it fails as *"subject is no longer attached to
+  the DOM"*, seen mostly on slower PHP 8.0 CI runs. Whether the editor canvas
+  is an iframe is stable for a given WordPress version, so it is detected once
+  synchronously via `Cypress.$` instead.
+- **Stubbing voices in the block editor doesn't work**: `cy.intercept` on the
+  REST voices route stubs fine in the classic editor, but the block editor's
+  `wp.data` store ends up empty. Branches that depend on voice-list contents
+  (e.g. the single-bucket Model/Voice case) are covered by the classic-editor
+  spec plus Jest unit tests instead.
+
 ##  Further reading
 
 * [Xdebug IDE support](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#xdebug-ide-support).

--- a/doc/settings-internals.md
+++ b/doc/settings-internals.md
@@ -1,0 +1,30 @@
+# Settings internals
+
+Non-obvious plumbing behind the plugin settings screens, implemented in
+[src/settings/class-utils.php](../src/settings/class-utils.php) and
+[src/settings/class-tabs.php](../src/settings/class-tabs.php).
+
+## Settings-error transport (`Utils::add_settings_error_message()`)
+
+Error notices raised while saving settings must survive the Settings API's
+`wp_redirect()` back to the settings page. They are carried in a **transient**,
+not `wp_cache_*`: WordPress's default object cache is request-scoped, so on
+hosts without a persistent Redis/Memcached drop-in a cache entry would be empty
+after the redirect. Transients fall back to the options table, which does
+persist. The 30-second TTL deliberately matches core's own `settings_errors`
+transient.
+
+## API connection check (`Utils::validate_api_connection()`)
+
+`beyondwords_valid_api_connection` stores a **timestamp** recording the last
+successful credential validation. It gates visibility of the Integration /
+Preferences tabs via `Tabs::get_visible_tabs()`.
+
+- The validation request relies on `Client::DEFAULT_REQUEST_TIMEOUT`, so a slow
+  or unreachable API cannot block admin rendering.
+- Transient failures (timeout, DNS, 5xx, `WP_Error`) intentionally leave the
+  last known-good flag in place — a blip should not lock the operator out of
+  the settings tabs.
+- Only authentication failures clear it: a 401 (in `Client::call_api()`) or a
+  403 (in the validation itself), after which the settings page re-runs
+  validation.

--- a/doc/video-settings-payload.md
+++ b/doc/video-settings-payload.md
@@ -1,0 +1,36 @@
+# Video settings payload
+
+Why `Content::get_video_settings_params()` sends a full `video_settings` object
+instead of just a template ID.
+
+## Backend requirements
+
+Choosing "Video" (or "Audio + video") output opts a post into video generation,
+overriding the project's default `video_settings.enabled`. However, the
+BeyondWords backend **silently skips video generation** unless the payload
+carries all of:
+
+- `enabled: true`
+- a non-empty `variants` array
+- a non-empty `sizes` array whose entries include `width`/`height`
+
+Earlier plugin versions sent only `template.id` and `sizes[].name`/`enabled`,
+which left `variants` empty server-side — so no video was ever produced.
+
+## Approach: mirror the dashboard
+
+The BeyondWords dashboard sends the full object whenever a user customises
+video, so the plugin does the same:
+
+1. Seed the payload from the project's default video settings
+   (`Client::get_video_settings()`, fetched once and cached). The defaults are
+   fetched for the project the post publishes to — which may be a per-post
+   override of the global project — so variants and size dimensions match the
+   project the content POST actually targets.
+2. Layer the post's own choices on top:
+   - the chosen size becomes the only enabled size;
+   - the chosen video template overrides the project default (omitted when the
+     post has none, deferring to the project default).
+3. Anything the post doesn't customise (`variants`, and the size dimensions) is
+   echoed straight from the project defaults. The plugin exposes no per-post
+   variant control, so the project default is the correct value to send.

--- a/doc/wordpress-vip.md
+++ b/doc/wordpress-vip.md
@@ -18,3 +18,18 @@ PHP, custom JavaScript, and SVG files. We do not review HTML, CSS, SASS, many
 popular third-party JavaScript libraries, or built JavaScript files.
 
 See [Developing with VIP](https://wpvip.com/documentation/developing-with-vip)
+
+##  Object-cache notes
+
+On hosts with an external object cache (VIP uses Memcached), transients are not
+stored as `_transient_*` rows in the options table, so they cannot be
+enumerated or bulk-deleted. This is why:
+
+- the uninstaller's transient cleanup only deletes known keys — anything else
+  holds a TTL and self-expires;
+- the API client salts its cache keys with the project ID + API key
+  (`Client::cache_key()`), so changing credentials invalidates the cache
+  implicitly with no flush step.
+
+See also [async-rest-migration.md](./async-rest-migration.md) for the
+VIP-gated background (cron) audio generation.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,27 +1,12 @@
 #!/usr/bin/env bash
 #
-# bump-version.sh — set the plugin version in every place it lives, in one command.
+# bump-version.sh — set the plugin version in every place it lives (see usage()).
 #
-# Usage:
-#   scripts/bump-version.sh <version>
-#
-# Example:
-#   scripts/bump-version.sh 7.0.0-beta.1
-#   scripts/bump-version.sh 7.0.0
-#
-# Updates, atomically-ish (all-or-nothing after validation):
-#   - speechkit.php       plugin header `Version:` line
-#   - speechkit.php       BEYONDWORDS__PLUGIN_VERSION constant
-#   - package.json        "version"
-#   - package-lock.json   root "version" and packages[""]."version"
-#   - readme.txt          "Stable tag:"
-#
-# It does NOT touch the changelog headings (those are curated by hand) and does
-# not create a git commit or tag — run it, review the diff, then commit.
+# Changelog headings are curated by hand, and no git commit or tag is created —
+# run it, review the diff, then commit.
 
 set -euo pipefail
 
-# --- locate the repo root relative to this script, so it works from any cwd ---
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
@@ -45,7 +30,6 @@ EOF
 
 die() { echo "bump-version: error: $*" >&2; exit 1; }
 
-# --- args -------------------------------------------------------------------
 [ $# -eq 1 ] || usage
 NEW="$1"
 
@@ -53,20 +37,18 @@ case "$NEW" in
   -h|--help) usage ;;
 esac
 
-# Semver: MAJOR.MINOR.PATCH with optional -prerelease and +build (dot-separated
-# alphanumeric identifiers). Rejects a leading "v", trailing spaces, etc.
+# Strict semver; rejects a leading "v", trailing spaces, etc.
 if ! printf '%s' "$NEW" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
   die "'$NEW' is not a valid semver version (expected e.g. 7.0.0 or 7.0.0-beta.1)"
 fi
 
-# --- preflight: required tools and files ------------------------------------
 command -v node >/dev/null 2>&1 || die "node is required (used to edit the JSON files safely)"
 command -v perl >/dev/null 2>&1 || die "perl is required"
 for f in "$SPEECHKIT" "$PACKAGE_JSON" "$PACKAGE_LOCK" "$README"; do
   [ -f "$f" ] || die "expected file not found: $f (is the repo layout as expected?)"
 done
 
-# --- current canonical version (from the plugin constant) -------------------
+# The plugin constant is the canonical current version.
 OLD="$(perl -ne "print \$1 if /BEYONDWORDS__PLUGIN_VERSION\x27\s*,\s*\x27([^\x27]*)\x27/" "$SPEECHKIT")"
 [ -n "$OLD" ] || die "could not read the current version from $SPEECHKIT"
 
@@ -77,14 +59,11 @@ fi
 
 echo "bump-version: $OLD -> $NEW"
 
-# --- edit speechkit.php: header line + constant -----------------------------
 NEW="$NEW" perl -i -pe 's{^(\s*\*\s*Version:\s*)\S+}{$1$ENV{NEW}}' "$SPEECHKIT"
 NEW="$NEW" perl -i -pe 's{(BEYONDWORDS__PLUGIN_VERSION\x27\s*,\s*\x27)[^\x27]*}{$1$ENV{NEW}}' "$SPEECHKIT"
 
-# --- edit readme.txt: Stable tag --------------------------------------------
 NEW="$NEW" perl -i -pe 's{^(Stable tag:\s*)\S+}{$1$ENV{NEW}}' "$README"
 
-# --- edit package.json + package-lock.json via node (targeted, keeps format) -
 # Editing the exact JSON paths avoids clobbering any dependency's "version".
 NEW="$NEW" node -e '
   const fs = require("fs");
@@ -103,7 +82,6 @@ NEW="$NEW" node -e '
   }
 '
 
-# --- verify every location now reads NEW ------------------------------------
 declare -a checks=(
   "speechkit.php (header)|$(perl -ne 'print $1 if /^\s*\*\s*Version:\s*(\S+)/' "$SPEECHKIT")"
   "speechkit.php (constant)|$(perl -ne "print \$1 if /BEYONDWORDS__PLUGIN_VERSION\x27\s*,\s*\x27([^\x27]*)\x27/" "$SPEECHKIT")"

--- a/speechkit.php
+++ b/speechkit.php
@@ -27,15 +27,12 @@ declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || exit;
 
-// Composer autoload
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
-// Define constants
 // phpcs:disable
 define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-beta.1');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable
 
-// Bootstrap.
 BeyondWords\Core\Plugin::init();

--- a/src/api/class-client.php
+++ b/src/api/class-client.php
@@ -1,21 +1,13 @@
 <?php
 /**
- * BeyondWords REST API client.
+ * BeyondWords REST API client: one method per endpoint, errors normalised into post meta.
  *
- * Thin wrapper around `wp_remote_request()` that exposes one method per
- * endpoint we touch and normalises errors into post meta for the editor UI.
- *
- * Auth (`X-Api-Key`) and JSON `Content-Type` are injected automatically via
- * the `http_request_args` filter registered in `init()` — but only for
- * outbound requests targeting the BeyondWords API host, so other plugins'
- * HTTP traffic is untouched.
+ * Auth and Content-Type headers are injected via the `http_request_args`
+ * filter, only for requests targeting the BeyondWords API host.
  *
  * @package BeyondWords\Api
  * @since   3.0.0
- * @since   7.0.0 Refactored to BeyondWords namespace with snake_case methods.
- *                Moved from BeyondWords\Core\ApiClient to BeyondWords\Api\Client.
- *                Replaced the `Request` value object with a `http_request_args`
- *                filter for header injection.
+ * @since   7.0.0 Moved from BeyondWords\Core\ApiClient to BeyondWords\Api\Client.
  */
 
 declare( strict_types = 1 );
@@ -32,26 +24,23 @@ defined( 'ABSPATH' ) || exit;
 class Client {
 
 	/**
-	 * Format used for the value stored in `beyondwords_error_message` post meta.
+	 * Format for the `beyondwords_error_message` post meta value.
 	 *
-	 * Keeping the HTTP status as the prefix lets `Sync::update_or_recreate_audio()`
-	 * recognise 404s by string-matching `#404:` without parsing the body.
+	 * The HTTP-status prefix lets `Sync::update_or_recreate_audio()` recognise
+	 * 404s by matching `#404:` without parsing the body.
 	 */
 	const ERROR_FORMAT = '#%s: %s';
 
 	/**
-	 * How long to cache editor dropdown data (languages, voices, templates,
-	 * project settings). These change rarely, so a short TTL keeps the editor
-	 * render off the network on the hot path while self-healing quickly.
+	 * How long to cache editor dropdown data (languages, voices, templates, project settings).
 	 */
 	const CACHE_TTL = 15 * MINUTE_IN_SECONDS;
 
 	/**
-	 * How long to negative-cache a *failed* editor-dropdown fetch (WP_Error /
-	 * timeout, 5xx, 4xx, non-JSON). Much shorter than CACHE_TTL so a transient
-	 * outage self-heals within minutes, but long enough that a slow or
-	 * unreachable API is probed at most once per interval rather than blocking
-	 * every admin edit-screen render.
+	 * How long to negative-cache a failed editor-dropdown fetch.
+	 *
+	 * Short enough that an outage self-heals within minutes, long enough that an
+	 * unreachable API doesn't block every admin edit-screen render.
 	 *
 	 * @since 7.0.0
 	 */
@@ -60,12 +49,8 @@ class Client {
 	/**
 	 * Default timeout, in seconds, for a BeyondWords API request.
 	 *
-	 * VIP's approved ceiling for a blocking remote request — the
-	 * `WordPressVIPMinimum.Performance.RemoteRequestTimeout` sniff errors above
-	 * 3 seconds. The API answers fast on every endpoint except voices: content
-	 * create/update returns the content ID immediately and generates the audio
-	 * asynchronously server-side, so even the write paths have no reason to
-	 * wait longer than this.
+	 * VIP's approved ceiling for a blocking remote request; content writes return
+	 * immediately and generate audio server-side, so nothing needs longer.
 	 *
 	 * @since 7.0.0
 	 */
@@ -74,12 +59,8 @@ class Client {
 	/**
 	 * Timeout, in seconds, for the voices GET — the one slow endpoint.
 	 *
-	 * Voices is genuinely slow to prepare — ~3.7s p95 in Sentry, against
-	 * ~250ms p95 for every other GET — so the shared `DEFAULT_REQUEST_TIMEOUT`
-	 * would abandon more than 5% of cold-cache fetches. Because a failure is
-	 * then negative-cached, that would blank the Voice dropdown for a whole
-	 * `CACHE_TTL_ON_ERROR` rather than just the one render. Only ever paid on
-	 * a cache miss.
+	 * Voices is ~3.7s p95 against ~250ms for every other GET, so the default
+	 * timeout would abandon (and then negative-cache) many cold-cache fetches.
 	 *
 	 * @since 7.0.0
 	 */
@@ -88,20 +69,16 @@ class Client {
 	/**
 	 * Register WordPress hooks.
 	 *
-	 * Must run early in the plugin bootstrap so the `http_request_args` filter
-	 * is in place before any code makes a BeyondWords API call.
+	 * Must run early in the bootstrap so the filter precedes any API call.
 	 */
 	public static function init(): void {
-		// The VIP "manual inspection" warning on this filter is for code that
-		// raises the request timeout — `filter_http_request_args()` only adds
-		// headers and never touches the timeout, so the warning is suppressed.
+		// The VIP warning targets raised timeouts; this filter only adds headers.
 		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 		add_filter( 'http_request_args', [ self::class, 'filter_http_request_args' ], 10, 2 );
 	}
 
 	/**
-	 * Inject the BeyondWords `X-Api-Key` and `Content-Type: application/json`
-	 * headers, but only for outbound requests targeting the BeyondWords API.
+	 * Inject `X-Api-Key` and JSON `Content-Type` headers for BeyondWords API requests only.
 	 *
 	 * @param array<string,mixed> $args WordPress HTTP args.
 	 * @param string              $url  Outbound request URL.
@@ -143,17 +120,11 @@ class Client {
 	/**
 	 * GET /projects/:project/content/:content_id
 	 *
-	 * Falls back to the global `beyondwords_project_id` option when no project
-	 * ID is supplied.
-	 *
 	 * @param string          $content_id BeyondWords content ID.
 	 * @param int|string|null $project_id Optional project ID override.
 	 *
-	 * @return array<mixed>|\WP_Error|false Raw HTTP response array, a `\WP_Error`
-	 *                                      on transport-level failure (unreachable
-	 *                                      host, timeout) which the caller surfaces
-	 *                                      as a connection error, or false when the
-	 *                                      project/content ID is missing.
+	 * @return array<mixed>|\WP_Error|false Raw HTTP response, WP_Error on transport
+	 *                                      failure, or false when an ID is missing.
 	 */
 	public static function get_content( int|string $content_id, int|string|null $project_id = null ): array|\WP_Error|false {
 		if ( ! $project_id ) {
@@ -199,7 +170,7 @@ class Client {
 	 *
 	 * @param int $post_id WordPress post ID.
 	 *
-	 * @return array<mixed>|null|false
+	 * @return array<mixed>|null|false Decoded response body, or false when an ID is missing.
 	 */
 	public static function update_audio( int $post_id ): array|null|false {
 		$project_id = \BeyondWords\Post\Meta::get_project_id( $post_id );
@@ -219,9 +190,6 @@ class Client {
 	/**
 	 * DELETE /projects/:project/content/:content_id
 	 *
-	 * Resolves the project + content IDs from the post's meta and delegates to
-	 * `delete_audio_by_ids()`.
-	 *
 	 * @param int $post_id WordPress post ID.
 	 *
 	 * @return array<mixed>|null|false `false` when the request didn't return 204.
@@ -237,11 +205,7 @@ class Client {
 	 * DELETE /projects/:project/content/:content_id using explicit IDs.
 	 *
 	 * Split out from `delete_audio()` so the deferred trash/delete cron job can
-	 * delete audio from the project + content IDs captured before the post meta
-	 * was wiped (see `\BeyondWords\Post\Sync::delete_audio_by_ids()`). Deletion
-	 * runs on the synchronous trash/delete admin path and is best-effort (a
-	 * timeout just leaves the audio in the BeyondWords dashboard), so the short
-	 * default timeout applies.
+	 * still delete after the post meta has been wiped.
 	 *
 	 * @since 7.0.0
 	 *
@@ -269,9 +233,7 @@ class Client {
 	/**
 	 * POST /projects/:project/content/batch_delete
 	 *
-	 * Accepts a heterogeneous list of WordPress post IDs, groups them by
-	 * BeyondWords project, and refuses cross-project batches (the API only
-	 * supports one project per request).
+	 * Refuses cross-project batches — the API only supports one project per request.
 	 *
 	 * @param int[] $post_ids WordPress post IDs.
 	 *
@@ -322,17 +284,14 @@ class Client {
 
 		$response_code = wp_remote_retrieve_response_code( $response );
 
-		// 2xx means the API accepted the batch — return the IDs we sent so the
-		// caller can clear local meta. Anything else: refuse to clear meta so
-		// the operator can retry.
+		// On failure, return no IDs so the caller keeps local meta and can retry.
 		return $response_code <= 299 ? $updated_post_ids : [];
 	}
 
 	/**
 	 * GET /projects/:project/player/by_source_id/:post_id
 	 *
-	 * Magic Embed (client-side) bootstrap: tells BeyondWords to look up — or
-	 * create — content for the given source URL, returning the player blob.
+	 * Magic Embed bootstrap: BeyondWords looks up or creates content for the source URL.
 	 *
 	 * @param int $post_id WordPress post ID used as the source ID.
 	 *
@@ -369,9 +328,6 @@ class Client {
 
 	/**
 	 * GET /organization/voices?filter[language.code]=…
-	 *
-	 * Passes the longer `VOICES_REQUEST_TIMEOUT` — this endpoint is materially
-	 * slower than the other editor dropdowns.
 	 *
 	 * @param int|string $language_code BeyondWords language code (or numeric ID).
 	 *
@@ -435,9 +391,6 @@ class Client {
 	/**
 	 * GET /projects/:id
 	 *
-	 * Returns the project, including its default `language` code. Editor scripts
-	 * read it to pre-select the Language dropdown when "Customize" is enabled.
-	 *
 	 * @since 7.0.0
 	 *
 	 * @param int|null $project_id Optional override; falls back to the global option.
@@ -461,9 +414,6 @@ class Client {
 	/**
 	 * GET /summarization_settings_templates
 	 *
-	 * The list of script templates available to the organization. Editor
-	 * scripts use this to populate the "Script template" dropdown.
-	 *
 	 * @since 7.0.0
 	 *
 	 * @return array<mixed>|null|false
@@ -477,9 +427,6 @@ class Client {
 	/**
 	 * GET /video_settings_templates
 	 *
-	 * The list of video templates available to the organization. Editor
-	 * scripts use this to populate the "Video template" dropdown.
-	 *
 	 * @since 7.0.0
 	 *
 	 * @return array<mixed>|null|false
@@ -491,19 +438,10 @@ class Client {
 	}
 
 	/**
-	 * Make the API call, normalising errors into post meta when a post is
-	 * supplied.
+	 * Make the API call, normalising errors into post meta when a post is supplied.
 	 *
-	 * For 401 responses we also clear the cached `beyondwords_valid_api_connection`
-	 * so the settings page re-runs validation.
-	 *
-	 * Magic Embed (client-side) errors are not persisted because the SDK
-	 * regenerates content lazily — surfacing those errors in the editor would
-	 * be misleading.
-	 *
-	 * Headers `X-Api-Key` and `Content-Type` are injected automatically by the
-	 * `http_request_args` filter registered in `init()` — pass `$headers`
-	 * here for any *additional* per-request headers.
+	 * A 401 also clears `beyondwords_valid_api_connection` so the settings page
+	 * re-runs validation.
 	 *
 	 * @param string               $method  HTTP method.
 	 * @param string               $url     Absolute URL.
@@ -540,15 +478,13 @@ class Client {
 	/**
 	 * Build the WordPress HTTP args for a BeyondWords API call.
 	 *
-	 * Auth and Content-Type headers are *not* added here — they're injected
-	 * by `filter_http_request_args()` so the same logic applies to any other
-	 * code that calls `wp_remote_request()` against the BeyondWords API.
+	 * Auth and Content-Type headers are added by `filter_http_request_args()`,
+	 * not here, so they also apply to third-party calls against the API.
 	 *
 	 * @param string               $method  HTTP method.
 	 * @param string               $body    Request body.
 	 * @param array<string,string> $headers Extra per-request headers.
-	 * @param int                  $timeout Request timeout in seconds. Defaults to DEFAULT_REQUEST_TIMEOUT;
-	 *                                      the voices GET passes the longer VOICES_REQUEST_TIMEOUT.
+	 * @param int                  $timeout Request timeout in seconds.
 	 *
 	 * @return array<string,mixed>
 	 */
@@ -565,9 +501,8 @@ class Client {
 	/**
 	 * Build a transient key for a cached GET.
 	 *
-	 * Salted with the project ID + API key so changing either invalidates the
-	 * cache implicitly — no explicit flush needed, which matters on object-cache
-	 * hosts (e.g. VIP) where `_transient_*` rows can't be enumerated.
+	 * Salted with the project ID + API key so changing either invalidates
+	 * implicitly — no flush needed, which object-cache hosts can't do anyway.
 	 *
 	 * @since 7.0.0
 	 *
@@ -586,23 +521,14 @@ class Client {
 	/**
 	 * GET an editor-render-path endpoint, caching both hits and failures.
 	 *
-	 * Successful 2xx array responses are cached for {@see CACHE_TTL}. Failures
-	 * (WP_Error / timeout, 5xx, 4xx, non-JSON) are negative-cached for the much
-	 * shorter {@see CACHE_TTL_ON_ERROR}, so a slow or unreachable API is probed
-	 * at most once per interval instead of re-issuing a blocking request on
-	 * every admin render. The request itself uses the short
-	 * {@see DEFAULT_REQUEST_TIMEOUT} for the same reason; the slower voices
-	 * endpoint passes its own {@see VOICES_REQUEST_TIMEOUT}.
-	 *
-	 * A 401 additionally self-heals: call_api() clears
-	 * `beyondwords_valid_api_connection`, which ungates the metabox next load.
+	 * Failures are negative-cached for the shorter {@see CACHE_TTL_ON_ERROR} so
+	 * an unreachable API is probed at most once per interval, not every render.
 	 *
 	 * @since 7.0.0
 	 *
 	 * @param string $suffix  Cache-key suffix (include any project/language id).
 	 * @param string $url     Absolute endpoint URL.
-	 * @param int    $timeout Request timeout in seconds. Defaults to DEFAULT_REQUEST_TIMEOUT;
-	 *                        the voices GET passes the longer VOICES_REQUEST_TIMEOUT.
+	 * @param int    $timeout Request timeout in seconds.
 	 *
 	 * @return array<mixed>|null|false Decoded body on the fetching call; the cached
 	 *                                 value ([] after a cached failure) thereafter.
@@ -628,8 +554,6 @@ class Client {
 			return $decoded;
 		}
 
-		// Negative-cache the failure so the next render is served from the
-		// transient instead of blocking on another remote round-trip.
 		set_transient( $key, [], self::CACHE_TTL_ON_ERROR );
 
 		return $decoded;
@@ -653,9 +577,8 @@ class Client {
 				}
 				$message = implode( ', ', $messages );
 			} elseif ( array_key_exists( 'message', $body ) ) {
-				// The API body is arbitrary JSON, so `message` may be null, a
-				// number, or a nested structure. Coerce to a string so the
-				// `: string` return type holds under strict_types.
+				// `message` is arbitrary JSON; coerce so the `: string` return
+				// type holds under strict_types.
 				$message = is_string( $body['message'] )
 					? $body['message']
 					: (string) wp_json_encode( $body['message'] );

--- a/src/compatibility/class-wpgraphql.php
+++ b/src/compatibility/class-wpgraphql.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * WPGraphQL compatibility.
- *
- * Exposes BeyondWords audio metadata as a GraphQL type and field on every
- * BeyondWords-compatible post type.
+ * WPGraphQL compatibility: a BeyondWords GraphQL type + field on compatible post types.
  *
  * @package BeyondWords\Compatibility
  * @since   3.6.0

--- a/src/core/class-plugin.php
+++ b/src/core/class-plugin.php
@@ -2,11 +2,6 @@
 /**
  * Plugin bootstrap.
  *
- * Single static `init()` invoked from `speechkit.php` after the autoloader
- * is registered. Runs migrations, registers cross-cutting hooks, then wires
- * up the per-screen UI classes — but only when the API connection is valid,
- * to keep the admin clean for un-authenticated installs.
- *
  * @package BeyondWords\Core
  * @since   3.0.0
  * @since   7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -31,56 +26,37 @@ class Plugin {
 	/**
 	 * Boot the plugin.
 	 *
-	 * Order matters — `Updater::run()` first because subsequent classes read
-	 * the `beyondwords_version` option it normalises. Settings classes register
-	 * before the per-screen UI so that `Settings\Utils::has_valid_api_connection()`
-	 * can gate UI registration on the result.
+	 * Order matters: `Updater::run()` normalises the version option later classes
+	 * read, and Settings must register before the API-connection-gated UI wiring.
 	 */
 	public static function init(): void {
 		Updater::run();
 
-		// API client — registers the http_request_args filter that injects
-		// auth + Content-Type for outbound BeyondWords API calls. Must run
-		// before anything that might issue an API request.
+		// Must run before anything that might issue an API request.
 		\BeyondWords\Api\Client::init();
 
-		// Third-party compatibility shims.
 		\BeyondWords\Compatibility\WPGraphQL::init();
-
-		// WordPress ↔ BeyondWords post sync (save/trash/delete + meta registration).
 		\BeyondWords\Post\Sync::init();
-
-		// Site Health debug panel.
 		\BeyondWords\SiteHealth\SiteHealth::init();
-
-		// Front-end player rendering.
 		\BeyondWords\Player\Player::init();
-
-		// Post screen entry point — head meta tags for singular pages.
 		\BeyondWords\Post\Head::init();
 
-		// Settings page + REST endpoints.
 		\BeyondWords\Settings\Tabs::init();
 		\BeyondWords\Settings\Fields::init();
 		\BeyondWords\Settings\Preselect::init();
 		\BeyondWords\Settings\Settings::init();
 
-		// Skip admin UI when we don't have credentials yet — prevents broken
-		// JS in the editor for fresh installs.
+		// Skip admin UI without credentials — prevents broken editor JS on fresh installs.
 		if ( ! \BeyondWords\Settings\Utils::has_valid_api_connection() ) {
 			return;
 		}
 
-		// Block-editor JS bootstrap (registers every @wordpress/plugins slot
-		// under src/editor/).
 		\BeyondWords\Editor\Block\Assets::init();
 
-		// Posts list screen (edit.php) — column, bulk-edit, admin notices.
 		\BeyondWords\PostsList\Column::init();
 		\BeyondWords\PostsList\BulkEdit::init();
 		\BeyondWords\PostsList\Notices::init();
 
-		// Post edit screen — top-level UI.
 		\BeyondWords\Editor\Components\AddPlayer::init();
 		\BeyondWords\Editor\Components\BlockAttributes::init();
 		\BeyondWords\Editor\Components\ErrorNotice\Assets::init();
@@ -88,7 +64,6 @@ class Plugin {
 		\BeyondWords\Editor\Components\InspectPanel\Assets::init();
 		\BeyondWords\Editor\Components\Sidebar\Assets::init();
 
-		// Post edit screen — classic-editor metabox controls.
 		\BeyondWords\Editor\Components\ContentId::init();
 		\BeyondWords\Editor\Components\ContentId\Assets::init();
 		\BeyondWords\Editor\Components\GenerateAudio::init();

--- a/src/core/class-uninstaller.php
+++ b/src/core/class-uninstaller.php
@@ -1,12 +1,6 @@
 <?php
 /**
- * Uninstall cleanup.
- *
- * Invoked from `uninstall.php` when WordPress removes the plugin. Deletes
- * every option, transient, and post-meta key recorded in `Utils`. On
- * multisite each site is cleaned in turn, since `uninstall.php` only runs
- * once — in the network's main-site context — and every value is stored
- * per-site.
+ * Uninstall cleanup: deletes every BeyondWords option, transient and post-meta row.
  *
  * @package BeyondWords\Core
  * @since   3.7.0
@@ -29,14 +23,8 @@ class Uninstaller {
 	/**
 	 * Run the full uninstall cleanup for every site on the install.
 	 *
-	 * WordPress executes `uninstall.php` a single time, in the context of the
-	 * network's main site. Every BeyondWords value — options, transients and
-	 * post-meta — is stored per-site (`update_option()` and the per-site
-	 * `options`/`postmeta` tables); the plugin never writes network/site
-	 * options. So on multisite we must visit each site in turn, otherwise only
-	 * the main site is cleaned and every subsite keeps its settings, including
-	 * the `beyondwords_api_key` secret. Single-site installs are cleaned in one
-	 * pass.
+	 * `uninstall.php` runs once, in the main site's context, yet every value is
+	 * stored per-site — so on multisite each site must be visited in turn.
 	 *
 	 * @since 7.0.0
 	 *
@@ -48,8 +36,7 @@ class Uninstaller {
 			return;
 		}
 
-		// `number => 0` lifts the default 100-site cap so no site is skipped on
-		// large networks.
+		// `number => 0` lifts the default 100-site cap.
 		$site_ids = get_sites(
 			[
 				'fields' => 'ids',
@@ -65,8 +52,7 @@ class Uninstaller {
 	}
 
 	/**
-	 * Delete every BeyondWords option, transient and post-meta value for the
-	 * current site.
+	 * Delete every BeyondWords value for the current site.
 	 *
 	 * @since 7.0.0
 	 *
@@ -86,11 +72,8 @@ class Uninstaller {
 	public static function cleanup_plugin_transients(): int {
 		global $wpdb;
 
-		// Each transient is stored as a pair of options — `_transient_<key>` and
-		// `_transient_timeout_<key>` — so both prefixes must be swept, otherwise
-		// the timeout rows are left orphaned. (On external-object-cache hosts,
-		// e.g. VIP, there are no option rows to delete; those entries hold a TTL
-		// and self-expire.)
+		// Transients are stored as `_transient_<key>` + `_transient_timeout_<key>`
+		// option pairs; sweep both prefixes or the timeout rows are orphaned.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		$count = $wpdb->query(
 			"DELETE FROM $wpdb->options
@@ -104,9 +87,6 @@ class Uninstaller {
 	/**
 	 * Delete every BeyondWords plugin option (current + deprecated).
 	 *
-	 * Iterates the list from `Utils::get_options( 'all' )` so this stays
-	 * in sync with new keys without uninstall code changes.
-	 *
 	 * @return int Options deleted.
 	 */
 	public static function cleanup_plugin_options(): int {
@@ -114,19 +94,13 @@ class Uninstaller {
 		$total   = 0;
 
 		foreach ( $options as $option ) {
-			// Every option is stored per-site via `update_option()`, so
-			// `delete_option()` is the correct call on both single-site and
-			// multisite. The previous `delete_site_option()`-only branch swept
-			// `wp_sitemeta` rows that were never written and left every real
-			// option — including the `beyondwords_api_key` secret — in place on
-			// multisite.
+			// Options are stored per-site via `update_option()`, so `delete_option()`
+			// is the correct call on both single-site and multisite.
 			if ( delete_option( $option ) ) {
 				++$total;
 			}
 
-			// Defensive: a legacy install may have stored a matching network
-			// (site) option. This is network-global and idempotent, so it is a
-			// harmless no-op when nothing was stored.
+			// Defensive: a legacy install may have stored a matching network option.
 			if ( is_multisite() ) {
 				delete_site_option( $option );
 			}
@@ -138,9 +112,8 @@ class Uninstaller {
 	/**
 	 * Delete every BeyondWords post-meta value.
 	 *
-	 * Done one meta_id at a time to keep individual queries fast on sites with
-	 * many posts — the alternative `DELETE … WHERE meta_key IN (…)` can lock
-	 * the postmeta table for unacceptably long.
+	 * Deletes by meta_id in per-key batches — a single `DELETE … WHERE meta_key
+	 * IN (…)` can lock the postmeta table for unacceptably long.
 	 *
 	 * @return int Meta rows deleted.
 	 */

--- a/src/core/class-updater.php
+++ b/src/core/class-updater.php
@@ -1,10 +1,6 @@
 <?php
 /**
- * Plugin update routines.
- *
- * Runs on every page load; cheap when nothing's changed because `run()` bails
- * as soon as the recorded version matches this build. Each migration is gated
- * on a version bump so it executes at most once per upgrade path.
+ * Plugin update routines: version-gated migrations run on every page load.
  *
  * @package BeyondWords\Core
  * @since   3.0.0
@@ -27,20 +23,12 @@ class Updater {
 	/**
 	 * Run any pending migrations and update the recorded plugin version.
 	 *
-	 * Bails immediately once the recorded version matches this build, so the
-	 * migrations run at most once per version change instead of on every
-	 * request. That guard — not the per-migration `version_compare` gates — is
-	 * what makes the common path cheap: a pre-release build such as
-	 * `7.0.0-beta.1` compares `< 7.0.0`, so those gates never close on it and
-	 * would otherwise re-run the v7 migrations (~40 uncached queries plus a slow
-	 * postmeta JOIN) on every page load, front end included.
+	 * The exact-version bail — not the `version_compare` gates — keeps the common
+	 * path cheap: a pre-release like `7.0.0-beta.1` compares `< 7.0.0` forever.
 	 */
 	public static function run(): void {
 		$version = get_option( 'beyondwords_version', '1.0.0' );
 
-		// Already up to date: nothing to migrate, and the version write below
-		// would be a no-op. Bail before touching the database. This is the hot
-		// path — it runs on every request once the plugin has booted once.
 		if ( BEYONDWORDS__PLUGIN_VERSION === $version ) {
 			return;
 		}
@@ -69,14 +57,8 @@ class Updater {
 	/**
 	 * Convert the legacy preselect option to the 7.0.0 mode-based format.
 	 *
-	 * Pre-7.0.0 stored either `'1'` (whole post type) or
-	 * `[ taxonomy => [ term ids ] ]` (term-gated) per post type. 7.0.0 stores
-	 * `[ 'mode' => 'all' ]` or `[ 'mode' => 'terms', 'terms' => [...] ]`.
-	 *
-	 * Reuses the tolerant readers on `Preselect`, so it is idempotent: already
-	 * mode-based values pass through unchanged. Pre-release builds compare
-	 * `< 7.0.0`, so this can re-run once on each dev-version bump — idempotency
-	 * keeps those re-runs safe.
+	 * Reuses the tolerant readers on `Preselect`, so it is idempotent — which
+	 * keeps the re-runs pre-release builds trigger (`< 7.0.0` forever) safe.
 	 *
 	 * @since 7.0.0
 	 */
@@ -116,10 +98,7 @@ class Updater {
 	/**
 	 * v7.0.0: remove every option marked deprecated in `Utils::get_options()`.
 	 *
-	 * Targets the player styling, voice, and project options that v7.0.0 dropped
-	 * (audio/video output now sourced from the BeyondWords project, not WP), as
-	 * well as long-stale pre-v3 `speechkit_*` options. Multisite-aware because
-	 * legacy installs may have stored these as site options.
+	 * Multisite-aware because legacy installs may have stored these as site options.
 	 *
 	 * @since 7.0.0
 	 */
@@ -134,13 +113,10 @@ class Updater {
 	}
 
 	/**
-	 * v7.0.0: the per-post "Display player" opt-out (`beyondwords_disabled`) is
-	 * replaced by the Embed dropdown's "None" option.
+	 * v7.0.0: migrate the legacy `beyondwords_disabled` opt-out to Embed "None".
 	 *
-	 * Carry the flag forward so previously-hidden players stay hidden, then drop
-	 * the legacy key. Only posts that explicitly disabled the player carry the
-	 * flag, so the set is small; we still batch to keep memory bounded. We never
-	 * overwrite an Embed value the post already has.
+	 * Carries the flag forward so previously-hidden players stay hidden; never
+	 * overwrites an existing Embed value, and batches to keep memory bounded.
 	 *
 	 * @since 7.0.0
 	 */
@@ -182,8 +158,6 @@ class Updater {
 
 	/**
 	 * v3.0.0: migrate `speechkit_settings.*` array values to top-level options.
-	 *
-	 * Skipped when `speechkit_settings` is empty (already migrated or never set).
 	 */
 	public static function migrate_settings(): void {
 		$old_settings = get_option( 'speechkit_settings', [] );
@@ -210,8 +184,7 @@ class Updater {
 	}
 
 	/**
-	 * Build a v3 preselect array from the v2 `speechkit_select_post_types` +
-	 * `speechkit_selected_categories` fields.
+	 * Build a v3 preselect array from the v2 post-type + category settings.
 	 *
 	 * @return array<string,mixed>|false `false` when the legacy `speechkit_settings` option is missing.
 	 */
@@ -250,8 +223,9 @@ class Updater {
 	}
 
 	/**
-	 * v3.7.0: copy `speechkit_*` option keys to `beyondwords_*` while leaving
-	 * the originals in place so plugin downgrades remain safe.
+	 * v3.7.0: copy `speechkit_*` option keys to `beyondwords_*`.
+	 *
+	 * Originals are left in place so plugin downgrades remain safe.
 	 */
 	public static function rename_plugin_settings(): void {
 		$api_key         = get_option( 'speechkit_api_key' );

--- a/src/core/class-urls.php
+++ b/src/core/class-urls.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * BeyondWords URL registry.
- *
- * Each accessor returns the override defined in `wp-config.php` if present,
- * falling back to the production constant baked into the class.
+ * BeyondWords URL registry: production defaults with optional `wp-config.php` overrides.
  *
  * @package BeyondWords\Core
  * @since   3.0.0

--- a/src/core/class-utils.php
+++ b/src/core/class-utils.php
@@ -15,8 +15,7 @@ namespace BeyondWords\Core;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Core-wide utilities: editor-screen detection and the option/meta-key registries
- * the uninstaller iterates.
+ * Core-wide utilities: editor-screen detection and option/meta-key registries.
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
@@ -65,8 +64,6 @@ class Utils {
 
 	/**
 	 * Whether the current request is being served as AMP.
-	 *
-	 * Tries the official AMP plugin, AMP for WP, and the legacy `is_amp_endpoint()`.
 	 */
 	public static function is_amp(): bool {
 		return (
@@ -89,9 +86,8 @@ class Utils {
 	 * @throws \Exception When `$type` is unrecognised.
 	 */
 	public static function get_post_meta_keys( string $type = 'current' ): array {
-		// Order matches the editor Inspect panel display/copy order. Every
-		// consumer treats this as a set (in_array / foreach), so the order only
-		// affects the block-editor Copy payload, which sources it from here.
+		// Order matches the editor Inspect panel display/copy order; every other
+		// consumer treats this as a set.
 		$current = [
 			'beyondwords_generate_audio',
 			'beyondwords_project_id',
@@ -177,8 +173,7 @@ class Utils {
 		];
 
 		$deprecated = [
-			// Removed in v7.0.0 — settings UI consolidated to three tabs and
-			// player/project styling moved to the BeyondWords dashboard.
+			// Removed in v7.0.0 — player/project styling moved to the BeyondWords dashboard.
 			'beyondwords_player_call_to_action',
 			'beyondwords_player_clickable_sections',
 			'beyondwords_player_content',

--- a/src/editor/block/class-assets.php
+++ b/src/editor/block/class-assets.php
@@ -2,9 +2,6 @@
 /**
  * BeyondWords block-editor asset enqueue.
  *
- * Owns the registration and enqueue of the bundled block-editor JS that
- * registers every `@wordpress/plugins` slot under [src/editor/block/](src/editor/block/).
- *
  * @package BeyondWords\Editor\Block
  * @since   7.0.0
  */
@@ -32,10 +29,8 @@ class Assets {
 	/**
 	 * Enqueue the bundled block-editor JS on compatible post-type screens.
 	 *
-	 * The API-valid gate is handled at bootstrap time in
-	 * [src/core/class-plugin.php](src/core/class-plugin.php) — `init()`
-	 * isn't called without a valid API connection — so we only need the
-	 * per-request post-type check here.
+	 * No API-valid check needed: class-plugin.php only calls init() with a
+	 * valid API connection.
 	 */
 	public static function enqueue_block_editor_assets(): void {
 		if ( ! in_array( get_post_type(), \BeyondWords\Settings\Utils::get_compatible_post_types(), true ) ) {

--- a/src/editor/block/document-setting/index.js
+++ b/src/editor/block/document-setting/index.js
@@ -17,9 +17,8 @@ import PlayAudio from '../../components/play-audio';
 import Stack from '../../components/stack';
 
 export default class DocumentSettingPanel extends Component {
-	// The Voice (Customize/Language/Voice) and Player (Embed) settings are
-	// exposed only in the plugin sidebar; this panel keeps the "Generate audio"
-	// control plus the link to open that sidebar.
+	// Voice and Player settings live only in the plugin sidebar; this panel keeps
+	// "Generate audio" plus the link to open it.
 	render() {
 		return (
 			<PluginDocumentSettingPanel

--- a/src/editor/block/prepublish/index.js
+++ b/src/editor/block/prepublish/index.js
@@ -13,15 +13,12 @@ import ErrorNotice from '../../components/error-notice';
 import GenerateAudio from '../../components/generate-audio';
 import Stack from '../../components/stack';
 
-// The pre-publish panel renders the registered plugin's icon after the title by
-// default (a generic "plug"). Suppress it with a no-op — the brand icon already
-// sits before the label via <BeyondwordsTitle />.
+// Suppress the default plugin icon rendered after the title (a generic "plug") —
+// the brand icon already sits before the label via <BeyondwordsTitle />.
 const NoIcon = () => null;
 
 export default class PrepublishPanel extends Component {
-	// Matches the Document Settings panel: only the "Generate audio" control.
-	// The Voice (Customize/Language/Voice) and Player (Embed) settings live in
-	// the plugin sidebar.
+	// Only the "Generate audio" control; Voice and Player settings live in the plugin sidebar.
 	render() {
 		return (
 			<PluginPrePublishPanel

--- a/src/editor/classic/class-assets.php
+++ b/src/editor/classic/class-assets.php
@@ -2,10 +2,6 @@
 /**
  * BeyondWords Metabox — asset enqueue.
  *
- * Owns the classic-editor metabox stylesheet. Split from
- * [class-metabox.php](class-metabox.php) so the container/render concerns
- * stay separate from CSS registration.
- *
  * @package BeyondWords\Editor\Classic
  * @since   7.0.0
  */
@@ -33,10 +29,8 @@ class Assets {
 	/**
 	 * Enqueue Metabox CSS on classic-editor post screens for compatible post types.
 	 *
-	 * The API-valid gate is handled at bootstrap time in
-	 * [src/core/class-plugin.php](src/core/class-plugin.php) — `init()`
-	 * isn't called without a valid API connection — so we only need the
-	 * per-request hook + post-type checks here.
+	 * No API-valid check needed: class-plugin.php only calls init() with a
+	 * valid API connection.
 	 *
 	 * @param string $hook Current admin page hook.
 	 */

--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -87,7 +87,6 @@ class Metabox {
 		// Single nonce guarding the Content/Format/Player <select> fields.
 		\BeyondWords\Editor\Components\SettingsFields::nonce();
 
-		// Player section: player/errors, Embed, Generate audio.
 		self::heading( __( 'Player', 'speechkit' ) );
 
 		self::errors( $post );
@@ -100,27 +99,22 @@ class Metabox {
 			}
 		}
 
-		// The Embed dropdown ("None" = no player) replaces the old Display
-		// player checkbox.
+		// The Embed dropdown ("None" = no player) replaces the old Display player checkbox.
 		\BeyondWords\Editor\Components\SettingsFields::render_player_section( $post );
 		( new \BeyondWords\Editor\Components\GenerateAudio() )::element( $post );
 
-		// Content section: Source + Script template.
 		echo '<hr />';
 		self::heading( __( 'Content', 'speechkit' ) );
 		\BeyondWords\Editor\Components\SettingsFields::render_content_section( $post );
 
-		// Format section: Output + Video template + Video size.
 		echo '<hr />';
 		self::heading( __( 'Format', 'speechkit' ) );
 		\BeyondWords\Editor\Components\SettingsFields::render_format_section( $post );
 
-		// Voice section: Language + Voice + Model.
 		echo '<hr />';
 		self::heading( __( 'Voice', 'speechkit' ) );
 		( new \BeyondWords\Editor\Components\SelectVoice() )::element( $post );
 
-		// Data section: Content ID + Fetch button.
 		echo '<hr />';
 		self::heading( __( 'Data', 'speechkit' ) );
 		\BeyondWords\Editor\Components\ContentId::element( $post );
@@ -131,10 +125,6 @@ class Metabox {
 
 	/**
 	 * Print a settings-section heading.
-	 *
-	 * The sections mirror the block editor's Player/Content/Format/Voice panels.
-	 * A heading gives each group a label because the individual field labels
-	 * (Source, Output, Embed…) aren't self-explanatory on their own.
 	 *
 	 * @since 7.0.0
 	 *
@@ -148,12 +138,10 @@ class Metabox {
 	}
 
 	/**
-	 * The "Pending review" message, shown instead of the audio player
-	 * if the post status in WordPress is "pending".
+	 * The "Pending review" message for posts with "pending" status.
 	 *
-	 * This message is displayed instead of the player because the player
-	 * cannot be rendered for audio which has been created
-	 * with { published: false }.
+	 * Shown instead of the player, which cannot render audio created with
+	 * { published: false }.
 	 *
 	 * @since 3.7.0
 	 * @since 6.0.0 Make static.
@@ -219,19 +207,8 @@ class Metabox {
 		$content_id    = \BeyondWords\Post\Meta::get_content_id( $post->ID );
 		$preview_token = \BeyondWords\Post\Meta::get_preview_token( $post->ID );
 
-		/*
-		 * Build the player SDK config as a PHP array, then JSON-encode it for the
-		 * inline `onload` handler instead of concatenating the values by hand.
-		 *
-		 * The Content ID is editable post meta (Meta::get_content_id) and the
-		 * preview token is supplied by the REST API, so both are untrusted in this
-		 * output context. The HEX flags escape ' " < > & inside every string value
-		 * as \uXXXX, so a value cannot break out of the JS string literal, the
-		 * single-quoted attribute, or the surrounding <script> markup; the
-		 * structural JSON quotes are left intact so the spread object literal stays
-		 * valid JavaScript, and esc_attr() below encodes those for the attribute.
-		 * Mirrors \BeyondWords\Player\Renderer\Javascript::render().
-		 */
+		// The content ID and preview token are untrusted; the JSON_HEX_* flags escape
+		// them so no value breaks out of the onload attribute. Mirrors Javascript::render().
 		$config = [
 			'projectId'        => (int) $project_id,
 			'previewToken'     => (string) $preview_token,

--- a/src/editor/components/add-player/index.js
+++ b/src/editor/components/add-player/index.js
@@ -11,15 +11,13 @@ import { __ } from '@wordpress/i18n';
  */
 import { BeyondwordsIcon } from '../icon';
 
-// Register the block
 registerBlockType( 'beyondwords/player', {
 	icon: <BeyondwordsIcon />,
 	edit: function Edit() {
 		const blockProps = useBlockProps();
 
-		// The live player is not embedded in the editor preview — it only
-		// renders on the front end. Show a static Placeholder marking where
-		// the player will appear in the published post.
+		// The live player only renders on the front end; show a static
+		// Placeholder marking where it will appear.
 		return (
 			<div { ...blockProps }>
 				<Placeholder

--- a/src/editor/components/add-player/tinymce.js
+++ b/src/editor/components/add-player/tinymce.js
@@ -2,7 +2,6 @@
 
 ( function () {
 	tinymce.PluginManager.add( 'beyondwords_player', function ( editor, url ) {
-		// Command for Button
 		editor.addCommand( 'beyondwords_insert_player', function () {
 			const playerElement =
 				'<div data-beyondwords-player="true" contenteditable="false"></div>\uFEFF';
@@ -12,7 +11,6 @@
 
 		const image = url + '/tinymce-button.png';
 
-		// Add Button to Visual Editor Toolbar
 		editor.addButton( 'beyondwords_player', {
 			title: 'Insert BeyondWords player',
 			cmd: 'beyondwords_insert_player',

--- a/src/editor/components/block-attributes/addAttributes.js
+++ b/src/editor/components/block-attributes/addAttributes.js
@@ -20,7 +20,6 @@ import { isBeyondwordsSupportedBlock } from './isBeyondwordsSupportedBlock';
  * @return {Object} settings Modified settings.
  */
 function addAttributes( settings, name ) {
-	// Only add attributes to content blocks
 	if ( ! isBeyondwordsSupportedBlock( name ) ) {
 		return settings;
 	}

--- a/src/editor/components/block-attributes/addControls.js
+++ b/src/editor/components/block-attributes/addControls.js
@@ -33,8 +33,7 @@ const withBeyondwordsBlockControls = createHigherOrderComponent(
 		return ( props ) => {
 			const { name } = props;
 
-			// Skip blocks that shouldn't have controls
-			// Do this check BEFORE accessing attributes to avoid unnecessary processing
+			// Check BEFORE accessing attributes to avoid unnecessary processing.
 			if ( ! isBeyondwordsSupportedBlock( name ) ) {
 				return <BlockEdit { ...props } />;
 			}

--- a/src/editor/components/block-attributes/class-block-attributes.php
+++ b/src/editor/components/block-attributes/class-block-attributes.php
@@ -45,7 +45,6 @@ class BlockAttributes {
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 */
 	public static function register_audio_attribute( $args ) {
-		// Setup attributes if needed.
 		if ( ! isset( $args['attributes'] ) ) {
 			$args['attributes'] = [];
 		}
@@ -70,7 +69,6 @@ class BlockAttributes {
 	 * @since 6.0.0 Make static.
 	 */
 	public static function register_marker_attribute( $args ) {
-		// Setup attributes if needed.
 		if ( ! isset( $args['attributes'] ) ) {
 			$args['attributes'] = [];
 		}

--- a/src/editor/components/block-attributes/isBeyondwordsSupportedBlock.js
+++ b/src/editor/components/block-attributes/isBeyondwordsSupportedBlock.js
@@ -1,12 +1,12 @@
 /**
  * Check if a block is supported by BeyondWords.
- * Only content blocks that can be read aloud should have BeyondWords attributes and controls.
+ *
+ * Only content blocks that can be read aloud get attributes and controls.
  *
  * @param {string} name Block name.
  * @return {boolean} Whether the block is supported by BeyondWords.
  */
 export function isBeyondwordsSupportedBlock( name ) {
-	// Skip blocks without a name
 	if ( ! name ) {
 		return false;
 	}
@@ -24,7 +24,6 @@ export function isBeyondwordsSupportedBlock( name ) {
 		return false;
 	}
 
-	// Skip editor UI blocks
 	const excludedBlocks = [
 		'beyondwords/player', // The Player block embeds the player itself
 		'core/freeform', // Classic editor

--- a/src/editor/components/content-id/class-assets.php
+++ b/src/editor/components/content-id/class-assets.php
@@ -2,9 +2,6 @@
 /**
  * BeyondWords Content ID — asset enqueue.
  *
- * Owns the classic-editor JS that powers the "Fetch" button next to the
- * Content ID input. Split from [class-content-id.php](class-content-id.php).
- *
  * @package BeyondWords\Editor\Components\ContentId
  * @since   7.0.0
  */

--- a/src/editor/components/content-id/class-content-id.php
+++ b/src/editor/components/content-id/class-content-id.php
@@ -117,9 +117,8 @@ class ContentId {
 		}
 
 		if ( isset( $_POST['beyondwords_content_id'] ) ) {
-			// Content IDs are interpolated into BeyondWords API URL paths, so they
-			// need a stricter charset than sanitize_text_field() alone allows —
-			// see \BeyondWords\Post\Meta::sanitize_content_id().
+			// Content IDs are interpolated into API URL paths, so they need a stricter
+			// charset than sanitize_text_field() — see Meta::sanitize_content_id().
 			update_post_meta(
 				$post_id,
 				'beyondwords_content_id',

--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -110,7 +110,6 @@
 	 * @param {Object} meta The meta values that were saved.
 	 */
 	function updateMetaboxUI( meta ) {
-		// Content ID input.
 		const contentIdInput = document.getElementById(
 			'beyondwords_content_id'
 		);
@@ -118,7 +117,6 @@
 			contentIdInput.value = meta.beyondwords_content_id;
 		}
 
-		// Generate audio checkbox — fetched content sets this to '0'.
 		const generateAudioCheckbox = document.getElementById(
 			'beyondwords_generate_audio'
 		);
@@ -127,7 +125,6 @@
 				meta.beyondwords_generate_audio === '1';
 		}
 
-		// Language select — only update if the value exists as an option.
 		// Match option values directly so a malformed API value can't throw.
 		const languageSelect = document.getElementById(
 			'beyondwords_language_code'
@@ -149,7 +146,6 @@
 			errorContainer.remove();
 		}
 
-		// Re-initialise the player preview with the fetched content.
 		if (
 			meta.beyondwords_content_id &&
 			meta.beyondwords_project_id &&
@@ -175,9 +171,8 @@
 			if ( playerContainer ) {
 				playerContainer.innerHTML = '';
 
-				// The player SDK is an external CDN script, so its constructor
-				// can throw; contain it so a preview-only error can't fail the
-				// save. Mirrors play-audio/hooks.js.
+				// The external SDK constructor can throw; contain it so a preview-only
+				// error can't fail the save. Mirrors play-audio/hooks.js.
 				try {
 					new BeyondWords.Player( {
 						target: playerContainer,
@@ -254,7 +249,6 @@
 		clearNotice();
 		let spinner = setLoading( button, input, true );
 
-		// Fetch content from the BeyondWords API.
 		fetch(
 			beyondwordsData.root +
 				'beyondwords/v1/projects/' +
@@ -291,9 +285,8 @@
 
 				return savePostMeta( restBase, postId, meta ).then(
 					function () {
-						// Save succeeded. Refreshing the UI is best-effort —
-						// contain failures so they can't reject the chain and
-						// divert into the .catch, overwriting the saved meta.
+						// UI refresh is best-effort — contain failures so they can't
+						// reject the chain into the .catch and overwrite the saved meta.
 						try {
 							updateMetaboxUI( meta );
 						} catch {
@@ -321,7 +314,6 @@
 					return;
 				}
 
-				// Persist the error message to post meta.
 				const errorMeta = {
 					beyondwords_content_id: contentId,
 					beyondwords_error_message: wp.i18n.__(

--- a/src/editor/components/content-id/index.js
+++ b/src/editor/components/content-id/index.js
@@ -13,7 +13,6 @@ import { useSelect, useDispatch, select } from '@wordpress/data';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
-// Internal utilities
 const updatePostMeta = ( postId, meta ) => {
 	const postType = select( 'core/editor' ).getCurrentPostType();
 	const postTypeInfo = select( 'core' ).getPostType( postType );
@@ -120,7 +119,6 @@ export function ContentId( { wrapper } ) {
 			await updatePostMeta( postId, meta );
 			editPost( { meta } );
 
-			// Update local state with the returned content ID.
 			setContentId( id || '' );
 		} catch {
 			const errorMeta = {

--- a/src/editor/components/error-notice/class-assets.php
+++ b/src/editor/components/error-notice/class-assets.php
@@ -2,10 +2,6 @@
 /**
  * BeyondWords Error Notice — asset enqueue.
  *
- * Owns the block-editor stylesheet for the post error notice. Split from
- * [class-error-notice.php](class-error-notice.php) so each feature folder
- * has a single class responsible for asset registration.
- *
  * @package BeyondWords\Editor\Components\ErrorNotice
  * @since   7.0.0
  */

--- a/src/editor/components/generate-audio/class-generate-audio.php
+++ b/src/editor/components/generate-audio/class-generate-audio.php
@@ -50,11 +50,8 @@ class GenerateAudio {
 	/**
 	 * Enqueue the classic-editor Generate audio script.
 	 *
-	 * Classic editor only — the block editor handles this in React. The script
-	 * keeps the state-reflecting "Generation enabled/disabled" caption in step
-	 * with the checkbox, so it loads for every compatible post type. When the
-	 * post type is configured with `terms` mode it also carries the term data
-	 * needed to live-update the checkbox as matching terms are ticked.
+	 * Always enqueued (the caption sync needs it); `terms` mode additionally
+	 * localizes the term data used to live-update the checkbox.
 	 *
 	 * @since 7.0.0
 	 * @since 7.0.0 Always enqueued (for the caption); preselect data is optional.
@@ -84,8 +81,6 @@ class GenerateAudio {
 			true
 		);
 
-		// Term-gated preselect additionally needs the watched terms — only in
-		// `terms` mode, and only when there is something to watch.
 		if ( \BeyondWords\Settings\Preselect::MODE_TERMS === \BeyondWords\Settings\Preselect::get_mode( $post_type ) ) {
 			$terms = \BeyondWords\Settings\Preselect::get_selected_terms( $post_type );
 
@@ -106,10 +101,6 @@ class GenerateAudio {
 
 	/**
 	 * Check whether the "Generate audio" checkbox should be preselected.
-	 *
-	 * Delegates to the shared decision in `Preselect`, which honours both
-	 * whole-post-type ('all') and term-gated ('terms') preselection and is
-	 * tolerant of taxonomies that have since been unregistered.
 	 *
 	 * @since 6.0.0 Make static.
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -132,9 +123,8 @@ class GenerateAudio {
 
 		$generate_audio = \BeyondWords\Post\Meta::has_generate_audio( $post->ID );
 
-		// State-reflecting caption: the label reads out the current state. The
-		// data attributes let classic-metabox.js keep it in step as the checkbox
-		// is toggled (the block editor toggle behaves the same way).
+		// State-reflecting caption; the data attributes let classic-metabox.js keep
+		// it in step as the checkbox toggles (mirrors the block editor toggle).
 		$label_enabled  = __( 'Generation enabled', 'speechkit' );
 		$label_disabled = __( 'Generation disabled', 'speechkit' );
 		?>
@@ -171,7 +161,6 @@ class GenerateAudio {
 			return $post_id;
 		}
 
-		// "save_post" can be triggered at other times, so verify this request came from the our component
 		if (
 			! isset( $_POST['beyondwords_generate_audio_nonce'] ) ||
 			! wp_verify_nonce(

--- a/src/editor/components/generate-audio/classic-metabox.js
+++ b/src/editor/components/generate-audio/classic-metabox.js
@@ -1,30 +1,12 @@
 /* global beyondwordsPreselect */
 
-/*
- * Classic-editor Generate audio behaviours.
- *
- * 1. State-reflecting caption — keep the "Generation enabled/disabled" label in
- *    step with the checkbox as it is ticked/unticked (mirrors the block editor
- *    toggle). The server renders the correct initial caption on page load.
- *
- * 2. Term-gated preselect (only when configured) — when the publisher has chosen
- *    to preselect "Generate audio" only for posts with specific hierarchical
- *    taxonomy terms, keep the checkbox in step as the editor ticks/unticks those
- *    terms. The server sets the correct initial state on page load (via
- *    Preselect::should_preselect_for_post); this only handles live changes — and
- *    stops once the user toggles the checkbox themselves, so a deliberate choice
- *    is never clobbered (mirrors the block editor).
- *
- * Vanilla JS — no jQuery. Listens via event delegation so terms added through
- * the "+ Add New Category" UI are covered too.
- */
+// Keeps the Generate audio caption in step with the checkbox and, in term-gated
+// preselect mode, auto-syncs the checkbox from watched terms (mirrors block editor).
 ( function () {
 	'use strict';
 
 	const generateAudioCheckbox = () =>
 		document.getElementById( 'beyondwords_generate_audio' );
-
-	/* ---- 1. State-reflecting caption ---- */
 
 	const captionEl = () =>
 		document.getElementById( 'beyondwords-generate-audio-label' );
@@ -43,8 +25,6 @@
 		}
 	};
 
-	/* ---- 2. Term-gated preselect (optional) ---- */
-
 	const data =
 		typeof beyondwordsPreselect !== 'undefined'
 			? beyondwordsPreselect
@@ -52,7 +32,6 @@
 
 	const termGating = !! ( data && data.mode === 'terms' && data.terms );
 
-	// The classic metabox input name for a taxonomy's term checkboxes.
 	const inputNameFor = ( taxonomy ) =>
 		taxonomy === 'category'
 			? 'post_category[]'
@@ -70,7 +49,6 @@
 	// Once the editor toggles Generate audio by hand, stop auto-managing it.
 	let userToggled = false;
 
-	// Does any currently-ticked term match the preselect rule (OR semantics)?
 	const anyTermMatches = () =>
 		watched.some( ( { inputName, wanted } ) => {
 			const checked = document.querySelectorAll(
@@ -97,16 +75,13 @@
 		target.type === 'checkbox' &&
 		watched.some( ( { inputName } ) => target.name === inputName );
 
-	/* ---- Wire up ---- */
-
 	// Align the caption with the server-rendered checkbox state up front.
 	syncCaption();
 
+	// Delegated so terms added via the "+ Add New Category" UI are covered too.
 	document.addEventListener( 'change', ( event ) => {
 		const target = event.target;
 
-		// A manual toggle of Generate audio updates the caption and (when
-		// term-gating) freezes auto-management.
 		if ( target && target.id === 'beyondwords_generate_audio' ) {
 			userToggled = true;
 			syncCaption();

--- a/src/editor/components/generate-audio/index.js
+++ b/src/editor/components/generate-audio/index.js
@@ -30,8 +30,9 @@ const parseFlag = ( value ) => {
 };
 
 /**
- * Resolve the preselect mode for a post type's config, tolerant of the
- * pre-7.0.0 shapes (`'1'` and a bare taxonomy array).
+ * Resolve the preselect mode for a post type's config.
+ *
+ * Tolerant of the pre-7.0.0 shapes (`'1'` and a bare taxonomy array).
  *
  * @param {*} config The preselect entry for a post type.
  *
@@ -98,13 +99,8 @@ export function GenerateAudio( { wrapper } ) {
 		const savedMeta = getCurrentPostAttribute( 'meta' ) || {};
 		const editedMeta = getPostEdits()?.meta || {};
 
-		/**
-		 * The explicit value, if any — the user's decision.
-		 *
-		 * An in-session edit wins (the user toggled this session); otherwise
-		 * the saved meta, preferring beyondwords_generate_audio and falling
-		 * back to the deprecated speechkit_generate_audio.
-		 */
+		// The user's explicit decision, if any: an in-session edit wins over
+		// saved meta.
 		let explicit;
 		if ( META_KEY in editedMeta ) {
 			explicit = parseFlag( editedMeta[ META_KEY ] );
@@ -114,12 +110,8 @@ export function GenerateAudio( { wrapper } ) {
 				parseFlag( savedMeta.speechkit_generate_audio );
 		}
 
-		/**
-		 * Should "Generate audio" be preselected, per the plugin setting?
-		 *
-		 * Reactive: for term-gated post types this recomputes as taxonomy terms
-		 * are edited, so the toggle follows the rule in both directions.
-		 */
+		// Reactive: for term-gated post types this recomputes as taxonomy terms
+		// are edited, so the toggle follows the preselect rule in both directions.
 		const getShouldPreselect = () => {
 			const settings = getSettings();
 			if ( ! settings ) {
@@ -175,11 +167,8 @@ export function GenerateAudio( { wrapper } ) {
 		};
 
 		return {
-			// Derived only — we never write meta for the preselect case, so the
-			// post is not dirtied. When the publisher has not made an explicit
-			// choice the toggle reflects the preselect rule; persistence of an
-			// untouched preselected post is handled server-side by
-			// Meta::has_generate_audio() → Preselect::should_preselect_for_post().
+			// Derived only — no meta write for the preselect case, so the post isn't
+			// dirtied; the server persists it via Preselect::should_preselect_for_post().
 			checked:
 				explicit !== undefined && explicit !== null
 					? explicit
@@ -188,13 +177,12 @@ export function GenerateAudio( { wrapper } ) {
 	}, [] );
 
 	const handleChange = () => {
-		// The user's explicit choice — a real, persisted edit (correctly
-		// dirties the post). Once set, it overrides the preselect rule.
+		// An explicit choice is a real edit (dirties the post) and overrides the
+		// preselect rule from then on.
 		editPost( { meta: { [ META_KEY ]: ! checked ? '1' : '0' } } );
 	};
 
-	// State-reflecting caption: the toggle reads out its current state rather
-	// than the action it performs.
+	// State-reflecting caption: the label reads the current state, not the action.
 	const label = checked
 		? __( 'Generation enabled', 'speechkit' )
 		: __( 'Generation disabled', 'speechkit' );

--- a/src/editor/components/icon/index.js
+++ b/src/editor/components/icon/index.js
@@ -6,10 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * The BeyondWords brand mark, used for the editor sidebar / panel icons.
  *
- * Uses `currentColor` so it inherits the surrounding text colour (e.g. the
- * active/!active states of the plugin sidebar button). The 30×30 mark is inset
- * within a larger viewBox so it carries padding and renders at ~79% of the box
- * — closer in size to the standard WordPress dashicons.
+ * Uses `currentColor` to inherit the surrounding text colour; the mark is inset
+ * in a larger viewBox so it renders at a dashicon-like size.
  *
  * @return {Element} The icon SVG.
  */
@@ -33,8 +31,7 @@ export function BeyondwordsIcon() {
 }
 
 /**
- * The brand mark followed by the "BeyondWords" label, for a consistent panel
- * title — the icon sits before the text with a small, fixed gap.
+ * The brand mark followed by the "BeyondWords" label, for a consistent panel title.
  *
  * @return {Element} The title element.
  */

--- a/src/editor/components/inspect-panel/class-assets.php
+++ b/src/editor/components/inspect-panel/class-assets.php
@@ -2,10 +2,6 @@
 /**
  * BeyondWords Inspect Panel — asset enqueue.
  *
- * Owns the classic-editor JS for the Inspect metabox. Split from
- * [class-inspect-panel.php](class-inspect-panel.php) so each feature folder has
- * a single class responsible for asset registration.
- *
  * @package BeyondWords\Editor\Components\InspectPanel
  * @since   7.0.0
  */

--- a/src/editor/components/inspect-panel/class-inspect-panel.php
+++ b/src/editor/components/inspect-panel/class-inspect-panel.php
@@ -253,8 +253,7 @@ class InspectPanel {
 	 * @param array $metadata Post metadata.
 	 *
 	 * @since 3.0.0
-	 * @since 3.9.0 Output all post meta data from the earlier has_meta() call instead of
-	 *              the previous multiple get_post_meta() calls.
+	 * @since 3.9.0 Output all post meta data from the earlier has_meta() call.
 	 * @since 6.0.0 Make static.
 	 *
 	 * @return string
@@ -274,15 +273,8 @@ class InspectPanel {
 	/**
 	 * Runs when a post is saved.
 	 *
-	 * If "Remove" has been pressed in the Classic Editor we set the `beyondwords_delete_content`
-	 * custom field. At a later priority we check for this custom field and if it's set
-	 * we make a DELETE request to the BeyondWords REST API, keeping WordPress and the
-	 * REST API in sync.
-	 *
-	 * If we don't perform a DELETE REST API request to keep them in sync then the
-	 * API will respond with a "source_id is already in use" error message whenver we
-	 * attempt to regenerate audio for a post that has audio content "Removed" in
-	 * WordPress but still exists in the REST API.
+	 * "Remove" sets the `beyondwords_delete_content` custom field; a later-priority
+	 * hook then DELETEs at the API — else regeneration fails with "source_id is already in use".
 	 *
 	 * @since 4.0.7
 	 * @since 6.0.0 Make static.
@@ -319,8 +311,6 @@ class InspectPanel {
 	}
 
 	/**
-	 * REST API init.
-	 *
 	 * Register REST API routes.
 	 *
 	 * @since 6.0.0 Make static.
@@ -338,8 +328,6 @@ class InspectPanel {
 	}
 
 	/**
-	 * REST API response.
-	 *
 	 * Fetches a content object from the BeyondWords REST API.
 	 *
 	 * @since 6.0.0 Make static.
@@ -374,7 +362,6 @@ class InspectPanel {
 
 		$response = \BeyondWords\Api\Client::get_content( $beyondwords_id, $project_id );
 
-		// Check for REST API connection errors.
 		if ( is_wp_error( $response ) ) {
 			return rest_ensure_response(
 				new \WP_Error(
@@ -388,7 +375,6 @@ class InspectPanel {
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
 
-		// Check for REST API response errors.
 		if ( $code < 200 || $code >= 300 ) {
 			return rest_ensure_response(
 				new \WP_Error(
@@ -404,7 +390,6 @@ class InspectPanel {
 
 		$data = json_decode( $body, true );
 
-		// Check for REST API JSON response.
 		if ( ! is_array( $data ) ) {
 			return rest_ensure_response(
 				new \WP_Error(
@@ -414,7 +399,6 @@ class InspectPanel {
 			);
 		}
 
-		// Return the project ID in the response.
 		$data['project_id'] = $project_id;
 
 		return rest_ensure_response( $data );

--- a/src/editor/components/inspect-panel/helpers.js
+++ b/src/editor/components/inspect-panel/helpers.js
@@ -3,14 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 
-// Diagnostics appended to the copied payload only. These are always present (the
-// plugin/WP versions and the post id), so they are never counted as removable
-// post data when deciding whether the Remove button should be enabled.
-//
-// The current + deprecated *data* keys are NOT defined here on purpose — they are
-// the single source of truth in PHP (\BeyondWords\Core\Utils::get_post_meta_keys)
-// and reach the block editor via the beyondwords/settings store, so the two
-// editors can never drift apart.
+// Always-present diagnostics appended to the copied payload only — never counted
+// as removable post data. The data-key lists stay in PHP (single source of truth).
 export const SYSTEM_META_KEYS = [
 	'plugin_version',
 	'wp_version',
@@ -20,9 +14,8 @@ export const SYSTEM_META_KEYS = [
 /**
  * Does the post hold any BeyondWords data worth removing?
  *
- * Checks the live data fields only (current + deprecated, supplied from PHP),
- * never the always-present system fields, so the Remove button tracks the post's
- * current state rather than a snapshot taken at mount.
+ * Checks the data fields only (never the always-present system fields), so the
+ * Remove button tracks the post's current state, not a mount-time snapshot.
  *
  * @param {Object}   meta     Live custom-field values keyed by field name.
  * @param {string[]} dataKeys Current + deprecated meta keys (sourced from PHP).
@@ -34,9 +27,8 @@ export const hasBeyondwordsData = ( meta, dataKeys = [] ) =>
 /**
  * Build the plain-text diagnostics payload for the Copy button.
  *
- * Reads the same live `meta` object as {@link hasBeyondwordsData} so the Copy and
- * Remove controls can never disagree about the post's data. The key lists are
- * supplied by the caller (sourced from PHP) and rendered in the order given.
+ * Reads the same live `meta` as {@link hasBeyondwordsData} so Copy and Remove
+ * can never disagree; the key lists render in the order supplied.
  *
  * @param {Object}   meta           Live values keyed by field name (incl. system).
  * @param {string[]} currentKeys    Current meta keys, in display order.

--- a/src/editor/components/inspect-panel/helpers.test.js
+++ b/src/editor/components/inspect-panel/helpers.test.js
@@ -5,8 +5,7 @@
  */
 import { SYSTEM_META_KEYS, hasBeyondwordsData, getTextToCopy } from './helpers';
 
-// Key lists as PHP supplies them via the settings store (a representative subset
-// is enough for these unit tests — the real lists come from get_post_meta_keys).
+// Representative subset of the key lists PHP supplies via the settings store.
 const CURRENT = [ 'beyondwords_generate_audio', 'beyondwords_content_id' ];
 const DEPRECATED = [ 'speechkit_podcast_id' ];
 const DATA_KEYS = [ ...CURRENT, ...DEPRECATED ];

--- a/src/editor/components/inspect-panel/index.js
+++ b/src/editor/components/inspect-panel/index.js
@@ -20,7 +20,6 @@ import Stack from '../stack';
 import { getTextToCopy, hasBeyondwordsData } from './helpers';
 
 export function PostInspectPanel( {
-	// Current custom fields
 	beyondwordsDeleteContent,
 	beyondwordsGenerateAudio,
 	beyondwordsIntegrationMethod,
@@ -37,16 +36,13 @@ export function PostInspectPanel( {
 	beyondwordsVideoTemplateId,
 	beyondwordsVideoSize,
 	beyondwordsEmbed,
-	// System
 	pluginVersion,
 	wpVersion,
 	wpPostId,
-	// Live post meta + the current/deprecated key lists (sourced from PHP via
-	// the beyondwords/settings store) that drive the Copy and Remove controls.
+	// Live post meta + key lists (from PHP) that drive the Copy/Remove controls.
 	meta,
 	currentMetaKeys,
 	deprecatedMetaKeys,
-	// Other
 	createWarningNotice,
 	removeWarningNotice,
 	setDeleteContent,
@@ -75,10 +71,8 @@ export function PostInspectPanel( {
 		}
 	}, [ didPostSaveRequestSucceed, isAutosavingPost, isSavingPost, removed ] );
 
-	// `meta` is the live post meta (getEditedPostAttribute('meta')); the current
-	// and deprecated key lists come from PHP via the settings store. Deriving both
-	// controls from the same live source means Copy and Remove can never disagree,
-	// and the Remove button tracks edits made after mount (e.g. audio generated).
+	// Copy and Remove derive from the same live meta + PHP-supplied key lists, so
+	// they can never disagree and Remove tracks edits made after mount.
 	const dataKeys = [
 		...( currentMetaKeys ?? [] ),
 		...( deprecatedMetaKeys ?? [] ),
@@ -284,7 +278,6 @@ export default compose( [
 		const { pluginVersion, wpVersion, inspectMetaKeys } = getSettings();
 
 		return {
-			// Current custom fields
 			beyondwordsDeleteContent:
 				getEditedPostAttribute( 'meta' ).beyondwords_delete_content,
 			beyondwordsGenerateAudio:
@@ -317,16 +310,13 @@ export default compose( [
 				getEditedPostAttribute( 'meta' ).beyondwords_video_size,
 			beyondwordsEmbed:
 				getEditedPostAttribute( 'meta' ).beyondwords_embed,
-			// Live post meta + the current/deprecated key lists (from PHP via the
-			// settings store) that drive the Copy and Remove controls.
+			// Live post meta + key lists (from PHP) that drive the Copy/Remove controls.
 			meta: getEditedPostAttribute( 'meta' ),
 			currentMetaKeys: inspectMetaKeys?.current,
 			deprecatedMetaKeys: inspectMetaKeys?.deprecated,
-			// System
 			pluginVersion,
 			wpVersion,
 			wpPostId: getCurrentPostId(),
-			// Other
 			currentPostType: getCurrentPostType(),
 			didPostSaveRequestSucceed: didPostSaveRequestSucceed(),
 			isSavingPost: isSavingPost(),
@@ -354,7 +344,6 @@ export default compose( [
 			removeWarningNotice: () =>
 				removeNotice( 'beyondwords-remove-post-data--warning' ),
 			setDeleteContent: ( deleteContent ) => {
-				// Update the Post Meta (AKA the Custom Field)
 				editPost( {
 					meta: {
 						beyondwords_delete_content: deleteContent ? '1' : '',

--- a/src/editor/components/inspect-panel/js/inspect.js
+++ b/src/editor/components/inspect-panel/js/inspect.js
@@ -2,8 +2,7 @@
 
 /*
  * Classic-editor Inspect panel: copy-to-clipboard confirmation + "Remove all
- * BeyondWords data" toggle. Vanilla JS — no jQuery dependency. ClipboardJS is a
- * standalone library (not jQuery).
+ * BeyondWords data" toggle.
  */
 ( function () {
 	'use strict';

--- a/src/editor/components/play-audio/check.js
+++ b/src/editor/components/play-audio/check.js
@@ -4,8 +4,7 @@
 import { useHasPlayAudioAction } from './hooks';
 
 /**
- * Renders its children only when the BeyondWords player has everything it
- * needs to load a preview.
+ * Renders its children only when the BeyondWords player can load a preview.
  *
  * @param {Object}  props          Component props.
  * @param {Element} props.children Content to gate behind the play-audio check.

--- a/src/editor/components/play-audio/hooks.js
+++ b/src/editor/components/play-audio/hooks.js
@@ -10,8 +10,7 @@ const PLAYER_SCRIPT_SRC =
 	'https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js';
 
 // Delay first player load after a contentId appears so the CDN doesn't cache a
-// 404 for content it hasn't published yet. Matches the implicit delay the
-// Classic Editor gets from its post-save page reload.
+// 404 for content it hasn't published yet.
 const NEW_CONTENT_DELAY_MS = 2000;
 
 export function useBeyondWordsNamespace() {
@@ -20,11 +19,8 @@ export function useBeyondWordsNamespace() {
 	} );
 
 	useEffect( () => {
-		// The script can finish loading in the gap between the render-phase
-		// useState initializer (which may have seen no namespace) and this
-		// post-paint effect. Re-read the namespace synchronously so we don't
-		// attach a 'load' listener to an already-loaded script — that listener
-		// would never fire again, leaving value null and the player uncreated.
+		// The script can finish loading between the useState initializer and this
+		// effect; re-read now so we don't listen on an already-loaded script.
 		if ( window?.BeyondWords ) {
 			setValue( window.BeyondWords );
 			return;
@@ -148,14 +144,10 @@ export function useBeyondWordsPlayer( {
 }
 
 /**
- * Whether the post has everything the BeyondWords player needs to load a
- * preview.
+ * Whether the post has everything the BeyondWords player needs to load a preview.
  *
- * Pure selector so it can be called inside `useSelect`/`withSelect` (and unit
- * tested without a React render). Shared by the `beyondwords/player` block and
- * the `PlayAudioCheck` gate via `useHasPlayAudioAction()`. Legacy `podcast_id`
- * keys are recognised so posts upgraded from older plugin versions still
- * preview correctly.
+ * Pure selector (usable in `useSelect`/`withSelect`, unit-testable). Legacy
+ * `podcast_id` keys are recognised so upgraded posts still preview.
  *
  * @param {Function} select Redux-style select() from `@wordpress/data`.
  *
@@ -169,7 +161,6 @@ export function selectHasPlayAudioAction( select ) {
 	const integrationMethod =
 		getEditedPostAttribute( 'meta' ).beyondwords_integration_method;
 
-	// Get Content ID, inc fallbacks for legacy field names.
 	const beyondwordsContentId =
 		getEditedPostAttribute( 'meta' ).beyondwords_content_id;
 	const beyondwordsPodcastId =
@@ -192,8 +183,7 @@ export function selectHasPlayAudioAction( select ) {
 }
 
 /**
- * Hook wrapper around {@link selectHasPlayAudioAction} for use in function
- * components — the block preview and the `PlayAudioCheck` gate.
+ * Hook wrapper around {@link selectHasPlayAudioAction} for function components.
  *
  * @return {boolean} True when the player can load.
  */

--- a/src/editor/components/play-audio/index.js
+++ b/src/editor/components/play-audio/index.js
@@ -46,13 +46,11 @@ export default compose( [
 		const { getCurrentPostId, getEditedPostAttribute } =
 			select( 'core/editor' );
 
-		// Project ID.
 		const beyondwordsProjectId =
 			getEditedPostAttribute( 'meta' ).beyondwords_project_id;
 		const speechkitProjectId =
 			getEditedPostAttribute( 'meta' ).speechkit_project_id;
 
-		// Content ID.
 		const beyondwordsContentId =
 			getEditedPostAttribute( 'meta' ).beyondwords_content_id;
 		const beyondwordsPodcastId =
@@ -60,7 +58,6 @@ export default compose( [
 		const speechkitPodcastId =
 			getEditedPostAttribute( 'meta' ).speechkit_podcast_id;
 
-		// Other attributes.
 		const beyondwordsPreviewToken =
 			getEditedPostAttribute( 'meta' ).beyondwords_preview_token;
 

--- a/src/editor/components/preview-panel/index.js
+++ b/src/editor/components/preview-panel/index.js
@@ -14,10 +14,8 @@ import PlayAudio from '../play-audio';
 /**
  * Whether the post has audio/video ready to preview.
  *
- * Matches PlayAudioCheck so the panel hides itself when PlayAudio would also
- * have nothing to render — i.e. before the first successful generation. Legacy
- * `podcast_id` keys are recognised so existing posts upgraded from older plugin
- * versions still preview correctly.
+ * Matches PlayAudioCheck so the panel hides when PlayAudio would render nothing;
+ * legacy `podcast_id` keys are recognised for upgraded posts.
  *
  * @param {Function} select Redux-style select() from `@wordpress/data`.
  *
@@ -47,8 +45,7 @@ function hasError( select ) {
 }
 
 export function PreviewPanel() {
-	// Show the panel when there's something to preview *or* an error to surface,
-	// mirroring the error display in the document-settings panel.
+	// An error alone also shows the panel, mirroring the document-settings display.
 	const showPanel = useSelect(
 		( select ) => hasGeneratedContent( select ) || hasError( select ),
 		[]

--- a/src/editor/components/select-voice/class-assets.php
+++ b/src/editor/components/select-voice/class-assets.php
@@ -2,9 +2,6 @@
 /**
  * BeyondWords Select Voice — asset enqueue.
  *
- * Owns the classic-editor JS that wires up the language/voice select boxes.
- * Split from [class-select-voice.php](class-select-voice.php).
- *
  * @package BeyondWords\Editor\Components\SelectVoice
  * @since   7.0.0
  */

--- a/src/editor/components/select-voice/class-select-voice.php
+++ b/src/editor/components/select-voice/class-select-voice.php
@@ -24,8 +24,7 @@ defined( 'ABSPATH' ) || exit;
 class SelectVoice {
 
 	/**
-	 * Voice "service" that exposes selectable models. Only ElevenLabs voices
-	 * carry a `model_id`; every (name, model_id) pair is a distinct voice id.
+	 * The only voice service whose voices carry a selectable `model_id`.
 	 *
 	 * @since 7.0.0
 	 */
@@ -89,8 +88,7 @@ class SelectVoice {
 		$voices        = self::get_voices_for_language( $language_code );
 
 		// "Customize" is opt-in: a post is customised once it has an explicit
-		// language or voice. When off we hide the fields and store nothing, so the
-		// BeyondWords project defaults apply.
+		// language or voice; when off we store nothing so project defaults apply.
 		$customize    = '' !== (string) $language_code || '' !== (string) $voice_id;
 		$fields_style = $customize ? '' : 'display: none;';
 
@@ -112,9 +110,8 @@ class SelectVoice {
 	/**
 	 * Render the "Customize" toggle.
 	 *
-	 * When unchecked the post uses the project default language and voice and the
-	 * language/voice fields are hidden. classic-metabox.js mirrors the visibility
-	 * and clears the selects when it is unchecked so save() removes the meta.
+	 * When unchecked, classic-metabox.js hides the fields and clears the selects
+	 * so save() removes the meta and the project defaults apply.
 	 *
 	 * @since 7.0.0
 	 *
@@ -171,14 +168,8 @@ class SelectVoice {
 	/**
 	 * Get all available languages.
 	 *
-	 * Coerces the API result to a list of language records so the language
-	 * dropdown degrades to empty when the languages API call fails (network
-	 * error, WP_Error, non-2xx status, empty body or invalid JSON).
-	 * Client::get_languages() is declared array|null|false, so an unguarded
-	 * null/false would throw a TypeError against render_language_select()'s
-	 * array-typed parameter under strict_types; non-array elements (e.g. the
-	 * scalar values of a decoded API error body) are dropped so the render loop
-	 * only iterates records. Mirrors get_voices_for_language().
+	 * Coerced to a list of language records so an API failure (null/false, or a
+	 * decoded error body) degrades to an empty dropdown instead of a TypeError.
 	 *
 	 * @since 7.0.0
 	 *
@@ -197,14 +188,8 @@ class SelectVoice {
 	/**
 	 * Get voices for a language code.
 	 *
-	 * Coerces the API result to a list of voice records so the Model and Voice
-	 * dropdowns degrade to empty when the voices API call fails. Beyond the
-	 * top-level array check (Client::get_voices() is declared array|null|false,
-	 * so an unguarded null/false throws a TypeError against the render helpers'
-	 * array-typed parameters under strict_types), each element is filtered to an
-	 * array: a non-2xx response can decode to the API's error shape — e.g.
-	 * {"message": "Too many requests"} on a 429 — whose scalar element would
-	 * otherwise fatal in voice_model_key(). Mirrors get_languages().
+	 * Coerced to a list of voice records so an API failure (null/false, or a
+	 * decoded error body like a 429's) degrades to empty instead of fataling.
 	 *
 	 * @since 6.0.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -274,12 +259,8 @@ class SelectVoice {
 	/**
 	 * Render the Model select: a language-level filter over the voices.
 	 *
-	 * Each ElevenLabs model_id is a bucket, plus a single "Standard" bucket for
-	 * non-ElevenLabs voices. Picking a model narrows the Voice dropdown to the
-	 * voices that offer it. The Model select carries no `name` — it is a
-	 * client-side filter and is not submitted; the persisted value is the voice
-	 * id from the Voice select. The dropdown is hidden when a language offers a
-	 * single bucket (there is nothing to narrow by).
+	 * Carries no `name` — it is never submitted; the persisted value is the
+	 * voice id. Hidden when a language offers a single bucket.
 	 *
 	 * @since 7.0.0
 	 *
@@ -327,10 +308,8 @@ class SelectVoice {
 	/**
 	 * Render the Voice select: the voices in the currently selected model bucket.
 	 *
-	 * This is the saved field (`beyondwords_voice_id`) — its value is the voice
-	 * id, which carries the model. With a single bucket every voice is listed;
-	 * with several the list is scoped to the selected model and the field is
-	 * hidden until a model is chosen.
+	 * The saved field (`beyondwords_voice_id`) — the submitted voice id carries
+	 * the model.
 	 *
 	 * @since 6.0.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -346,7 +325,6 @@ class SelectVoice {
 		$models     = self::language_models( $voices );
 		$show_model = count( $models ) > 1;
 
-		// Single bucket → list every voice; several → scope to the chosen model.
 		if ( $show_model ) {
 			$bucket_voices = array_values(
 				array_filter(
@@ -360,8 +338,7 @@ class SelectVoice {
 			$bucket_voices = array_values( $voices );
 		}
 
-		// Model gates the Voice list: hide it until a model is chosen. With a
-		// single bucket there is no Model dropdown, so the Voice list shows now.
+		// Model gates the Voice list: hide it until a model is chosen.
 		$show_voice  = count( $voices ) > 0 && ( ! $show_model || '' !== strval( $selected_key ) );
 		$voice_style = $show_voice ? '' : 'display: none;';
 		?>
@@ -416,11 +393,10 @@ class SelectVoice {
 	}
 
 	/**
-	 * The model bucket key for a voice: its ElevenLabs model_id, or the shared
-	 * Standard bucket for any other service (or any non-record value). Mirrors
-	 * `voiceModelKey()` in src/editor/components/settings-panel/helpers.js, which
-	 * guards with `voice?.` so a scalar left by a decoded API error body buckets
-	 * as Standard rather than fataling against an `array` type under strict_types.
+	 * The model bucket key for a voice: its ElevenLabs model_id, else Standard.
+	 *
+	 * Accepts any value so a scalar from a decoded API error body buckets as
+	 * Standard rather than fataling. Mirrors settings-panel/helpers.js.
 	 *
 	 * @since 7.0.0
 	 *
@@ -441,10 +417,10 @@ class SelectVoice {
 	}
 
 	/**
-	 * The distinct model buckets across a language's voices, as `[key, label]`
-	 * pairs for the Model dropdown — ElevenLabs models first (the default
-	 * leading), then a single Standard bucket if present. Mirrors
-	 * `getLanguageModels()` in src/editor/components/settings-panel/helpers.js.
+	 * The distinct model buckets across a language's voices, for the Model dropdown.
+	 *
+	 * ElevenLabs models first (the default leading), then a single Standard
+	 * bucket if present. Mirrors getLanguageModels() in settings-panel/helpers.js.
 	 *
 	 * @since 7.0.0
 	 *
@@ -500,9 +476,9 @@ class SelectVoice {
 	}
 
 	/**
-	 * Human label for a voice model_id slug. Unknown slugs fall back to a
-	 * title-cased version of the slug minus the `eleven_` prefix. Mirrors
-	 * `voiceModelLabel()` in src/editor/components/settings-panel/helpers.js.
+	 * Human label for a voice model_id slug.
+	 *
+	 * Mirrors voiceModelLabel() in settings-panel/helpers.js.
 	 *
 	 * @since 7.0.0
 	 *
@@ -567,7 +543,6 @@ class SelectVoice {
 			return $post_id;
 		}
 
-		// "save_post" can be triggered at other times, so verify this request came from the our component
 		if (
 			! wp_verify_nonce(
 				sanitize_key( $_POST['beyondwords_select_voice_nonce'] ),
@@ -610,7 +585,6 @@ class SelectVoice {
 	 * @return void
 	 */
 	public static function rest_api_init_callback() {
-		// Languages endpoint
 		register_rest_route(
 			'beyondwords/v1',
 			'/languages',
@@ -621,7 +595,6 @@ class SelectVoice {
 			]
 		);
 
-		// Voices endpoint
 		register_rest_route(
 			'beyondwords/v1',
 			'/languages/(?P<languageCode>[a-zA-Z0-9-_]+)/voices',
@@ -650,8 +623,7 @@ class SelectVoice {
 	}
 
 	/**
-	 * "Voices" WP REST API response (required for the Gutenberg editor
-	 * and Block Editor).
+	 * "Voices" WP REST API response (required for the Gutenberg editor).
 	 *
 	 * @since 4.0.0
 	 * @since 6.0.0 Make static.

--- a/src/editor/components/select-voice/classic-metabox.js
+++ b/src/editor/components/select-voice/classic-metabox.js
@@ -1,24 +1,9 @@
 /* global beyondwordsData */
 
 /*
- * Classic-editor Customize + Language + Model + Voice behaviour.
- *
- * "Customize" is opt-in. While off, the post uses the project default language
- * and voice: the fields stay hidden and the selects submit empty so save()
- * removes the meta. While on, the Language dropdown drives a voices fetch and
- * seeds the language's default voice (we never send the language itself — the
- * voice carries it).
- *
- * "Model" is a language-level filter: each ElevenLabs model_id, plus a single
- * "Standard" bucket for non-ElevenLabs voices. Picking a model narrows the
- * Voice dropdown to the voices that offer it. The Voice dropdown is the saved
- * field (`beyondwords_voice_id`) — it submits the chosen voice id, which carries
- * the model. When a language offers a single bucket the Model dropdown is hidden
- * and every voice is listed. Mirrors the block editor's voice-section.js +
- * helpers.js.
- *
- * Vanilla JS — no jQuery dependency. The selects live in the post <form>, so
- * their values submit on save; no autosave/Heartbeat hook is needed.
+ * Classic-editor Customize + Language + Model + Voice behaviour. Mirrors the
+ * block editor's voice-section.js + helpers.js. The selects live in the post
+ * <form> and submit on save, so no autosave/Heartbeat hook is needed.
  */
 ( function () {
 	'use strict';
@@ -55,8 +40,7 @@
 	};
 
 	/**
-	 * The model bucket key for a voice: its ElevenLabs model_id, or the shared
-	 * Standard bucket for any other service.
+	 * The model bucket key for a voice: its ElevenLabs model_id, else Standard.
 	 *
 	 * @param {Object} voice A voice record.
 	 *
@@ -74,8 +58,7 @@
 	};
 
 	/**
-	 * The distinct model buckets across a language's voices, ElevenLabs models
-	 * first (the default leading), then a single Standard bucket if present.
+	 * The distinct model buckets across a language's voices, for the Model dropdown.
 	 *
 	 * @param {Array<Object>} voices All voices for the current language.
 	 *
@@ -172,16 +155,15 @@
 				} );
 			}
 
-			// A saved customized post is server-rendered with its Model + Voice
-			// dropdowns populated, but this.voices starts empty; hydrate it so the
-			// Model filter has data before the user interacts.
+			// Seed this.voices so the Model filter has data before the user interacts.
 			this.hydrate();
 		},
 
 		/**
-		 * Show/hide the language/model/voice fields. Turning Customize off reverts
-		 * the post to the project defaults by clearing the selects, so they submit
-		 * empty and save() removes the meta.
+		 * Show/hide the language/model/voice fields.
+		 *
+		 * Customize off clears the selects so they submit empty and save()
+		 * removes the meta, reverting the post to the project defaults.
 		 *
 		 * @param {boolean} on Whether Customize is enabled.
 		 */
@@ -206,10 +188,10 @@
 		},
 
 		/**
-		 * On Customize-on, fetch the project's default language and pre-select it
-		 * — only the language; the user picks the Model + Voice. A spinner shows
-		 * while the language and its voices resolve. On failure, or when the post
-		 * already has a language, fall back to the manual "pick a language" flow.
+		 * On Customize-on, fetch the project's default language and pre-select it.
+		 *
+		 * Only the language is seeded — the user picks the Model + Voice; on
+		 * failure we fall back to the manual "pick a language" flow.
 		 */
 		applyProjectDefaultLanguage() {
 			const language = byId( 'beyondwords_language_code' );
@@ -230,10 +212,8 @@
 				} )
 				.then( ( response ) => response.json() )
 				.then( ( project ) => {
-					// Bail if Customize was switched off, or a language was
-					// chosen, while the request was in flight — otherwise we'd
-					// re-show the fields and persist a language on a post the
-					// user left un-customised.
+					// Bail if Customize was switched off, or a language chosen, while
+					// in flight — else we'd persist a language on an un-customised post.
 					const customize = byId( 'beyondwords_customize' );
 					if (
 						! customize ||
@@ -259,20 +239,17 @@
 		},
 
 		/**
-		 * Hydrate this.voices for an already-customized saved post so the Model
-		 * filter has data before the user interacts. The PHP element() server-
-		 * renders the correct Model + Voice dropdowns, but this.voices starts
-		 * empty; without this the first Model change finds no voices, empties the
-		 * Voice select, and save() then drops the stored voice. Loads WITHOUT
-		 * clearing first, so the correct server-rendered dropdowns stay put until
-		 * the fetch resolves and re-renders to the same selection.
+		 * Hydrate this.voices for an already-customized saved post.
+		 *
+		 * Without it the first Model change runs against empty state and save()
+		 * drops the stored voice. Loads without clearing, so the server-rendered
+		 * dropdowns stay put until the fetch re-renders the same selection.
 		 */
 		hydrate() {
 			const customize = byId( 'beyondwords_customize' );
 			const language = byId( 'beyondwords_language_code' );
 
-			// A fresh, un-customized post has no language yet; toggling Customize
-			// fetches on demand. Only a saved customized post needs hydrating.
+			// Only a saved customized post needs hydrating; a fresh one fetches on demand.
 			if (
 				! customize ||
 				! customize.checked ||
@@ -285,10 +262,8 @@
 			const voiceSelect = byId( 'beyondwords_voice_id' );
 			const savedVoiceId = voiceSelect ? voiceSelect.value : '';
 
-			// Disable the Model filter until the in-memory voices load, so a Model
-			// change during the fetch can't run against empty state (which would
-			// blank the Voice select). The Model select carries no name, so
-			// disabling it has no effect on what the form submits.
+			// Disable the Model filter until voices load so a change can't run
+			// against empty state; it carries no name, so submits are unaffected.
 			const modelSelect = byId( 'beyondwords_model' );
 			if ( modelSelect ) {
 				modelSelect.disabled = true;
@@ -309,10 +284,9 @@
 
 		/**
 		 * Get voices for a language, then rebuild the Model + Voice dropdowns.
-		 * When a default voice id is supplied (the language's default body voice,
-		 * set when the user picks a language) its model is pre-selected and the
-		 * voice chosen; otherwise the Model dropdown opens on its placeholder and
-		 * the Voice dropdown stays hidden until a model is picked.
+		 *
+		 * A supplied default voice pre-selects its model and voice; otherwise the
+		 * Model opens on its placeholder and Voice stays hidden until one is picked.
 		 *
 		 * @param {string} languageCode   The language code.
 		 * @param {string} defaultVoiceId The language's default body voice id.
@@ -330,10 +304,10 @@
 		},
 
 		/**
-		 * Fetch a language's voices into this.voices, serialising concurrent
-		 * fetches so only the latest applies. Does not render — the caller decides
-		 * how. Resolves true when this (latest) fetch succeeded and this.voices was
-		 * updated; false when superseded, on error, or when no language is given.
+		 * Fetch a language's voices into this.voices. Does not render.
+		 *
+		 * Resolves true when this (latest) fetch applied; false when superseded,
+		 * on error, or when no language is given.
 		 *
 		 * @param {string} languageCode The language code.
 		 *
@@ -358,10 +332,8 @@
 					headers: { 'X-WP-Nonce': data.nonce },
 				} )
 				.then( ( response ) => {
-					// window.fetch does not reject on HTTP error statuses. A
-					// WordPress REST error (e.g. an expired nonce returning 403)
-					// resolves with a JSON error *object*, not a voices array,
-					// so surface it through the catch below.
+					// fetch doesn't reject on HTTP errors; a REST error (e.g. expired
+					// nonce → 403) resolves with a JSON object, so throw into the catch.
 					if ( ! response.ok ) {
 						return response
 							.json()
@@ -399,10 +371,9 @@
 		},
 
 		/**
-		 * Rebuild the Model dropdown from the current voices and select the model
-		 * for the supplied voice (if any), then rebuild the Voice dropdown for
-		 * that model. The Model dropdown is hidden when a language offers a single
-		 * bucket.
+		 * Rebuild the Model dropdown from the current voices, then the Voice dropdown.
+		 *
+		 * The Model dropdown is hidden when a language offers a single bucket.
 		 *
 		 * @param {string} selectedVoiceId The voice id to pre-select, or ''.
 		 */
@@ -445,9 +416,9 @@
 		},
 
 		/**
-		 * Rebuild the Voice dropdown for a model bucket and select a voice. With a
-		 * Model gate and no model chosen, the Voice dropdown is hidden; with a
-		 * single bucket every voice is listed.
+		 * Rebuild the Voice dropdown for a model bucket and select a voice.
+		 *
+		 * Hidden while gated with no model chosen; a single bucket lists every voice.
 		 *
 		 * @param {string}  modelKey    The selected model bucket key, or ''.
 		 * @param {string}  preselectId The voice id to select if in the bucket.
@@ -459,7 +430,6 @@
 			);
 			const voiceSelect = byId( 'beyondwords_voice_id' );
 
-			// Gated and no model chosen yet → hide the (empty) Voice dropdown.
 			if ( showModel && '' === modelKey ) {
 				if ( voiceSelect ) {
 					voiceSelect.replaceChildren( option( '', SELECT_VOICE ) );
@@ -497,8 +467,9 @@
 		},
 
 		/**
-		 * Pick a model → list that bucket's voices and select the first, so a
-		 * concrete voice id is always submitted (the voice carries the model).
+		 * Pick a model: list that bucket's voices and select the first.
+		 *
+		 * A concrete voice id is always submitted (the voice carries the model).
 		 *
 		 * @param {string} modelKey The selected model bucket key.
 		 */

--- a/src/editor/components/settings-fields/class-assets.php
+++ b/src/editor/components/settings-fields/class-assets.php
@@ -2,10 +2,6 @@
 /**
  * BeyondWords Settings Fields — asset enqueue.
  *
- * Owns the classic-editor JS that wires up the Content/Format/Player <select>
- * controls (show/hide + Embed option recompute). Split from
- * [class-settings-fields.php](class-settings-fields.php).
- *
  * @package BeyondWords\Editor\Components\SettingsFields
  * @since   7.0.0
  */

--- a/src/editor/components/settings-fields/class-settings-fields.php
+++ b/src/editor/components/settings-fields/class-settings-fields.php
@@ -5,15 +5,8 @@ declare( strict_types = 1 );
 /**
  * BeyondWords Component: Settings Fields (Classic editor).
  *
- * The classic-editor counterparts of the block editor's Content, Format and
- * Player settings sections. Each section renders server-side <select> controls;
- * the dynamic show/hide + option-recompute behaviour lives in the bundled
- * [classic-metabox.js](classic-metabox.js), which mirrors the block editor's
- * [helpers.js](../settings-panel/helpers.js).
- *
- * The option-derivation helpers (source/output/embed) are kept as pure static
- * methods so they can be unit-tested and reused by both the renderers here and,
- * conceptually, the JS mirror.
+ * Classic-editor counterparts of the block editor's Content/Format/Player
+ * sections; dynamic behaviour lives in classic-metabox.js (mirrors helpers.js).
  *
  * @package BeyondWords\Editor\Components
  * @author  Stuart McAlpine <stu@beyondwords.io>
@@ -80,8 +73,10 @@ class SettingsFields {
 	// Option helpers (mirror src/editor/components/settings-panel/helpers.js).
 
 	/**
-	 * The "Project default" leaf option. An empty value defers to the project
-	 * setting — the plugin omits the field from the content payload when empty.
+	 * The "Project default" leaf option.
+	 *
+	 * An empty value defers to the project setting — the plugin omits the field
+	 * from the content payload when empty.
 	 *
 	 * @since 7.0.0
 	 *
@@ -260,11 +255,10 @@ class SettingsFields {
 	}
 
 	/**
-	 * The default Embed value for a post that hasn't chosen one yet: the first
-	 * asset the current Source × Output produces (e.g. Post × Audio → "Audio
-	 * (post)"). This keeps the player visible by default — "None" is the
-	 * deliberate opt-out. Mirrors `getDefaultEmbed()` in
-	 * src/editor/components/settings-panel/helpers.js.
+	 * The default Embed for a post that hasn't chosen one: the first produced asset.
+	 *
+	 * Keeps the player visible by default — "None" is the deliberate opt-out.
+	 * Mirrors getDefaultEmbed() in settings-panel/helpers.js.
 	 *
 	 * @since 7.0.0
 	 *
@@ -286,15 +280,8 @@ class SettingsFields {
 	/**
 	 * Resolve the effective Embed value for a post.
 	 *
-	 * Centralises the source×output→asset resolution so the dropdown's shown
-	 * default ({@see render_player_section()}) and the rendered player
-	 * ({@see \BeyondWords\Player\ConfigBuilder}) can never diverge:
-	 *
-	 * - No explicit choice yet: a legacy "Display player" opt-out (pre-v7 posts
-	 *   not yet migrated) resolves to None, otherwise the first asset the current
-	 *   Source × Output produces so the player stays visible.
-	 * - A persisted value that no longer fits the current Source × Output falls
-	 *   back to None.
+	 * Centralised so the shown default and the rendered player (ConfigBuilder)
+	 * never diverge; legacy opt-outs and no-longer-valid values resolve to None.
 	 *
 	 * @since 7.0.0
 	 *
@@ -323,10 +310,8 @@ class SettingsFields {
 	/**
 	 * Whether the player is suppressed on a post.
 	 *
-	 * The Embed dropdown's "None" replaces the pre-v7 "Display player" opt-out.
-	 * An explicit Embed value is authoritative; only when none is set do we fall
-	 * back to the legacy `beyondwords_disabled` flag (for posts saved before the
-	 * v7.0.0 migration ran).
+	 * An explicit Embed value is authoritative ("None" replaces the pre-v7 opt-out);
+	 * only when unset do we fall back to the legacy `beyondwords_disabled` flag.
 	 *
 	 * @since 7.0.0
 	 *
@@ -600,8 +585,7 @@ class SettingsFields {
 			return $post_id;
 		}
 
-		// The nonce proves intent, not authorisation — confirm this user may
-		// edit this specific post before writing its meta.
+		// The nonce proves intent, not authorisation.
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return $post_id;
 		}
@@ -627,8 +611,7 @@ class SettingsFields {
 				continue;
 			}
 
-			// Reject anything outside the known option set rather than persist
-			// arbitrary values.
+			// Reject anything outside the known option set.
 			if ( self::is_valid_meta_value( $key, $value ) ) {
 				update_post_meta( $post_id, $key, $value );
 			}
@@ -640,9 +623,8 @@ class SettingsFields {
 	/**
 	 * Whether a submitted value is allowed for the given Settings Fields key.
 	 *
-	 * Enum fields are checked against their option sets; the template-id fields
-	 * must be numeric; the free-form video size (an API-supplied name) only needs
-	 * the sanitisation already applied by the caller.
+	 * The free-form video size (an API-supplied name) only needs the
+	 * sanitisation already applied by the caller.
 	 *
 	 * @since 7.0.0
 	 *

--- a/src/editor/components/settings-fields/classic-metabox.js
+++ b/src/editor/components/settings-fields/classic-metabox.js
@@ -2,14 +2,7 @@
 
 /*
  * Classic-editor dynamic behaviour for the Content/Format/Player settings
- * fields. Mirrors the block editor's settings-panel logic
- * (src/editor/components/settings-panel/helpers.js):
- *
- * - Source toggles the Script template field.
- * - Output toggles the Video template + Video size fields.
- * - Embed options are derived from Source × Output and recomputed live.
- *
- * Vanilla JS — no jQuery dependency.
+ * fields (show/hide + Embed recompute). Mirrors settings-panel/helpers.js.
  */
 ( function () {
 	'use strict';

--- a/src/editor/components/settings-panel/content-section.js
+++ b/src/editor/components/settings-panel/content-section.js
@@ -30,8 +30,7 @@ export function ContentSection() {
 		[]
 	);
 
-	// `useEntityProp` returns `{}` (so `meta` is undefined) until the post entity
-	// record is hydrated; default to an empty object before reading meta values.
+	// `useEntityProp` yields undefined meta until the post entity record is hydrated.
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 

--- a/src/editor/components/settings-panel/format-section.js
+++ b/src/editor/components/settings-panel/format-section.js
@@ -43,8 +43,7 @@ export function FormatSection() {
 		[ projectId ]
 	);
 
-	// `useEntityProp` returns `{}` (so `meta` is undefined) until the post entity
-	// record is hydrated; default to an empty object before reading meta values.
+	// `useEntityProp` yields undefined meta until the post entity record is hydrated.
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 

--- a/src/editor/components/settings-panel/helpers.js
+++ b/src/editor/components/settings-panel/helpers.js
@@ -17,21 +17,16 @@ export const EMBED_AUDIO_SCRIPT = 'audio_script';
 export const EMBED_VIDEO_POST = 'video_post';
 export const EMBED_VIDEO_SCRIPT = 'video_script';
 
-// Empty value = defer to the project setting. The plugin omits the field from
-// the content payload when empty, so the BeyondWords backend applies the
-// project default. Prepend this to leaf-setting dropdowns.
+// Empty value = defer to the project setting — the plugin omits the field from
+// the content payload so the BeyondWords backend applies the project default.
 export const PROJECT_DEFAULT_VALUE = '';
 
 export function projectDefaultOption() {
 	return { label: __( 'Project default', 'speechkit' ), value: '' };
 }
 
-// Voice "models" only exist for ElevenLabs voices, exposed as a snake_case
-// `model_id` slug. Each (name, model_id) pair is a distinct voice record with
-// its own `id`. The Model dropdown is a language-level filter: picking a model
-// narrows the Voice list to the voices that offer it, then the chosen voice id
-// (which carries the model) is the only value sent to the API. Voices from any
-// other service have no `model_id` and share a single "Standard" bucket.
+// Voice "models" only exist for ElevenLabs voices; each (name, model_id) pair is
+// a distinct voice record, and the chosen voice id is the only value sent to the API.
 export const ELEVENLABS_SERVICE = 'ElevenLabs';
 
 // The model listed first in the Model dropdown.
@@ -40,8 +35,7 @@ export const DEFAULT_ELEVENLABS_VOICE_MODEL_ID = 'eleven_multilingual_v2';
 // Bucket key for voices without an ElevenLabs `model_id` (e.g. standard voices).
 export const STANDARD_MODEL_KEY = 'standard';
 
-// Human labels for the known ElevenLabs model slugs. Unknown slugs fall back to
-// a title-cased version of the slug minus the `eleven_` prefix.
+// Human labels for the known ElevenLabs model slugs.
 const VOICE_MODEL_LABELS = {
 	eleven_v3: __( 'v3', 'speechkit' ),
 	eleven_multilingual_v2: __( 'Multilingual v2', 'speechkit' ),
@@ -69,8 +63,7 @@ export function voiceModelLabel( modelId ) {
 /**
  * The model bucket key for a voice.
  *
- * ElevenLabs voices key by their `model_id`; every other voice falls into the
- * shared STANDARD_MODEL_KEY bucket.
+ * ElevenLabs voices key by `model_id`; all others share the Standard bucket.
  *
  * @param {Object} voice A voice record.
  *
@@ -87,11 +80,9 @@ export function voiceModelKey( voice ) {
 }
 
 /**
- * The distinct model buckets offered across a language's voices, as
- * `{ key, label }` options for the Model dropdown.
+ * The distinct model buckets across a language's voices, for the Model dropdown.
  *
- * ElevenLabs models come first (the default model leading), followed by a
- * single "Standard" bucket when any non-ElevenLabs voices are present.
+ * ElevenLabs models first (the default leading), then a single Standard bucket.
  *
  * @param {Array<Object>} voices All voices for the current language.
  *
@@ -177,9 +168,7 @@ export function outputIncludesVideo( output ) {
 /**
  * Derive the valid "Embed" dropdown options from the current Source × Output.
  *
- * Returns None plus one entry for each asset combination the current
- * source/output would produce. The Embed value persisted to post meta picks
- * one of these to render on the published post.
+ * Returns None plus one entry per asset the current source/output would produce.
  *
  * @param {string} source One of SOURCE_*.
  * @param {string} output One of OUTPUT_*.
@@ -238,9 +227,9 @@ export function isEmbedValid( embed, source, output ) {
 }
 
 /**
- * The default Embed value for a post that hasn't chosen one yet: the first asset
- * the current Source × Output produces (e.g. Post × Audio → "Audio (post)").
- * This keeps the player visible by default — "None" is the deliberate opt-out.
+ * The default Embed for a post that hasn't chosen one: the first produced asset.
+ *
+ * Keeps the player visible by default — "None" is the deliberate opt-out.
  *
  * @param {string} source One of SOURCE_*.
  * @param {string} output One of OUTPUT_*.

--- a/src/editor/components/settings-panel/player-section.js
+++ b/src/editor/components/settings-panel/player-section.js
@@ -26,8 +26,7 @@ export function PlayerSection( { withPanel = true } ) {
 		[]
 	);
 
-	// `useEntityProp` returns `{}` (so `meta` is undefined) until the post entity
-	// record is hydrated; default to an empty object before reading meta values.
+	// `useEntityProp` yields undefined meta until the post entity record is hydrated.
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 
@@ -35,10 +34,8 @@ export function PlayerSection( { withPanel = true } ) {
 	const output = meta.beyondwords_output || OUTPUT_AUDIO;
 
 	const stored = meta.beyondwords_embed;
-	// No explicit choice yet → default to the first asset so the player shows.
-	// ("Embed: None" is the deliberate opt-out.) Legacy `beyondwords_disabled`
-	// posts are converted to "None" by the v7.0.0 migration, so an unset value
-	// here always means "show".
+	// Unset → default to the first asset so the player shows ("None" is the
+	// opt-out; the v7.0.0 migration converts legacy `beyondwords_disabled` posts).
 	const embed = stored || getDefaultEmbed( source, output );
 
 	const embedOptions = getEmbedOptions( source, output );
@@ -47,13 +44,8 @@ export function PlayerSection( { withPanel = true } ) {
 		setMeta( { ...meta, beyondwords_embed: value } );
 	};
 
-	// When Source × Output narrows the option list and the *stored* embed is no
-	// longer offered, fall back to None.
-	//
-	// We never write meta on mount: an unset value already means "show the first
-	// asset" (Player::is_enabled() treats it that way), and a mount-time write
-	// races the other panels' preselect writes — e.g. it would clobber the
-	// Generate audio preselect back to off.
+	// Never write meta on mount: an unset value already means "show", and a
+	// mount-time write races the other panels' preselect writes (e.g. Generate audio).
 	useEffect( () => {
 		if ( stored && ! isEmbedValid( stored, source, output ) ) {
 			setEmbed( EMBED_NONE );
@@ -77,8 +69,7 @@ export function PlayerSection( { withPanel = true } ) {
 		/>
 	);
 
-	// In the document/pre-publish panels we render the field directly inside the
-	// existing "BeyondWords" panel rather than nesting another panel.
+	// Document/pre-publish panels render the field without nesting another panel.
 	if ( ! withPanel ) {
 		return <Stack>{ field }</Stack>;
 	}

--- a/src/editor/components/settings-panel/voice-section.js
+++ b/src/editor/components/settings-panel/voice-section.js
@@ -21,18 +21,15 @@ export function VoiceSection( { withPanel = true } ) {
 		[]
 	);
 
-	// `useEntityProp` returns `{}` (so `meta` is undefined) until the post entity
-	// record is hydrated; default to an empty object before reading meta values.
+	// `useEntityProp` yields undefined meta until the post entity record is hydrated.
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 
 	const languageCode = meta.beyondwords_language_code || '';
 	const voiceId = meta.beyondwords_body_voice_id || '';
 
-	// "Customize" is opt-in. A post counts as customised as soon as it carries an
-	// explicit language or voice; otherwise it uses the project defaults, we show
-	// no fields and send nothing. Held in local state so toggling on can reveal
-	// the pickers before any choice has been made.
+	// "Customize" is opt-in: a post counts as customised once it carries an explicit
+	// language or voice. Local state so toggling on reveals the pickers pre-choice.
 	const [ customize, setCustomize ] = useState(
 		() => !! ( languageCode || voiceId )
 	);
@@ -45,11 +42,8 @@ export function VoiceSection( { withPanel = true } ) {
 		[]
 	);
 
-	// When Customize is turned on for a post with no explicit choice yet, fetch
-	// the project's default language and pre-select it. We populate only the
-	// Language — the user picks the Voice (a project default voice can belong to
-	// a different language than the one we list). On failure we leave the
-	// Language empty and fall back to the manual "pick a language" flow.
+	// Customize-on with no choice yet: fetch the project default language and seed
+	// only the Language (a project default voice can belong to another language).
 	const needsDefault = customize && ! languageCode && ! voiceId;
 
 	const project = useSelect(
@@ -60,9 +54,8 @@ export function VoiceSection( { withPanel = true } ) {
 		[ needsDefault, projectId ]
 	);
 
-	// True once the project fetch has settled (resolved or failed). Keeps the
-	// spinner up and the Language hidden until we know the default — avoids a
-	// one-frame "empty dropdown then spinner" flicker on the first render.
+	// True once the project fetch has settled; keeps the spinner up until then to
+	// avoid a one-frame "empty dropdown then spinner" flicker.
 	const projectResolved = useSelect(
 		( s ) =>
 			! needsDefault ||
@@ -72,10 +65,8 @@ export function VoiceSection( { withPanel = true } ) {
 		[ needsDefault, projectId ]
 	);
 
-	// Apply the resolved default language. Guarded by needsDefault so it never
-	// overrides an explicit choice, and sets only the language (no voice). Reads
-	// the freshest meta — not the closure's — so a concurrent edit to another
-	// field during the async fetch isn't clobbered.
+	// Apply the resolved default language. Reads the freshest meta — not the
+	// closure's — so a concurrent edit during the async fetch isn't clobbered.
 	useEffect( () => {
 		if ( needsDefault && project?.language ) {
 			const current =
@@ -90,8 +81,7 @@ export function VoiceSection( { withPanel = true } ) {
 
 	const loadingProject = customize && needsDefault && ! projectResolved;
 
-	// Languages and voices are only needed while customising, so they are fetched
-	// lazily behind the toggle — a default post makes no language/voice API calls.
+	// Fetched lazily behind the toggle — a default post makes no language/voice API calls.
 	const languages = useSelect(
 		( s ) =>
 			customize ? s( 'beyondwords/settings' ).getLanguages() : [],
@@ -106,8 +96,7 @@ export function VoiceSection( { withPanel = true } ) {
 		[ customize, languageCode ]
 	);
 
-	// Changing the Language re-fetches its voices; show a Spinner in place of the
-	// Voice/Model dropdowns until that resolves.
+	// Show a Spinner in place of the Voice/Model dropdowns while voices re-fetch.
 	const isResolvingVoices = useSelect(
 		( s ) =>
 			customize &&
@@ -122,10 +111,8 @@ export function VoiceSection( { withPanel = true } ) {
 		setMeta( { ...meta, beyondwords_body_voice_id: value } );
 	};
 
-	// Picking a Language sets the language *and* seeds the voice with that
-	// language's default body voice, so a concrete voice is always stored (we
-	// never send the language itself — the voice carries it). Languages with no
-	// default voice fall back to the "Select a voice" placeholder.
+	// Picking a Language also seeds its default body voice so a concrete voice is
+	// always stored (we never send the language itself — the voice carries it).
 	const setLanguageCode = ( value ) => {
 		const language = ( languages ?? [] ).find(
 			( item ) => decodeEntities( item.code ) === value
@@ -141,8 +128,7 @@ export function VoiceSection( { withPanel = true } ) {
 		} );
 	};
 
-	// Toggling Customize off reverts the post to the project defaults by clearing
-	// both choices; toggling on just reveals the (empty) pickers.
+	// Customize off reverts to the project defaults by clearing both choices.
 	const toggleCustomize = () => {
 		const next = ! customize;
 		setCustomize( next );
@@ -166,18 +152,15 @@ export function VoiceSection( { withPanel = true } ) {
 		} ) ),
 	];
 
-	// "Model" is a language-level filter: each ElevenLabs model_id, plus a single
-	// "Standard" bucket for non-ElevenLabs voices. Picking a model narrows the
-	// Voice list to the voices that offer it. With a single bucket there is no
-	// Model dropdown and every voice is listed.
+	// "Model" is a language-level filter over the voices; with a single bucket
+	// there is no Model dropdown and every voice is listed.
 	const models = getLanguageModels( voices );
 	const showModel = models.length > 1;
 
 	const selectedVoice = ( voices ?? [] ).find(
 		( voice ) => String( voice.id ) === String( voiceId )
 	);
-	// The selected model is derived from the selected voice (we persist only the
-	// voice id); empty until a voice — and therefore a model — is chosen.
+	// Derived from the selected voice — we persist only the voice id.
 	const selectedModelKey = selectedVoice
 		? voiceModelKey( selectedVoice )
 		: '';
@@ -190,8 +173,7 @@ export function VoiceSection( { withPanel = true } ) {
 
 	const hasVoices = ( voices ?? [] ).length > 0;
 
-	// Model gates the Voice list: hide Voice until a model is chosen. The
-	// single-bucket case has no Model dropdown, so Voice shows immediately.
+	// Model gates the Voice list: hide Voice until a model is chosen.
 	const showVoice = hasVoices && ( ! showModel || '' !== selectedModelKey );
 
 	const modelOptions = [
@@ -267,8 +249,7 @@ export function VoiceSection( { withPanel = true } ) {
 		</Stack>
 	);
 
-	// In the document/pre-publish panels we render the fields directly inside the
-	// existing "BeyondWords" panel rather than nesting another panel.
+	// Document/pre-publish panels render the fields without nesting another panel.
 	if ( ! withPanel ) {
 		return fields;
 	}

--- a/src/editor/components/sidebar/class-assets.php
+++ b/src/editor/components/sidebar/class-assets.php
@@ -2,8 +2,6 @@
 /**
  * BeyondWords Post Sidebar — asset enqueue.
  *
- * Owns the block-editor stylesheet for the post sidebar plugin slot.
- *
  * @package BeyondWords\Editor\Components\Sidebar
  * @since   7.0.0
  */

--- a/src/editor/components/stack/index.js
+++ b/src/editor/components/stack/index.js
@@ -6,10 +6,8 @@ import { Flex } from '@wordpress/components';
 /**
  * Vertical stack with a consistent gap.
  *
- * Our controls set `__nextHasNoMarginBottom`, so the vertical spacing between
- * sibling fields is owned here — a single Flex `gap` — rather than by per-control
- * margins. Use it to wrap the contents of every panel/section so spacing stays
- * consistent across the editor.
+ * Our controls set `__nextHasNoMarginBottom`, so vertical spacing between
+ * sibling fields is owned here (a single Flex gap), not by per-control margins.
  *
  * @param {Object}  props          Props (forwarded to Flex).
  * @param {Element} props.children Stack contents.

--- a/src/editor/components/toggle/index.js
+++ b/src/editor/components/toggle/index.js
@@ -5,10 +5,7 @@ import { Flex, FlexBlock, FlexItem, FormToggle } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
- * BeyondWords toggle control.
- *
- * Standardised layout: the switch sits on the left and the label fills the row
- * to its right, laid out with the Flex primitives.
+ * BeyondWords toggle control: switch on the left, clickable label to its right.
  *
  * @param {Object}   props
  * @param {string}   [props.className] Extra class for the Flex wrapper.

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,14 @@
 /**
  * BeyondWords block editor JS bundle entry point.
  *
- * Each `require` pulls in a self-registering module — when bundled by
- * `wp-scripts build`, side effects in those modules wire up filters and
- * components.
+ * Each `require` is a self-registering module: its side effects wire up
+ * filters and components when bundled by `wp-scripts build`.
  */
 
-// Settings page (REST + admin UI).
 require( './settings' );
 
-// Block-editor JS bootstrap — registers the document-setting, sidebar and
-// prepublish plugin slots via @wordpress/plugins. Each slot's component is
-// imported transitively from src/editor/block/{slot}/index.js.
 require( './editor/block' );
 
-// Components — reusable PHP+JS UI bits consumed by the block-editor pages
-// (and by the classic-editor metabox in PHP). Each component's `index.js`
-// self-registers any block-editor filters or sidebar mounts it owns.
 require( './editor/components/add-player' );
 require( './editor/components/block-attributes' );
 require( './editor/components/data-panel' );

--- a/src/player/class-config-builder.php
+++ b/src/player/class-config-builder.php
@@ -16,10 +16,6 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Constructs the SDK parameters object for one post.
  *
- * Two-step build: project-level defaults first, then per-post overrides via
- * `merge_post_settings()`. Final result passes through the
- * `beyondwords_player_sdk_params` filter so callers can mutate it.
- *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
 class ConfigBuilder {
@@ -65,11 +61,8 @@ class ConfigBuilder {
 			$params['showUserInterface'] = false;
 		}
 
-		// Map the resolved Embed choice to the SDK's video/summary params so the
-		// on-page player shows the chosen asset. "script" === the AI summarization
-		// output, so script → summary:true. None/audio_post add nothing (the SDK
-		// defaults to audio + body); a None post normally never reaches here as the
-		// renderer short-circuits via Player::is_enabled(), but stay defensive.
+		// "Script" is the AI-summarization output, so script → summary:true.
+		// None/audio_post add nothing — the SDK defaults to audio + body.
 		$embed = \BeyondWords\Editor\Components\SettingsFields::get_effective_embed( $post->ID );
 
 		switch ( $embed ) {

--- a/src/player/class-player.php
+++ b/src/player/class-player.php
@@ -1,10 +1,6 @@
 <?php
 /**
- * BeyondWords player entry point.
- *
- * Owns the front-end hooks that decide when and how a BeyondWords player is
- * rendered on a post. Per-context rendering is delegated to the renderer
- * classes under `src/player/renderer/`.
+ * BeyondWords player entry point: front-end hooks that decide when a player renders.
  *
  * @package BeyondWords\Player
  * @since   3.0.0
@@ -25,8 +21,9 @@ defined( 'ABSPATH' ) || exit;
 class Player {
 
 	/**
-	 * Renderer classes evaluated in order. The first whose `check()` returns
-	 * true wins — keep AMP first so AMP requests get the AMP player.
+	 * Renderer classes evaluated in order; the first whose `check()` passes wins.
+	 *
+	 * AMP stays first so AMP requests get the AMP player.
 	 *
 	 * @var string[]
 	 */
@@ -41,9 +38,8 @@ class Player {
 	public static function init(): void {
 		add_action( 'init', [ self::class, 'register_shortcodes' ] );
 
-		// Replace legacy `<div data-beyondwords-player>` markup with the modern
-		// shortcode early, then auto-prepend the player at very late priority
-		// so other `the_content` filters can't strip it.
+		// Legacy-markup replacement runs early; auto-prepend runs at very late
+		// priority so other `the_content` filters can't strip the player.
 		add_filter( 'the_content', [ self::class, 'replace_legacy_custom_player' ], 5 );
 		add_filter( 'the_content', [ self::class, 'auto_prepend_player' ], 1000000 );
 		add_filter( 'newsstand_the_content', [ self::class, 'auto_prepend_player' ] );
@@ -57,8 +53,7 @@ class Player {
 	}
 
 	/**
-	 * Auto-prepend the player to `the_content` on singular pages, unless the
-	 * editor has already placed a player via shortcode/script/legacy div.
+	 * Auto-prepend the player to `the_content` unless the post already embeds one.
 	 *
 	 * @param string $content Post content.
 	 *
@@ -69,11 +64,8 @@ class Player {
 			return $content;
 		}
 
-		// Bail before the potentially expensive has_custom_player() DOM scan when
-		// no player could render anyway. This mirrors render_player()'s own early
-		// return, so returning $content here is equivalent to prepending its '' —
-		// but it spares every "player disabled / Embed: None" singular pageview
-		// the cost of parsing the post content.
+		// Mirrors render_player()'s own early return, but bails before the expensive
+		// has_custom_player() DOM scan when no player could render anyway.
 		$post = get_post();
 
 		if ( ! $post instanceof \WP_Post || ! self::is_enabled( $post ) ) {
@@ -88,11 +80,10 @@ class Player {
 	}
 
 	/**
-	 * Convert legacy `<div data-beyondwords-player>` placeholders to the
-	 * modern shortcode so the rest of the pipeline only deals with one form.
+	 * Convert legacy `<div data-beyondwords-player>` placeholders to the shortcode.
 	 *
-	 * The regex tolerates attribute reordering, missing values (boolean
-	 * attribute), and self-closing tags — see the inline examples.
+	 * The regex tolerates attribute reordering, valueless (boolean) attributes,
+	 * extra attributes, and self-closing tags.
 	 *
 	 * @param string $content Post content.
 	 *
@@ -103,12 +94,6 @@ class Player {
 			return $content;
 		}
 
-		// Examples this matches:
-		// <div data-beyondwords-player="true"></div>
-		// <div data-beyondwords-player></div>
-		// <div data-beyondwords-player contenteditable="false"></div>
-		// <div contenteditable="false" data-beyondwords-player> </div>
-		// <div data-beyondwords-player />
 		$pattern = '/<div\s+(?=[^>]*data-beyondwords-player[\s>=\/])[^>]*(?:\/>|>\s*<\/div>)/i';
 
 		return preg_replace( $pattern, '[beyondwords_player]', $content );
@@ -167,14 +152,11 @@ class Player {
 	 * Headless mode counts as enabled — we still emit the SDK script so the
 	 * publisher's own UI can drive it.
 	 *
-	 * @since 7.0.0 "Embed: None" hides the player; the legacy `beyondwords_disabled`
-	 *              flag is still honoured for posts saved before v7.
+	 * @since 7.0.0 "Embed: None" hides the player; the legacy disabled flag is still honoured.
 	 *
 	 * @param \WP_Post $post Post object.
 	 */
 	public static function is_enabled( \WP_Post $post ): bool {
-		// "Embed: None" hides the player; the legacy `beyondwords_disabled` flag
-		// is honoured for pre-v7 posts the migration hasn't reached.
 		if ( \BeyondWords\Editor\Components\SettingsFields::is_player_disabled_for_post( $post->ID ) ) {
 			return false;
 		}
@@ -200,11 +182,8 @@ class Player {
 
 		$js_sdk_url = \BeyondWords\Core\Urls::get_js_sdk_url();
 
-		// Skip the DOM parse below — expensive on large posts, yet run on every
-		// singular pageview — unless a marker substring is actually present. Both
-		// XPath queries require one of these literal strings in the markup (the
-		// attribute name, or the SDK URL inside a script `src`), so if neither
-		// appears the parse cannot match and we can bail cheaply.
+		// Both XPath queries need one of these literal substrings, so when neither
+		// appears we can skip the expensive per-pageview DOM parse.
 		if (
 			! str_contains( $content, 'data-beyondwords-player' )
 			&& ! str_contains( $content, $js_sdk_url )

--- a/src/player/renderer/class-amp.php
+++ b/src/player/renderer/class-amp.php
@@ -2,9 +2,6 @@
 /**
  * AMP-compatible BeyondWords player renderer.
  *
- * Used when the request is being served through an AMP plugin
- * (`\BeyondWords\Core\Utils::is_amp()`).
- *
  * @package BeyondWords\Player\Renderer
  * @since   6.0.0
  * @since   7.0.0 Refactored to BeyondWords namespace with snake_case methods.

--- a/src/player/renderer/class-base.php
+++ b/src/player/renderer/class-base.php
@@ -2,9 +2,6 @@
 /**
  * Base class for player renderers.
  *
- * Subclasses (`Amp`, `Javascript`) override `check()` to decide whether their
- * variant applies, and add a `render()` method to produce HTML.
- *
  * @package BeyondWords\Player\Renderer
  * @since   6.0.0
  * @since   7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -25,10 +22,6 @@ class Base {
 
 	/**
 	 * Whether a player should be rendered for this post in this request.
-	 *
-	 * Returns false during preview, in the block editor, or when the post is
-	 * missing a project ID. For REST API integration we additionally require
-	 * a content ID; Magic Embed (client-side) doesn't need one.
 	 *
 	 * @param \WP_Post $post WordPress post object.
 	 */

--- a/src/player/renderer/class-javascript.php
+++ b/src/player/renderer/class-javascript.php
@@ -23,10 +23,6 @@ class Javascript extends Base {
 	/**
 	 * Render the JavaScript player HTML.
 	 *
-	 * Returns an empty string when Player UI is set to "Disabled" — the post
-	 * is otherwise eligible (per `Base::check()`), the publisher has just
-	 * opted out of the visible player UI.
-	 *
 	 * @param \WP_Post $post    Post object.
 	 * @param string   $context Rendering context: 'auto' or 'shortcode'.
 	 */
@@ -37,14 +33,8 @@ class Javascript extends Base {
 
 		$params = \BeyondWords\Player\ConfigBuilder::build( $post );
 
-		/*
-		 * Encode the SDK params for safe embedding inside the inline `onload` handler.
-		 * The HEX flags escape ', ", <, >, & within any string value, so attacker- or
-		 * filter-controlled params (e.g. the Content ID post meta, or values injected
-		 * via the beyondwords_player_sdk_params filter) cannot break out of the
-		 * single-quoted attribute or the surrounding markup. The structural JSON quotes
-		 * are left intact, so the spread object literal remains valid JavaScript.
-		 */
+		// The HEX flags escape ', ", <, >, & inside string values so attacker- or
+		// filter-controlled params can't break out of the quoted onload attribute.
 		$json_params = wp_json_encode(
 			$params,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP

--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -20,17 +20,15 @@ class Content {
 	public const DATE_FORMAT = 'Y-m-d\TH:i:s\Z';
 
 	/**
-	 * Get the content "body" param for the audio, ready to be sent to the
-	 * BeyondWords API.
+	 * Get the content "body" param for the audio.
 	 *
-	 * From API version 1.1 the "summary" param is going to be used differently,
-	 * so for WordPress we now prepend the WordPress excerpt to the "body" param.
+	 * The excerpt is prepended to the body because API v1.1 repurposed the
+	 * "summary" param.
 	 *
+	 * @since 4.6.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
 	 * @param int|\WP_Post $post The WordPress post ID, or post object.
-	 *
-	 * @since 4.6.0
 	 *
 	 * @return string The content body param.
 	 */
@@ -80,32 +78,26 @@ class Content {
 		$content = self::get_content_without_excluded_blocks( $post );
 
 		if ( has_blocks( $post ) ) {
-			// wpautop breaks our HTML markup when block editor paragraphs are empty
+			// wpautop breaks our HTML markup when block editor paragraphs are empty,
+			// but we still want to remove the empty lines it would have handled.
 			remove_filter( 'the_content', 'wpautop' );
 
-			// But we still want to remove empty lines
 			$content = preg_replace( '/^\h*\v+/m', '', $content );
 		}
 
-		// Apply the_content filters to handle shortcodes etc
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Applying core WordPress filter
 		$content = apply_filters( 'the_content', $content );
 
-		// Trim to remove trailing newlines – common for WordPress content
 		return trim( $content );
 	}
 
 	/**
 	 * Get the post summary wrapper format.
 	 *
-	 * This is a <div> with optional attributes depending on the BeyondWords
-	 * data of the post.
-	 *
+	 * @since 4.6.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
 	 * @param int|\WP_Post $post The WordPress post ID, or post object.
-	 *
-	 * @since 4.6.0
 	 *
 	 * @return string The summary wrapper <div>.
 	 */
@@ -122,12 +114,11 @@ class Content {
 	/**
 	 * Get the post summary for the audio content.
 	 *
+	 * @since 4.0.0
+	 * @since 4.6.0 Renamed from Content::getSummary() to Content::get_post_summary()
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
 	 * @param int|\WP_Post $post The WordPress post ID, or post object.
-	 *
-	 * @since 4.0.0
-	 * @since 4.6.0 Renamed from Content::getSummary() to Content::get_post_summary()
 	 *
 	 * @return string The summary.
 	 */
@@ -140,16 +131,12 @@ class Content {
 
 		$summary = null;
 
-		// Optionally send the excerpt to the REST API, if the plugin setting has been checked
 		$prepend_excerpt = get_option( 'beyondwords_prepend_excerpt' );
 
 		if ( $prepend_excerpt && has_excerpt( $post ) ) {
-			// Escape characters
 			$summary = htmlentities( $post->post_excerpt, ENT_QUOTES | ENT_XHTML );
-			// Apply WordPress filters
             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Applying core WordPress filter
 			$summary = apply_filters( 'get_the_excerpt', $summary );
-			// Convert line breaks into paragraphs
 			$summary = trim( wpautop( $summary ) );
 		}
 
@@ -157,20 +144,14 @@ class Content {
 	}
 
 	/**
-	 * Get the post content without blocks which have been filtered.
-	 *
-	 * We have added buttons into the Gutenberg editor to optionally exclude selected
-	 * blocks from the source text for audio.
-	 *
-	 * This method filters all blocks, removing any which have been excluded.
-	 *
-	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
-	 *
-	 * @param int|\WP_Post $post The WordPress post ID, or post object.
+	 * Get the post content without the blocks an editor excluded from audio.
 	 *
 	 * @since 3.8.0
 	 * @since 4.0.0 Replace for loop with array_reduce
 	 * @since 6.0.0 Remove beyondwordsMarker attribute from rendered blocks.
+	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
+	 *
+	 * @param int|\WP_Post $post The WordPress post ID, or post object.
 	 *
 	 * @return string The post body without excluded blocks.
 	 */
@@ -199,12 +180,11 @@ class Content {
 	/**
 	 * Get audio-enabled blocks.
 	 *
+	 * @since 4.0.0
+	 * @since 5.0.0 Remove beyondwords_post_audio_enabled_blocks filter.
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
 	 * @param int|\WP_Post $post The WordPress post ID, or post object.
-	 *
-	 * @since 4.0.0
-	 * @since 5.0.0 Remove beyondwords_post_audio_enabled_blocks filter.
 	 *
 	 * @return array The blocks.
 	 */
@@ -252,7 +232,7 @@ class Content {
 	 * @static
 	 * @param int $post_id WordPress Post ID.
 	 *
-	 * @return string JSON endoded params.
+	 * @return string JSON encoded params.
 	 **/
 	public static function get_content_params( int $post_id ): array|string {
 		$body = [
@@ -269,14 +249,8 @@ class Content {
 
 		$status = get_post_status( $post_id );
 
-		/*
-		 * If the post status is draft/pending then we explicity send
-		 * { published: false } to the BeyondWords API, to prevent the
-		 * generated audio from being published in playlists.
-		 *
-		 * We also omit { publish_date } because get_post_time() returns `false`
-		 * for posts which are "Pending Review".
-		 */
+		// Drafts send { published: false } to keep the audio out of playlists, and
+		// omit publish_date because get_post_time() is false for pending posts.
 		if ( in_array( $status, [ 'draft', 'pending'] ) ) {
 			$body['published'] = false;
 			unset( $body['publish_date'] );
@@ -285,8 +259,6 @@ class Content {
 			 * Filters whether generated content is auto-published to BeyondWords.
 			 *
 			 * Replaces the v6.x `beyondwords_project_auto_publish_enabled` setting.
-			 * Default `true` matches the previous default; sites that need to keep
-			 * generated content as drafts can return `false`.
 			 *
 			 * @since 7.0.0
 			 *
@@ -300,19 +272,15 @@ class Content {
 			}
 		}
 
-		// The post language is never sent to the API. A chosen voice already
-		// implies its language, so sending the voice id is sufficient; when no
-		// voice is chosen ("Customize" off) we send nothing and the BeyondWords
-		// project default applies. `beyondwords_language_code` is retained only as
-		// editor state, used to fetch the per-language voice list.
+		// The language is never sent: a chosen voice implies it, and with no voice
+		// the project default applies. `beyondwords_language_code` is editor state only.
 		$body_voice_id = intval( get_post_meta( $post_id, 'beyondwords_body_voice_id', true ) );
 
 		if ( $body_voice_id > 0 ) {
 			$body['body_voice_id'] = $body_voice_id;
 		}
 
-		// Source = Script or Post + script → enable summarization so the API
-		// generates a script segment alongside the post body. Omitted when
+		// Source = Script or Post + script → enable summarization; omitted when
 		// Source is Post (or unset) so the project default applies.
 		$source = get_post_meta( $post_id, 'beyondwords_source', true );
 
@@ -330,7 +298,6 @@ class Content {
 			}
 		}
 
-		// Output = Video or Audio + video → enable video generation.
 		$output = get_post_meta( $post_id, 'beyondwords_output', true );
 
 		if ( in_array( $output, [ 'video', 'audio_and_video' ], true ) ) {
@@ -354,22 +321,9 @@ class Content {
 	/**
 	 * Build the `video_settings` param sent to the BeyondWords content endpoint.
 	 *
-	 * Choosing "Video" (or "Audio + video") output opts a post into video
-	 * generation, overriding the project's default `video_settings.enabled`.
-	 *
-	 * The BeyondWords backend silently skips video generation unless the payload
-	 * carries `enabled: true` AND a non-empty `variants` array AND a non-empty
-	 * `sizes` array whose entries include `width`/`height`. Earlier versions sent
-	 * only `template.id` and `sizes[].name`/`enabled`, which left `variants` empty
-	 * server-side — so no video was ever produced.
-	 *
-	 * We mirror the BeyondWords dashboard, which sends the full object whenever a
-	 * user customises video: seed the payload from the project's default video
-	 * settings (fetched once and cached by the API client), then layer the post's
-	 * own choices on top — the chosen size becomes the only enabled size, and the
-	 * chosen video template overrides the project default. Anything the post
-	 * doesn't customise (variants, and the size dimensions) is echoed straight
-	 * from the project defaults.
+	 * The backend silently skips video generation unless the payload has `enabled:
+	 * true` plus non-empty `variants` and `sizes` (with dimensions), so we seed
+	 * from the project defaults and layer the post's choices on top. See doc/video-settings-payload.md.
 	 *
 	 * @since 7.0.0
 	 *
@@ -378,25 +332,21 @@ class Content {
 	 * @return array<string, mixed> The `video_settings` param.
 	 */
 	private static function get_video_settings_params( int $post_id ): array {
-		// Fetch the defaults for the project this post publishes to — which may
-		// be a per-post override of the global project — so the variants and size
-		// dimensions match the project the content POST actually targets.
+		// The post's project may be a per-post override of the global one.
 		$project_id = \BeyondWords\Post\Meta::get_project_id( $post_id );
 		$defaults   = \BeyondWords\Api\Client::get_video_settings( is_numeric( $project_id ) ? (int) $project_id : null );
 		$defaults   = is_array( $defaults ) ? $defaults : [];
 
 		$settings = [ 'enabled' => true ];
 
-		// `variants` — echo the project defaults. The backend needs a non-empty
-		// list here or it skips generation, and the plugin exposes no per-post
-		// variant control, so the project default is the correct value to send.
+		// The backend needs a non-empty `variants`; there is no per-post variant
+		// control, so echo the project defaults.
 		if ( ! empty( $defaults['variants'] ) && is_array( $defaults['variants'] ) ) {
 			$settings['variants'] = array_values( $defaults['variants'] );
 		}
 
-		// `sizes` — echo the project's sizes (carrying the width/height the
-		// backend requires), toggling `enabled` to the post's chosen size when one
-		// is set, otherwise keeping each size's project default.
+		// Echo the project sizes (the backend requires width/height), enabling
+		// only the post's chosen size when one is set.
 		$video_size    = (string) get_post_meta( $post_id, 'beyondwords_video_size', true );
 		$default_sizes = ( isset( $defaults['sizes'] ) && is_array( $defaults['sizes'] ) ) ? $defaults['sizes'] : [];
 
@@ -421,8 +371,7 @@ class Content {
 			$settings['sizes'] = $sizes;
 		}
 
-		// `template` — the post's chosen video template, or omit to defer to the
-		// project default template.
+		// Omit `template` to defer to the project default.
 		$video_template_id = intval( get_post_meta( $post_id, 'beyondwords_video_template_id', true ) );
 
 		if ( $video_template_id > 0 ) {
@@ -435,14 +384,7 @@ class Content {
 	/**
 	 * Get the post metadata to send with BeyondWords API requests.
 	 *
-	 * The metadata key is defined by the BeyondWords API as "A custom object
-	 * for storing meta information".
-	 *
-	 * The metadata values are used to create filters for playlists in the
-	 * BeyondWords dashboard.
-	 *
-	 * We currently only include taxonomies by default, and the output of this
-	 * method can be filtered using the `beyondwords_post_metadata` filter.
+	 * The values are used to create playlist filters in the BeyondWords dashboard.
 	 *
 	 * @since 3.3.0
 	 * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils.
@@ -467,15 +409,6 @@ class Content {
 
 	/**
 	 * Get all taxonomies, and their selected terms, for a post.
-	 *
-	 * Returns an associative array of taxonomy names and terms.
-	 *
-	 * For example:
-	 *
-	 * array(
-	 *     "categories" => array("Category 1"),
-	 *     "post_tag" => array("Tag 1", "Tag 2", "Tag 3"),
-	 * )
 	 *
 	 * @since 3.3.0
 	 * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils

--- a/src/post/class-head.php
+++ b/src/post/class-head.php
@@ -29,14 +29,9 @@ class Head {
 
 	/**
 	 * Sets meta[beyondwords-*] tags in the head tag of singular pages.
-	 * We set both the [content] attribute and a custom data attribute for compatibility.
 	 *
-	 * Only emitted for the client-side ("Magic Embed") integration: those tags
-	 * are hints for the BeyondWords crawler/SDK, which reads them off the page to
-	 * detect content. With the REST API integration the platform already has the
-	 * title, author, voice and language from the content payload, so emitting
-	 * them — and exposing internal voice IDs in the page source — serves no
-	 * purpose.
+	 * Magic Embed only: the tags are hints for the BeyondWords crawler/SDK. The
+	 * REST API integration already sends these values in the content payload.
 	 *
 	 * @since 6.0.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.

--- a/src/post/class-meta.php
+++ b/src/post/class-meta.php
@@ -22,10 +22,8 @@ class Meta {
 	/**
 	 * Get "renamed" Post Meta.
 	 *
-	 * We previously saved custom fields with a prefix of `speechkit_*` and we now
-	 * save them with a prefix of `beyondwords_*`.
-	 *
-	 * This method checks both prefixes, copying `speechkit_*` data to `beyondwords_*`.
+	 * Checks `beyondwords_*` then the legacy `speechkit_*` prefix, migrating
+	 * legacy values to the new prefix on read.
 	 *
 	 * @since 3.7.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -43,7 +41,6 @@ class Meta {
 		if ( metadata_exists( 'post', $post_id, 'speechkit_' . $name ) ) {
 			$value = get_post_meta( $post_id, 'speechkit_' . $name, true );
 
-			// Migrate over to newer `beyondwords_*` format
 			update_post_meta( $post_id, 'beyondwords_' . $name, $value );
 
 			return $value;
@@ -67,7 +64,6 @@ class Meta {
 
 		$metadata = array_filter( $metadata, fn( $item ) => in_array( $item['meta_key'], $keys_to_check ) );
 
-		// Prepend the WordPress Post ID to the meta data
         // phpcs:disable WordPress.DB.SlowDBQuery
 		array_push(
 			$metadata,
@@ -124,7 +120,7 @@ class Meta {
 		$content_id         = self::get_content_id( $post_id );
 		$integration_method = get_post_meta( $post_id, 'beyondwords_integration_method', true );
 
-		// If the integration method is not set, we assume REST API for legacy compatibility.
+		// Unset means REST API, for legacy compatibility.
 		if ( empty( $integration_method ) ) {
 			$integration_method = \BeyondWords\Settings\Fields::INTEGRATION_REST_API;
 		}
@@ -133,7 +129,7 @@ class Meta {
 			return true;
 		}
 
-		// Get the project ID for the post (do not use the plugin setting).
+		// Strict: don't fall back to the plugin-setting project ID.
 		$project_id = self::get_project_id( $post_id, true );
 
 		if ( \BeyondWords\Settings\Fields::INTEGRATION_CLIENT_SIDE === $integration_method && ! empty( $project_id ) ) {
@@ -180,20 +176,11 @@ class Meta {
 	}
 
 	/**
-	 * Sanitize a BeyondWords Content ID.
+	 * Sanitize a BeyondWords Content ID (numeric ID or UUID).
 	 *
-	 * Content IDs are BeyondWords-issued numeric IDs or UUIDs, so the only valid
-	 * characters are alphanumerics and hyphens — the same `[a-zA-Z0-9\-]+` charset
-	 * the plugin's own inspect REST route enforces. Anything outside that set is
-	 * rejected (blanked) rather than stored, because the Content ID is later
-	 * interpolated into BeyondWords API URL paths in \BeyondWords\Api\Client, where
-	 * characters such as `/`, `.`, `?`, `#` and `&` would let a crafted value steer
-	 * an authenticated, organization-API-key-scoped request to an attacker-chosen
-	 * endpoint (path/query injection).
-	 *
-	 * Used both directly by the classic-editor save handler and as the
-	 * `sanitize_callback` for the `beyondwords_content_id` post meta, so the
-	 * block-editor / REST write path is validated identically.
+	 * Anything beyond alphanumerics and hyphens is rejected: the ID is later
+	 * interpolated into API URL paths, where `/`, `?`, `#` etc. would allow
+	 * path/query injection against the authenticated API.
 	 *
 	 * @since 7.0.0
 	 *
@@ -223,50 +210,34 @@ class Meta {
 	 * @return int|false Podcast ID, or false
 	 */
 	public static function get_podcast_id( int $post_id ): string|int|false {
-		// Check for "Podcast ID" custom field (number, or string for > 4.x)
 		$podcast_id = self::get_renamed_post_meta( $post_id, 'podcast_id' );
 
 		if ( $podcast_id ) {
 			return $podcast_id;
 		}
 
-		// It may also be found by parsing post_meta._speechkit_link
+		// Legacy player URLs are /a/[ID], /e/[ID] or /m/[ID].
 		$speechkit_link = get_post_meta( $post_id, '_speechkit_link', true );
-		// Player URL can be either /a/[ID] or /e/[ID] or /m/[ID]
 		preg_match( '/\/[aem]\/(\d+)/', (string) $speechkit_link, $matches );
 		if ( $matches ) {
 			return intval( $matches[1] );
 		}
 
-		// It may also be found by parsing post_meta.speechkit_response
 		$speechkit_response = self::get_http_response_body_from_post_meta( $post_id, 'speechkit_response' );
 		preg_match( '/"podcast_id":(")?(\d+)(?(1)\1|)/', (string) $speechkit_response, $matches );
-		// $matches[2] is the Podcast ID (response.podcast_id)
 		if ( $matches && $matches[2] ) {
 			return intval( $matches[2] );
 		}
 
-		/**
-		 * It may also be found by parsing post_meta.speechkit_info
-		 *
-		 * NOTE: This has been copied verbatim from the existing iframe player check
-		 *       at Speechkit_Public::iframe_player_embed_html(), in case it is
-		 *       needed for posts which were created a very long time ago.
-		 *       I cannot write unit tests for this to pass, they always fail for me,
-		 *       so there are currently no tests for it.
-		 */
-		// Mirrors the if/else at Speechkit_Public::iframe_player_embed_html();
+		// Mirrors the if/else at legacy Speechkit_Public::iframe_player_embed_html();
 		// only the share_url branch produces a usable Podcast ID for us.
 		$article = get_post_meta( $post_id, 'speechkit_info', true );
 		if ( ! empty( $article ) && isset( $article['share_url'] ) ) {
-			// Player URL can be either /a/[ID] or /e/[ID] or /m/[ID]
 			preg_match( '/\/[aem]\/(\d+)/', (string) $article['share_url'], $matches );
 			if ( $matches ) {
 				return intval( $matches[1] );
 			}
 		}
-
-		// todo throw ContentIdNotFoundException???
 
 		return false;
 	}
@@ -274,12 +245,7 @@ class Meta {
 	/**
 	 * Get the BeyondWords preview token for a WordPress Post.
 	 *
-	 * The preview token allows us to play audio that has a future scheduled
-	 * publish date, so we can preview the audio in WordPress admin before it
-	 * is published.
-	 *
-	 * The token is supplied by the BeyondWords REST API whenever audio content
-	 * is created/updated, and stored in a WordPress custom field.
+	 * The token allows previewing audio in admin before its scheduled publish date.
 	 *
 	 * @since 4.5.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
@@ -307,12 +273,10 @@ class Meta {
 	public static function has_generate_audio( int $post_id ): bool {
 		$generate_audio = self::get_renamed_post_meta( $post_id, 'generate_audio' );
 
-		// Checkbox was checked.
 		if ( $generate_audio === '1' ) {
 			return true;
 		}
 
-		// Checkbox was unchecked.
 		if ( $generate_audio === '0' ) {
 			return false;
 		}
@@ -323,10 +287,8 @@ class Meta {
 	/**
 	 * Get the Project ID for a WordPress Post.
 	 *
-	 * It is possible to change the BeyondWords project ID in the plugin settings,
-	 * so the current Project ID setting will not necessarily be correct for all
-	 * historic Posts. Because of this, we attempt to retrive the correct Project ID
-	 * from various custom fields, then fall-back to the plugin setting.
+	 * The plugin-setting project ID may have changed since a post was created,
+	 * so historic custom fields are checked before falling back to the setting.
 	 *
 	 * @since 3.0.0
 	 * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils
@@ -341,36 +303,29 @@ class Meta {
 	 * @return int|false Project ID, or false
 	 */
 	public static function get_project_id( int $post_id, bool $strict = false ): int|string|false {
-		// If strict is true, we only check the custom field and do not fall back to the plugin setting.
 		if ( $strict ) {
 			return self::get_renamed_post_meta( $post_id, 'project_id' );
 		}
 
-		// Check the post custom field.
 		$post_meta = intval( self::get_renamed_post_meta( $post_id, 'project_id' ) );
 
 		if ( ! empty( $post_meta ) ) {
 			return $post_meta;
 		}
 
-		// Parse post_meta.speechkit_response, if available.
 		$speechkit_response = self::get_http_response_body_from_post_meta( $post_id, 'speechkit_response' );
 
 		preg_match( '/"project_id":(")?(\d+)(?(1)\1|)/', (string) $speechkit_response, $matches );
 
-		// $matches[2] is the Project ID (response.project_id)
 		if ( $matches && $matches[2] ) {
 			return intval( $matches[2] );
 		}
 
-		// Check the plugin setting.
 		$setting = get_option( 'beyondwords_project_id' );
 
 		if ( $setting ) {
 			return intval( $setting );
 		}
-
-		// todo throw ProjectIdNotFoundException?
 
 		return false;
 	}
@@ -397,8 +352,6 @@ class Meta {
 	/**
 	 * Get the "Error Message" value for a WordPress Post.
 	 *
-	 * Supports data saved with the `beyondwords_*` prefix and the legacy `speechkit_*` prefix.
-	 *
 	 * @since 3.7.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
@@ -413,8 +366,6 @@ class Meta {
 	/**
 	 * Get the "Disabled" value for a WordPress Post.
 	 *
-	 * Supports data saved with the `beyondwords_*` prefix and the legacy `speechkit_*` prefix.
-	 *
 	 * @since 3.7.0
 	 * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
 	 *
@@ -427,11 +378,8 @@ class Meta {
 	/**
 	 * Get HTTP response body from post meta.
 	 *
-	 * The data may have been saved as a WordPress HTTP response array. If it was,
-	 * then return the 'body' key of the HTTP response instead of the raw post meta.
-	 *
-	 * The data may also have been saved as a WordPress WP_Error instance. If it was,
-	 * then return a string containing the WP_Error code and message.
+	 * Legacy rows may hold a whole WordPress HTTP response array or a WP_Error;
+	 * both are normalised to a string.
 	 *
 	 * @since 3.0.3
 	 * @since 3.5.0 Moved from Core\Utils to Component\Post\PostUtils

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -1,16 +1,10 @@
 <?php
 /**
- * WordPress ↔ BeyondWords post sync.
- *
- * Owns the post-save / trash / delete handlers and the meta key registration —
- * the bridge between WordPress post lifecycle events and the BeyondWords API.
- * Block-editor JS bootstrap lives in [src/editor/block/class-assets.php](src/editor/block/class-assets.php).
+ * WordPress ↔ BeyondWords post sync: save/trash/delete handlers and meta registration.
  *
  * @package BeyondWords\Post
  * @since   3.0.0
- * @since   7.0.0 Refactored to BeyondWords namespace with snake_case methods.
- *                Editor enqueue moved to BeyondWords\Editor\Editor.
- *                Renamed from BeyondWords\Core\Core to BeyondWords\Post\Sync.
+ * @since   7.0.0 Renamed from BeyondWords\Core\Core to BeyondWords\Post\Sync.
  */
 
 declare( strict_types = 1 );
@@ -27,38 +21,27 @@ defined( 'ABSPATH' ) || exit;
 class Sync {
 
 	/**
-	 * Cron hook that runs deferred audio (re)generation.
-	 *
-	 * Only scheduled on WordPress VIP (see `is_async_generation_enabled()`).
+	 * Cron hook that runs deferred audio (re)generation (VIP-only; see is_async_generation_enabled()).
 	 *
 	 * @since 7.0.0
 	 */
 	const GENERATE_AUDIO_CRON_HOOK = 'beyondwords_generate_audio';
 
 	/**
-	 * Cron hook that runs a deferred audio deletion.
+	 * Cron hook that runs a deferred audio deletion (VIP-only).
 	 *
-	 * Like GENERATE_AUDIO_CRON_HOOK, only scheduled when async is enabled (VIP).
-	 * The event args carry the BeyondWords project + content IDs — not a post ID —
-	 * because the post meta is wiped (on trash) or the post row is gone (on
-	 * permanent delete) by the time the job runs.
+	 * Args are the BeyondWords project + content IDs, not a post ID — the post
+	 * meta is wiped or the post row gone by the time the job runs.
 	 *
 	 * @since 7.0.0
 	 */
 	const DELETE_AUDIO_CRON_HOOK = 'beyondwords_delete_audio';
 
 	/**
-	 * Deprecated post-meta keys that still need REST exposure.
+	 * Deprecated post-meta keys still exposed to the block editor over REST.
 	 *
-	 * On a site upgraded from the legacy SpeechKit plugin these keys can hold a
-	 * post's only BeyondWords data until it is regenerated under v7, so the block
-	 * editor reads them in the authenticated `edit` context as a fallback — the
-	 * error notice, pending notice, play/preview controls, the "Generate audio"
-	 * toggle and the legacy player link all depend on them (see the components
-	 * under [src/editor/components/](src/editor/components/)). They are therefore
-	 * registered with `show_in_rest => true`; every *other* deprecated key —
-	 * including the secret `speechkit_access_key` — is registered
-	 * `show_in_rest => false` and never reaches the REST API.
+	 * On sites upgraded from legacy SpeechKit these can hold a post's only
+	 * BeyondWords data, so the editor components read them as a fallback.
 	 *
 	 * @since 7.0.0
 	 *
@@ -74,16 +57,10 @@ class Sync {
 	];
 
 	/**
-	 * REST-exposed post-meta keys that must never be readable by unauthenticated
-	 * visitors.
+	 * REST-exposed post-meta keys that hold secrets or internal data.
 	 *
-	 * The block editor needs these in the authenticated `edit` context, but
-	 * `WP_REST_Meta_Fields` returns `show_in_rest` meta in the public `view`
-	 * context too, with no capability check — so an anonymous
-	 * `GET /wp/v2/posts/:id` would otherwise disclose them. They hold secrets or
-	 * internal data (BeyondWords API error strings, the audio preview token and
-	 * the legacy player URL), so `hide_private_meta_from_rest()` strips them from
-	 * every non-`edit` response.
+	 * The hide_private_meta_from_rest() filter strips these from every
+	 * non-`edit` response so unauthenticated requests never see them.
 	 *
 	 * @since 7.0.0
 	 *
@@ -101,39 +78,23 @@ class Sync {
 	 */
 	public static function init(): void {
 		add_action( 'init', [ self::class, 'register_meta' ], 99, 3 );
-
-		// Strip secret/internal post meta from unauthenticated REST responses.
-		// Registered on `rest_api_init` so the filters only load for REST
-		// requests.
 		add_action( 'rest_api_init', [ self::class, 'register_rest_meta_visibility' ] );
 
 		add_action( 'wp_after_insert_post', [ self::class, 'on_add_or_update_post' ], 99 );
 		add_action( 'wp_trash_post', [ self::class, 'on_trash_post' ] );
 		add_action( 'before_delete_post', [ self::class, 'on_delete_post' ] );
 
-		// Background audio (re)generation — only used when async is enabled (VIP);
-		// the hook is always registered so a queued event still runs after a
-		// config change.
+		// Cron handlers are registered unconditionally so queued events still run
+		// after a config change.
 		add_action( self::GENERATE_AUDIO_CRON_HOOK, [ self::class, 'generate_audio_for_post' ] );
-
-		// Background audio deletion — the deferred counterpart to the trash/delete
-		// handlers. Registered unconditionally (like the generation hook) so a
-		// queued event still runs after a config change. Takes the project +
-		// content IDs as args because the post meta is gone by the time it fires.
 		add_action( self::DELETE_AUDIO_CRON_HOOK, [ self::class, 'delete_audio_by_ids' ], 10, 2 );
 
 		add_filter( 'is_protected_meta', [ self::class, 'is_protected_meta' ], 10, 2 );
-
-		// Older posts may be missing `beyondwords_language_code`; back-fill from
-		// the legacy `beyondwords_language_id` mapping when read.
 		add_filter( 'get_post_metadata', [ self::class, 'get_lang_code_from_json_if_empty' ], 10, 3 );
 	}
 
 	/**
 	 * Whether a given post status is one BeyondWords processes audio for.
-	 *
-	 * Defaults: pending, publish, private, future. Filterable via
-	 * `beyondwords_settings_post_statuses`.
 	 */
 	public static function should_process_post_status( string $status ): bool {
 		$statuses = [ 'pending', 'publish', 'private', 'future' ];
@@ -155,27 +116,17 @@ class Sync {
 	/**
 	 * Whether to (re)generate audio for a post on save.
 	 *
-	 * Returns false for autosaves, revisions, and ineligible statuses.
-	 *
-	 * An explicit `beyondwords_generate_audio` value always wins ('1' = yes,
-	 * '0' = no). When it is unset we fall back to the Preselect setting, but
-	 * only for editor/REST saves: the block editor derives the toggle from
-	 * Preselect without writing meta (so the post isn't dirtied — improvement
-	 * #2), so the generate decision has to come from the setting at save time.
-	 * The classic editor writes an explicit value via its checkbox, and
-	 * programmatic/imported posts (wp_insert_post, WXR import, cron) keep the
-	 * explicit-meta requirement so a bulk import never unexpectedly generates.
+	 * An explicit `beyondwords_generate_audio` meta value always wins; when it
+	 * is unset the Preselect setting decides, but only for editor/REST saves so
+	 * a programmatic/bulk import never unexpectedly generates audio.
 	 */
 	public static function should_generate_audio_for_post( int $post_id ): bool {
 		if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
 			return false;
 		}
 
-		// get_post_status() returns false when the post no longer exists — e.g. it
-		// was trashed or permanently deleted between a deferred job being queued
-		// (see on_add_or_update_post()) and the cron firing. An empty status is
-		// never processable, so bail before the strict-typed
-		// should_process_post_status() call, which would TypeError on false.
+		// False when the post was deleted between a deferred job being queued and
+		// the cron firing; bail before the strict-typed status check.
 		$status = get_post_status( $post_id );
 		if ( ! $status ) {
 			return false;
@@ -185,9 +136,6 @@ class Sync {
 			return false;
 		}
 
-		// Read via get_renamed_post_meta so a legacy post that still only has
-		// the old `speechkit_generate_audio` key is honoured (and migrated to
-		// `beyondwords_generate_audio` on read).
 		$generate_audio = \BeyondWords\Post\Meta::get_renamed_post_meta( $post_id, 'generate_audio' );
 
 		if ( '1' === $generate_audio ) {
@@ -207,24 +155,15 @@ class Sync {
 	}
 
 	/**
-	 * Whether audio (re)generation should run in the background rather than
-	 * blocking the save request.
+	 * Whether audio (re)generation runs in the background instead of blocking the save.
 	 *
-	 * Enabled only on WordPress VIP, whose Cron Control infrastructure runs
-	 * scheduled events from a real system cron — so a deferred job fires
-	 * promptly and reliably. Off-VIP, WP-Cron is traffic-triggered and
-	 * unreliable, so we keep the synchronous call and accept the slower save.
-	 *
-	 * Detection is by VIP-only symbols (`function_exists`/`class_exists`/
-	 * `defined`), so non-VIP installs always take the synchronous path.
-	 * Overridable via the `beyondwords_async_generate_audio` filter for hosts
-	 * with reliable cron, and for tests.
+	 * VIP-only: Cron Control runs scheduled events reliably there; elsewhere
+	 * WP-Cron is traffic-triggered, so we stay synchronous. See doc/async-rest-migration.md.
 	 *
 	 * @since 7.0.0
 	 */
 	public static function is_async_generation_enabled(): bool {
-		// VIP runs WP-Cron via its Cron Control plugin; these symbols only exist
-		// in that environment.
+		// These symbols only exist on WordPress VIP.
 		$enabled = class_exists( '\Automattic\WP\Cron_Control\Main' )
 			|| function_exists( 'wpcom_vip_schedule_single_event' )
 			|| defined( 'VIP_GO_APP_ENVIRONMENT' );
@@ -232,8 +171,7 @@ class Sync {
 		/**
 		 * Filters whether BeyondWords audio (re)generation runs in the background.
 		 *
-		 * Defaults to true only on WordPress VIP. Return true to force background
-		 * generation on another host with reliable WP-Cron.
+		 * Defaults to true only on WordPress VIP.
 		 *
 		 * @since 7.0.0
 		 *
@@ -244,11 +182,6 @@ class Sync {
 
 	/**
 	 * Generate audio for a post if eligibility checks pass.
-	 *
-	 * For Magic Embed (client-side) we POST to the by-source-id endpoint and
-	 * stamp the post meta. For REST API integration we either update existing
-	 * audio (with 404 recovery via `update_or_recreate_audio()`) or create
-	 * fresh content.
 	 *
 	 * @return array<mixed>|false|null Response from the API, or false when audio wasn't generated.
 	 */
@@ -264,7 +197,7 @@ class Sync {
 
 		$integration_method = \BeyondWords\Settings\Fields::get_integration_method( $post );
 
-		// Magic Embed: import via the source ID endpoint.
+		// Client-side integration is "Magic Embed": import via the by-source-id endpoint.
 		if ( \BeyondWords\Settings\Fields::INTEGRATION_CLIENT_SIDE === $integration_method ) {
 			update_post_meta( $post_id, 'beyondwords_integration_method', \BeyondWords\Settings\Fields::INTEGRATION_CLIENT_SIDE );
 			update_post_meta( $post_id, 'beyondwords_project_id', get_option( 'beyondwords_project_id' ) );
@@ -272,7 +205,6 @@ class Sync {
 			return \BeyondWords\Api\Client::get_player_by_source_id( $post_id );
 		}
 
-		// REST API integration: update or create.
 		update_post_meta( $post_id, 'beyondwords_integration_method', \BeyondWords\Settings\Fields::INTEGRATION_REST_API );
 
 		$content_id = \BeyondWords\Post\Meta::get_content_id( $post_id );
@@ -296,10 +228,8 @@ class Sync {
 	/**
 	 * Update audio for a post, recovering from a stale content ID.
 	 *
-	 * When BeyondWords returns 404 (content no longer exists in their database),
-	 * `\BeyondWords\Api\Client::update_audio()` writes `#404:…` into the error meta. We
-	 * detect that prefix, clear the stale ID, and create fresh content via
-	 * POST so the post recovers automatically.
+	 * A `#404:…` error meta means the content no longer exists at BeyondWords,
+	 * so clear the stale IDs and create fresh content instead.
 	 */
 	private static function update_or_recreate_audio( int $post_id ): array|null|false {
 		$response = \BeyondWords\Api\Client::update_audio( $post_id );
@@ -336,12 +266,6 @@ class Sync {
 	/**
 	 * Run a deferred audio deletion queued by the trash/delete handlers.
 	 *
-	 * The `DELETE_AUDIO_CRON_HOOK` cron event carries the BeyondWords project +
-	 * content IDs directly (not a post ID) because the post meta has already been
-	 * wiped — or the post row deleted — by the time this fires. Only reached on
-	 * the async path, which is VIP-only by default (see
-	 * `is_async_generation_enabled()`).
-	 *
 	 * @since 7.0.0
 	 *
 	 * @param int|string $project_id BeyondWords project ID.
@@ -369,12 +293,9 @@ class Sync {
 			update_post_meta( $post_id, 'beyondwords_project_id', $project_id );
 			update_post_meta( $post_id, 'beyondwords_content_id', $response['id'] );
 
-			// We deliberately do NOT copy `language` or `body_voice_id` back from
-			// the API response. Those meta keys hold the editor's *explicit*
-			// language/voice choices ("Customize" on); echoing the project-default
-			// values the API resolved would make a default post look customised
-			// and freeze its voice so it no longer follows the project default.
-			// See Content::get_content_params().
+			// Deliberately don't copy `language`/`body_voice_id` back: those keys hold
+			// explicit editor choices, and echoing the API-resolved project defaults
+			// would freeze them. See Content::get_content_params().
 			$copy = [
 				'preview_token' => 'beyondwords_preview_token',
 			];
@@ -392,15 +313,8 @@ class Sync {
 	/**
 	 * Register every BeyondWords post-meta key for REST + auth gating.
 	 *
-	 * Registers per-(post_type, meta_key) combination so the meta is exposed
-	 * only on compatible post types. Every key is registered so writes are
-	 * sanitised and the "Custom Fields" panel stays hidden (see
-	 * `is_protected_meta()`), but only the keys the block editor reads/writes
-	 * over REST get `show_in_rest => true`. Secrets and internal data — the
-	 * legacy `speechkit_access_key`, cached API responses, player/voice config —
-	 * are registered `show_in_rest => false` so they are never exposed via the
-	 * REST API. Sensitive keys the editor *does* need are additionally hidden
-	 * from unauthenticated requests by `hide_private_meta_from_rest()`.
+	 * Only keys the block editor reads/writes over REST get `show_in_rest`;
+	 * secrets and internal data never reach the REST API.
 	 */
 	public static function register_meta(): void {
 		$post_types = \BeyondWords\Settings\Utils::get_compatible_post_types();
@@ -411,8 +325,6 @@ class Sync {
 
 		$keys = \BeyondWords\Core\Utils::get_post_meta_keys( 'all' );
 
-		// The current keys plus the handful of deprecated keys the block editor
-		// still reads for back-compat (see REST_LEGACY_META_KEYS).
 		$rest_keys = array_merge(
 			\BeyondWords\Core\Utils::get_post_meta_keys( 'current' ),
 			self::REST_LEGACY_META_KEYS
@@ -420,9 +332,8 @@ class Sync {
 
 		foreach ( $post_types as $post_type ) {
 			foreach ( $keys as $key ) {
-				// Content IDs are interpolated into BeyondWords API URL paths, so
-				// the block-editor / REST write path needs the same strict charset
-				// validation as the classic editor — see Meta::sanitize_content_id().
+				// Content IDs are interpolated into API URL paths, so REST writes need
+				// the same strict validation as the classic editor.
 				$sanitize_callback = 'beyondwords_content_id' === $key
 					? [ \BeyondWords\Post\Meta::class, 'sanitize_content_id' ]
 					: 'sanitize_text_field';
@@ -446,8 +357,7 @@ class Sync {
 	}
 
 	/**
-	 * Register the REST response filter that hides private BeyondWords meta from
-	 * unauthenticated requests, for every compatible post type.
+	 * Register the REST filter that hides private BeyondWords meta, per post type.
 	 *
 	 * @since 7.0.0
 	 */
@@ -466,14 +376,8 @@ class Sync {
 	/**
 	 * Strip secret/internal BeyondWords meta from non-`edit` REST responses.
 	 *
-	 * `register_meta()` exposes a handful of keys the block editor needs in the
-	 * authenticated `edit` context (BeyondWords API error messages, the audio
-	 * preview token, the legacy player URL), but `WP_REST_Meta_Fields` returns
-	 * `show_in_rest` meta in the public `view` context too, with no capability
-	 * check. Requesting the `edit` context is itself permission-gated by the
-	 * posts controller, so we keep those keys only for `edit` requests and remove
-	 * them everywhere else — closing the anonymous `GET /wp/v2/posts/:id`
-	 * disclosure while leaving the block editor unaffected.
+	 * `WP_REST_Meta_Fields` returns `show_in_rest` meta in the public `view`
+	 * context with no capability check; the `edit` context is permission-gated.
 	 *
 	 * @since 7.0.0
 	 *
@@ -510,9 +414,8 @@ class Sync {
 	/**
 	 * Hide BeyondWords meta from the legacy "Custom Fields" panel.
 	 *
-	 * The Block Editor's Custom Fields panel can break when our meta is
-	 * shown alongside the auto-rendered controls — see
-	 * https://github.com/WordPress/gutenberg/issues/23078.
+	 * The panel can break when our meta renders alongside the auto-rendered
+	 * controls — https://github.com/WordPress/gutenberg/issues/23078.
 	 *
 	 * @param bool|null   $is_protected Whether the meta is currently flagged protected.
 	 * @param string|null $meta_key     Meta key being checked. Null is passed by some core paths.
@@ -532,13 +435,8 @@ class Sync {
 	/**
 	 * Schedule a deferred audio-generation cron event for a post.
 	 *
-	 * Only reached on the async path, which is VIP-only by default (see
-	 * `is_async_generation_enabled()`). Prefers VIP's
-	 * `wpcom_vip_schedule_single_event()` wrapper when it exists (classic
-	 * WordPress.com VIP); on VIP Go — and anywhere the async filter is forced
-	 * on — the core function is the correct call and is routed through Cron
-	 * Control. No-ops when an event for this post is already queued, so repeated
-	 * saves don't stack duplicate jobs.
+	 * No-ops when an event for this post is already queued, so repeated saves
+	 * don't stack duplicate jobs.
 	 *
 	 * @since 7.0.0
 	 */
@@ -558,11 +456,7 @@ class Sync {
 	/**
 	 * Schedule a deferred audio-deletion cron event.
 	 *
-	 * Mirrors `schedule_audio_generation()`: VIP-only in practice, prefers the
-	 * VIP wrapper when present, and no-ops when an identical event is already
-	 * queued so repeated trashing can't stack duplicate jobs. The project +
-	 * content IDs are the event args (rather than a post ID) because the meta is
-	 * gone by the time the job runs.
+	 * Mirrors `schedule_audio_generation()`, including the duplicate-event guard.
 	 *
 	 * @since 7.0.0
 	 */
@@ -582,13 +476,10 @@ class Sync {
 	}
 
 	/**
-	 * Clear any pending deferred audio-generation cron event for a post.
+	 * Clear any pending audio-generation cron event for a post.
 	 *
-	 * Called when a post is trashed or deleted so a job queued by
-	 * `on_add_or_update_post()` doesn't fire for a post that no longer exists.
-	 * Runs before the `has_content()` checks in the lifecycle handlers because a
-	 * queued post may not have written its content meta yet. `wp_clear_scheduled_hook()`
-	 * is routed through Cron Control on VIP, so it unschedules reliably there too.
+	 * Runs before the `has_content()` checks in the lifecycle handlers because
+	 * a queued post may not have written its content meta yet.
 	 *
 	 * @since 7.0.0
 	 */
@@ -599,15 +490,8 @@ class Sync {
 	/**
 	 * Delete a post's BeyondWords audio, deferring to background cron on VIP.
 	 *
-	 * On VIP (async enabled) we capture the project + content IDs now and
-	 * schedule a single background event, so the trash/delete request — which may
-	 * be removing many posts at once — returns immediately instead of blocking on
-	 * one remote DELETE per post. We read the IDs before the caller wipes the meta
-	 * (on trash) or WordPress deletes the row (on permanent delete). Off-VIP,
-	 * where WP-Cron is unreliable, we fall back to a synchronous DELETE, bounded
-	 * by the client's short `DEFAULT_REQUEST_TIMEOUT`.
-	 *
-	 * The caller must have confirmed `Meta::has_content()` first.
+	 * The IDs are captured now because the caller wipes the meta (trash) or
+	 * WordPress deletes the row (permanent delete) before a deferred job runs.
 	 *
 	 * @since 7.0.0
 	 */
@@ -627,8 +511,7 @@ class Sync {
 	}
 
 	/**
-	 * Trash hook — DELETE the audio so it disappears from the dashboard, then
-	 * remove our local metadata.
+	 * Trash hook: delete the remote audio, then remove our local metadata.
 	 */
 	public static function on_trash_post( $post_id ): void {
 		$post_id = (int) $post_id;
@@ -644,8 +527,7 @@ class Sync {
 	}
 
 	/**
-	 * Permanent delete hook — same DELETE call as trash, without the meta cleanup
-	 * (the row is going away anyway).
+	 * Permanent delete hook: same as trash, minus the meta cleanup.
 	 */
 	public static function on_delete_post( $post_id ): void {
 		$post_id = (int) $post_id;
@@ -662,9 +544,8 @@ class Sync {
 	/**
 	 * `wp_after_insert_post` hook.
 	 *
-	 * Skips the second invocation that Gutenberg makes via the meta-box save
-	 * round-trip, otherwise we'd double-process every save. When the post has
-	 * `beyondwords_delete_content` set we delete instead of generating.
+	 * Skips Gutenberg's second invocation via the meta-box save round-trip,
+	 * which would otherwise double-process every save.
 	 */
 	public static function on_add_or_update_post( $post_id ): bool {
 		$post_id = (int) $post_id;
@@ -680,11 +561,8 @@ class Sync {
 			return false;
 		}
 
-		// On VIP, defer the blocking create/update API call to a background cron
-		// job so the save request returns immediately. Off-VIP we fall through to
-		// the synchronous call below, because WP-Cron there is traffic-triggered
-		// and unreliable. The eligibility check is repeated inside
-		// generate_audio_for_post() when the deferred job runs.
+		// Eligibility is re-checked inside generate_audio_for_post() when the
+		// deferred job runs.
 		if ( self::is_async_generation_enabled() && self::should_generate_audio_for_post( $post_id ) ) {
 			self::schedule_audio_generation( $post_id );
 
@@ -695,10 +573,7 @@ class Sync {
 	}
 
 	/**
-	 * Back-fill `beyondwords_language_code` from the legacy numeric language ID
-	 * when the modern ISO-code meta is empty.
-	 *
-	 * Reads `assets/lang-codes.json` lazily — only when a stale post is queried.
+	 * Back-fill `beyondwords_language_code` from the legacy numeric language ID.
 	 *
 	 * @param mixed       $value     Existing meta value.
 	 * @param int         $object_id Post ID.

--- a/src/posts-list/class-bulk-edit.php
+++ b/src/posts-list/class-bulk-edit.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Bulk Edit handler for the posts list screen.
- *
- * Adds a "BeyondWords" column to the bulk-edit dropdown so multiple posts can
- * have audio generated or deleted in one action.
+ * Bulk Edit handler for the posts list screen: generate/delete audio for many posts.
  *
  * @package BeyondWords\PostsList
  * @since   3.0.0
@@ -83,27 +80,10 @@ class BulkEdit {
 	}
 
 	/**
-	 * AJAX handler for the inline bulk-edit submission.
+	 * AJAX handler (`wp_ajax_save_bulk_edit_beyondwords`) for the inline bulk edit.
 	 *
-	 * Wired via `wp_ajax_save_bulk_edit_beyondwords`. Verifies the nonce that
-	 * was emitted by `bulk_edit_custom_box()` and the current user's capability
-	 * before delegating to the generate/delete helpers.
-	 *
-	 * The nonce only proves the request was intentional (CSRF protection); it
-	 * does not authorise the action. Because every `wp_ajax_*` callback is
-	 * reachable by any logged-in user, we additionally gate on capabilities —
-	 * mirroring the core bulk-action capability checks the redirect-based
-	 * handlers rely on — so a Subscriber/Contributor cannot mutate or delete
-	 * audio on posts they are not allowed to edit.
-	 *
-	 * Always terminates the request via `wp_send_json_success()` /
-	 * `wp_send_json_error()` (both call `wp_die()` internally). A WordPress AJAX
-	 * callback that merely returns falls through to core's `wp_die( '0' )`, so
-	 * the payload would be discarded and the client would always receive the
-	 * bare string `0`. The generate/delete dispatch is wrapped in try/catch so a
-	 * thrown `\Exception` — e.g. when none of the selected posts have BeyondWords
-	 * audio — becomes a JSON error response instead of an uncaught fatal,
-	 * mirroring the handling in `handle_bulk_delete_action()`.
+	 * The nonce is CSRF protection only; any logged-in user can reach a
+	 * `wp_ajax_*` callback, so capabilities must additionally gate the action.
 	 */
 	public static function save_bulk_edit(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
@@ -148,9 +128,8 @@ class BulkEdit {
 			)
 		);
 
-		// A capable user may still have selected only posts they cannot edit; treat
-		// that as a clean no-op rather than the empty-batch error the delete helper
-		// would otherwise throw.
+		// A capable user may have selected only posts they cannot edit; treat that
+		// as a clean no-op rather than the delete helper's empty-batch error.
 		if ( empty( $post_ids ) ) {
 			wp_send_json_success( [] );
 		}
@@ -264,11 +243,8 @@ class BulkEdit {
 			$redirect
 		);
 
-		// Only operate on posts the current user is actually allowed to edit. Core
-		// routes custom bulk actions through this filter after only a coarse
-		// edit_posts check, so without this per-post guard a crafted request could
-		// force (billable) audio generation on another author's posts. Mirrors the
-		// capability filter in save_bulk_edit().
+		// Core routes custom bulk actions here after only a coarse edit_posts check,
+		// so guard per-post — else a crafted request could trigger billable generation.
 		$object_ids = array_values(
 			array_filter(
 				$object_ids,
@@ -276,8 +252,7 @@ class BulkEdit {
 			)
 		);
 
-		// A capable user may still have selected only posts they cannot edit; treat
-		// that as a clean no-op reporting a zero count.
+		// Nothing editable selected: a clean no-op reporting a zero count.
 		if ( empty( $object_ids ) ) {
 			$redirect = add_query_arg( 'beyondwords_bulk_generated', 0, $redirect );
 			$redirect = add_query_arg( 'beyondwords_bulk_failed', 0, $redirect );
@@ -338,11 +313,8 @@ class BulkEdit {
 			$redirect
 		);
 
-		// Only operate on posts the current user is actually allowed to edit. Core
-		// routes custom bulk actions through this filter after only a coarse
-		// edit_posts check, so without this per-post guard a crafted request could
-		// remotely delete audio and wipe plugin meta on another author's posts.
-		// Mirrors the capability filter in save_bulk_edit().
+		// Core routes custom bulk actions here after only a coarse edit_posts check,
+		// so guard per-post — else a crafted request could wipe another author's audio.
 		$object_ids = array_values(
 			array_filter(
 				$object_ids,
@@ -350,8 +322,7 @@ class BulkEdit {
 			)
 		);
 
-		// Bail before the remote batch-delete when nothing editable remains, so an
-		// empty selection cannot trigger an API call (or the BULK-NO-RESPONSE error).
+		// Bail before the remote batch-delete so an empty selection can't hit the API.
 		if ( empty( $object_ids ) ) {
 			$redirect = add_query_arg( 'beyondwords_bulk_deleted', 0, $redirect );
 

--- a/src/posts-list/class-column.php
+++ b/src/posts-list/class-column.php
@@ -14,8 +14,7 @@ namespace BeyondWords\PostsList;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Custom "BeyondWords" column for compatible post-type list tables, with
- * sortable header support.
+ * Sortable "BeyondWords" column on compatible post-type list tables.
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
@@ -75,10 +74,6 @@ class Column {
 	/**
 	 * Render the cell contents for the BeyondWords column.
 	 *
-	 * Output is one of: an error message (with warning dashicon), a green tick
-	 * if audio exists, or an em dash if not. A "Disabled" badge is appended
-	 * when the post has BeyondWords playback disabled.
-	 *
 	 * @param string $column_name Column slug being rendered.
 	 * @param int    $post_id     Post ID.
 	 */
@@ -94,8 +89,6 @@ class Column {
 		$error_message = \BeyondWords\Post\Meta::get_error_message( $post_id );
 		$has_content   = \BeyondWords\Post\Meta::has_content( $post_id );
 
-		// "Disabled" = no player on this post: the v7 "Embed: None" choice, or the
-		// legacy `beyondwords_disabled` flag for posts not yet migrated.
 		$disabled = \BeyondWords\Editor\Components\SettingsFields::is_player_disabled_for_post( $post_id );
 
 		if ( ! empty( $error_message ) ) {
@@ -124,8 +117,7 @@ class Column {
 	}
 
 	/**
-	 * Apply the BeyondWords meta-query sort to the main query when the user
-	 * clicks the BeyondWords column header.
+	 * Apply the BeyondWords meta-query sort when ordering by the BeyondWords column.
 	 *
 	 * @param \WP_Query $query Query object, modified in place.
 	 *

--- a/src/posts-list/class-notices.php
+++ b/src/posts-list/class-notices.php
@@ -14,8 +14,7 @@ namespace BeyondWords\PostsList;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * One notice per post-bulk-action result, all gated on the same nonce so
- * direct URL fiddling can't surface arbitrary text.
+ * One notice per bulk-action result, all nonce-gated against direct URL fiddling.
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
@@ -135,8 +134,7 @@ class Notices {
 	}
 
 	/**
-	 * Verify the result-nonce embedded in bulk-action redirects, fatally exiting
-	 * via `wp_nonce_ays()` on tamper.
+	 * Verify the result nonce in bulk-action redirects, dying via `wp_nonce_ays()` on tamper.
 	 *
 	 * Returns false (without exiting) when the nonce param is absent so callers
 	 * can short-circuit normal page loads cheaply.

--- a/src/settings/class-fields.php
+++ b/src/settings/class-fields.php
@@ -2,8 +2,7 @@
 /**
  * BeyondWords settings fields.
  *
- * Consolidates the simple text/select fields used by the settings tabs.
- * Compound fields (e.g. preselect) live in their own class.
+ * Compound fields (e.g. preselect) live in their own classes.
  *
  * @package BeyondWords\Settings
  *
@@ -19,11 +18,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Settings fields.
  *
- * One static method per field, each registering the option, sanitiser and
- * the renderer for `do_settings_fields`. Option keys, defaults and the
- * value enums for the integration method and player UI are exposed as
- * class constants so the rest of the plugin can read them without going
- * through the settings page.
+ * Option keys and value enums are class constants so the rest of the plugin
+ * can read them without going through the settings page.
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
@@ -116,10 +112,9 @@ class Fields {
 	}
 
 	/**
-	 * Register the per-site preferences (preselect, excerpt, player UI).
+	 * Register the per-site preferences (excerpt, player UI).
 	 *
-	 * Preselect lives in its own class because it has post-type-aware logic
-	 * and an enqueued JS asset for the post editor.
+	 * Preselect lives in its own class: post-type-aware logic plus a JS asset.
 	 */
 	public static function register_preferences_fields(): void {
 		register_setting(

--- a/src/settings/class-preselect.php
+++ b/src/settings/class-preselect.php
@@ -2,15 +2,10 @@
 /**
  * Preselect setting.
  *
- * Lets the publisher pick which post types have "Generate audio" ticked by
- * default in the post editor — either for every post of that type, or only
- * for posts assigned one of a chosen set of hierarchical taxonomy terms.
- *
  * @package BeyondWords\Settings
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
- * @since 7.0.0 Reinstated term-gating for all hierarchical taxonomies, stored
- *              in a mode-based format.
+ * @since 7.0.0 Reinstated term-gating, stored in a mode-based format.
  */
 
 declare( strict_types = 1 );
@@ -20,26 +15,10 @@ namespace BeyondWords\Settings;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Preselect setting.
+ * Preselect setting, stored as a per-post-type map with a `mode` key.
  *
- * Stored as a map keyed by post type, each value an array with a `mode`:
- *
- *     [
- *       'post' => [ 'mode' => 'all' ],
- *       'page' => [
- *         'mode'  => 'terms',
- *         'terms' => [ 'category' => [ 12, 34 ], 'genre' => [ 56 ] ],
- *       ],
- *     ]
- *
- * - A post type absent from the map is never preselected.
- * - `mode => 'all'`   preselects every post of that type.
- * - `mode => 'terms'` preselects only posts that have at least one of the
- *   listed term IDs (exact match, OR across taxonomies/terms).
- *
- * The pre-7.0.0 shapes (`'1'` for whole post type, `[ taxonomy => [ ids ] ]`
- * for term-gating) are read defensively here and converted to this format by
- * the migration in `Updater::run()`.
+ * `all` preselects every post; `terms` only posts with a listed term ID;
+ * absent means off. Pre-7.0.0 shapes are migrated by `Updater::run()`.
  *
  * @since 7.0.0
  */
@@ -64,8 +43,7 @@ class Preselect {
 	}
 
 	/**
-	 * Enqueue the settings-page script that progressively reveals the "All"
-	 * checkbox and term trees. Only on the BeyondWords settings page.
+	 * Enqueue the preselect progressive-disclosure script on the settings page.
 	 *
 	 * @since 7.0.0
 	 *
@@ -121,9 +99,8 @@ class Preselect {
 	/**
 	 * Resolve the preselect mode for a post type.
 	 *
-	 * Tolerant of the pre-7.0.0 shapes so behaviour is correct even before the
-	 * migration has run: `'1'` reads as `all`, a non-empty taxonomy array reads
-	 * as `terms`.
+	 * Tolerant of pre-7.0.0 shapes so behaviour is correct before the migration
+	 * runs: `'1'` reads as `all`, a non-empty taxonomy array as `terms`.
 	 *
 	 * @param string                   $post_type Post type slug.
 	 * @param array<string,mixed>|null $preselect Pre-loaded option, to avoid an extra `get_option()`.
@@ -212,13 +189,8 @@ class Preselect {
 	/**
 	 * Whether "Generate audio" should be preselected for a given post.
 	 *
-	 * - `all`   → always true.
-	 * - `terms` → true when the post has at least one listed term in a
-	 *             currently-registered taxonomy (exact match, OR semantics).
-	 * - `off`   → false.
-	 *
-	 * Tolerant of taxonomies that have since been unregistered or detached from
-	 * the post type — they are skipped, never fatal.
+	 * In `terms` mode a post matches when it has at least one listed term (OR
+	 * across taxonomies); unregistered/detached taxonomies are skipped, never fatal.
 	 *
 	 * @param \WP_Post|int $post Post object or ID.
 	 */
@@ -229,11 +201,8 @@ class Preselect {
 			return false;
 		}
 
-		// Use get(), whose explicit DEFAULT_VALUE fallback applies in every
-		// context (admin, REST block-editor saves, cron) — not just where the
-		// setting is registered. This keeps the server's generate decision in
-		// step with the editor's default-bearing display, since the block
-		// editor no longer writes the meta itself (it derives the toggle).
+		// get()'s DEFAULT_VALUE fallback applies in every context (REST, cron),
+		// keeping the server's decision in step with the editor's derived toggle.
 		$preselect = self::get();
 
 		$mode = self::get_mode( $post_type, $preselect );
@@ -278,20 +247,16 @@ class Preselect {
 	/**
 	 * Sanitise the submitted preselect map.
 	 *
-	 * Merge-preserve: only post types and taxonomies actually rendered this
-	 * request are taken from the submission. Config for post types that are not
-	 * currently compatible, and terms for taxonomies that are not currently
-	 * registered, are preserved from the stored value — so toggling a CPT or
-	 * taxonomy plugin off and saving settings never wipes the configuration.
+	 * Merge-preserve: only post types/taxonomies rendered this request are read
+	 * from the submission, so a save never wipes a deactivated plugin's config.
 	 *
 	 * @param mixed $value Raw submitted value.
 	 *
 	 * @return array<string,mixed>
 	 */
 	public static function sanitize( $value ): array {
-		// Use the RAW stored option as the merge base — not get(), which falls
-		// back to DEFAULT_VALUE and would otherwise leak `post => all` into a
-		// fresh save where 'post' isn't even a compatible post type.
+		// Merge from the RAW stored option — get()'s DEFAULT_VALUE fallback
+		// would leak `post => all` into a fresh save.
 		$raw      = get_option( self::OPTION_NAME );
 		$existing = is_array( $raw ) ? $raw : [];
 
@@ -299,13 +264,11 @@ class Preselect {
 			return $existing;
 		}
 
-		// Start from the stored value to preserve post types not rendered now.
 		$clean = $existing;
 
 		foreach ( Utils::get_compatible_post_types() as $post_type ) {
 			$submitted = ( isset( $value[ $post_type ] ) && is_array( $value[ $post_type ] ) ) ? $value[ $post_type ] : [];
 
-			// Post-type checkbox unticked → not preselected.
 			if ( empty( $submitted['enabled'] ) ) {
 				unset( $clean[ $post_type ] );
 				continue;
@@ -330,8 +293,7 @@ class Preselect {
 	}
 
 	/**
-	 * Sanitise the term map for one post type, merge-preserving terms for
-	 * taxonomies not rendered in this request.
+	 * Sanitise one post type's term map, merge-preserving unrendered taxonomies.
 	 *
 	 * @param string              $post_type Post type slug.
 	 * @param array<string,mixed> $submitted Submitted value for this post type.
@@ -399,15 +361,8 @@ class Preselect {
 	/**
 	 * Render the control for one post type.
 	 *
-	 * Three nested levels, progressively revealed by `preselect.js`:
-	 *   1. the post-type checkbox — off means "don't preselect" (term area hidden);
-	 *   2. an "All" checkbox, ticked by default when the post type is enabled —
-	 *      ticked means preselect every post of this type (taxonomy terms hidden);
-	 *   3. the hierarchical taxonomy term trees, shown when "All" is unticked, to
-	 *      preselect only posts that have one of the ticked terms.
-	 *
-	 * Maps to the stored format: off → absent, "All" → `mode => 'all'`, terms →
-	 * `mode => 'terms'`. "All" takes priority over any ticked terms.
+	 * Three nested levels (enable → "All" → term trees), progressively revealed
+	 * by `preselect.js`; "All" wins over any ticked terms on save.
 	 *
 	 * @param \WP_Post_Type       $post_type_object Post type object.
 	 * @param array<string,mixed> $preselect        Stored option.

--- a/src/settings/class-settings.php
+++ b/src/settings/class-settings.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * BeyondWords settings page.
- *
- * Owns the admin menu entry, the tabbed settings form, the REST endpoint
- * the editor scripts read, and the admin notices that surround them.
+ * BeyondWords settings page: admin menu, tabbed form, REST endpoints, notices.
  *
  * @package BeyondWords\Settings
  *
@@ -127,8 +124,7 @@ class Settings {
 	}
 
 	/**
-	 * Show a banner directing publishers to the settings page until creds
-	 * are entered.
+	 * Show a banner pointing to the settings page until creds are entered.
 	 */
 	public static function maybe_print_missing_creds_warning(): void {
 		if ( Utils::has_api_creds() ) {
@@ -166,8 +162,7 @@ class Settings {
 	}
 
 	/**
-	 * Show the once-only "leave us a review" notice on the settings page,
-	 * 14+ days after activation.
+	 * Show the once-only review notice 14+ days after activation.
 	 */
 	public static function maybe_print_review_notice(): void {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
@@ -208,16 +203,8 @@ class Settings {
 	/**
 	 * Drain queued settings errors into a notice.
 	 *
-	 * Hooked to `admin_notices`, which fires on every admin screen, so this
-	 * early-returns unless we are on the BeyondWords settings page — the only
-	 * screen these errors are ever queued for (the sanitizers redirect back
-	 * here, and the connection check runs on this page's load hook). Gating it
-	 * this way avoids a transient read on every unrelated admin page and stops
-	 * a queued error from painting on another screen before it is drained.
-	 *
-	 * Errors are queued via `Utils::add_settings_error_message()` into a
-	 * transient that survives the post-save redirect, then drained here and
-	 * rendered as a single `notice notice-error`.
+	 * `admin_notices` fires on every admin screen, so this early-returns off the
+	 * settings page — the only screen the errors are ever queued for.
 	 */
 	public static function print_settings_errors(): void {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
@@ -343,13 +330,8 @@ class Settings {
 	/**
 	 * Meta keys surfaced in the editor Inspect panel.
 	 *
-	 * Sourced from \BeyondWords\Core\Utils::get_post_meta_keys() so the block
-	 * editor never duplicates the canonical key lists — keeping it in step with
-	 * the Classic editor, which calls the same method directly.
-	 *
-	 * The deprecated set is the full deprecated list minus internal-only keys
-	 * (player config, voice ids, hashes, timestamps) that have never been shown
-	 * in the Inspect panel. array_diff preserves the canonical order.
+	 * Sourced from the canonical lists in \BeyondWords\Core\Utils, minus
+	 * internal-only keys that have never been shown in the panel.
 	 *
 	 * @since 7.0.0
 	 *
@@ -393,8 +375,7 @@ class Settings {
 	/**
 	 * Proxy for the BeyondWords video settings endpoint.
 	 *
-	 * Editor scripts use the `sizes` array in the response to populate the
-	 * "Video size" dropdown.
+	 * Editor scripts read the `sizes` array to populate the "Video size" dropdown.
 	 *
 	 * @since 7.0.0
 	 *
@@ -410,8 +391,7 @@ class Settings {
 	/**
 	 * Proxy for the BeyondWords project endpoint.
 	 *
-	 * Editor scripts read the project's default `language` to pre-select the
-	 * Language dropdown when "Customize" is enabled.
+	 * Editor scripts read the project's default `language` for the Language dropdown.
 	 *
 	 * @since 7.0.0
 	 *

--- a/src/settings/class-tabs.php
+++ b/src/settings/class-tabs.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * BeyondWords settings tabs.
+ * BeyondWords settings tabs: slugs, settings groups and section IDs per tab.
  *
- * Defines the three tabs (Authentication, Integration, Preferences),
- * their slugs, settings groups and section IDs. Field registration lives
- * in `Fields` and `Preselect`; this class is the single source of truth
- * for which tab a field belongs to.
+ * Field registration lives in `Fields` and `Preselect`.
  *
  * @package BeyondWords\Settings
  *
@@ -20,9 +17,6 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Settings tabs.
- *
- * `register()` runs on `admin_init` and creates the settings sections that
- * the field renderers attach to.
  *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */

--- a/src/settings/class-utils.php
+++ b/src/settings/class-utils.php
@@ -16,16 +16,12 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Settings utilities.
  *
- * Helpers shared across the settings classes — post-type compatibility
- * checks, API credential checks, and the BeyondWords REST connection check.
- *
  * @since 7.0.0 Refactored to BeyondWords namespace with snake_case methods.
  */
 class Utils {
 
 	/**
-	 * Built-in post types that BeyondWords never considers, regardless of
-	 * their `supports` array.
+	 * Built-in post types BeyondWords never considers, regardless of `supports`.
 	 *
 	 * @var string[]
 	 */
@@ -57,24 +53,20 @@ class Utils {
 	const REQUIRED_FEATURES = [ 'title', 'editor', 'custom-fields' ];
 
 	/**
-	 * How long a connection check is trusted before the settings page
-	 * re-validates. Throttles the API call to once per window per credential
-	 * set, keeping it off the admin render hot path.
+	 * How long a connection check is trusted before re-validating.
 	 */
 	const CONNECTION_CHECK_TTL = 5 * MINUTE_IN_SECONDS;
 
 	/**
-	 * Transient that throttles connection re-validation. Its value is a
-	 * fingerprint of the credentials last checked, so changing the API key or
-	 * project ID busts the throttle and forces an immediate re-check.
+	 * Transient that throttles connection re-validation.
+	 *
+	 * Holds a fingerprint of the last-checked credentials, so changing the API
+	 * key or project ID busts the throttle and forces an immediate re-check.
 	 */
 	const CONNECTION_CHECK_TRANSIENT = 'beyondwords_api_connection_checked';
 
 	/**
 	 * Get the post types eligible for BeyondWords audio generation.
-	 *
-	 * Filterable via `beyondwords_settings_post_types` so a site can opt
-	 * additional types in or out.
 	 *
 	 * @return string[]
 	 */
@@ -86,8 +78,7 @@ class Utils {
 		/**
 		 * Filters the post types BeyondWords considers compatible.
 		 *
-		 * Even if a type is added via this filter, it is dropped if it lacks
-		 * the required `supports` features (title, editor, custom-fields).
+		 * Types lacking the required `supports` features are still dropped.
 		 *
 		 * @since 3.3.3 Introduced as `beyondwords_post_types`.
 		 * @since 4.3.0 Renamed to `beyondwords_settings_post_types`.
@@ -104,9 +95,8 @@ class Utils {
 	/**
 	 * Whether a post type supports every feature BeyondWords requires.
 	 *
-	 * Unregistered post types pass through — they're slugs added by the
-	 * `beyondwords_settings_post_types` filter and we treat the filter as
-	 * authoritative. Registered types are checked against `REQUIRED_FEATURES`.
+	 * Unregistered types pass through — they were added by the
+	 * `beyondwords_settings_post_types` filter, which we treat as authoritative.
 	 *
 	 * @param string $post_type Post type slug.
 	 */
@@ -147,41 +137,21 @@ class Utils {
 	/**
 	 * Validate the BeyondWords REST API connection and persist the result.
 	 *
-	 * The last successful check is recorded as a timestamp in the
-	 * `beyondwords_valid_api_connection` option, which gates the visibility of
-	 * the Integration and Preferences tabs (see `Tabs::get_visible_tabs()`).
-	 *
-	 * This runs on every settings-page load, so the network call is
-	 * short-circuited to keep it off the admin render hot path:
-	 *
-	 * 1. A throttle transient ({@see self::CONNECTION_CHECK_TRANSIENT}), keyed to
-	 *    a fingerprint of the current credentials, limits re-validation to once
-	 *    per {@see self::CONNECTION_CHECK_TTL}. Changing the API key or project ID
-	 *    changes the fingerprint, so saving new credentials re-validates
-	 *    immediately rather than waiting out the throttle window.
-	 * 2. The request uses the client's short default timeout
-	 *    ({@see \BeyondWords\Api\Client::DEFAULT_REQUEST_TIMEOUT}) so a slow API
-	 *    can't block the page render.
-	 *
-	 * The stored flag is only cleared on a definitive auth failure (401/403) —
-	 * `Client::call_api()` clears it on 401 and we mirror that for 403 here. A
-	 * transient failure (timeout, DNS error, 5xx, `WP_Error`) leaves the last
-	 * known-good flag intact so an API blip can't hide the other settings tabs.
+	 * Throttled per credential fingerprint; only a definitive auth failure
+	 * (401/403) clears the stored flag, so an API blip can't hide the other tabs.
 	 */
 	public static function validate_api_connection(): bool {
 		$project_id = get_option( 'beyondwords_project_id' );
 		$api_key    = get_option( 'beyondwords_api_key' );
 
 		if ( ! $project_id || ! $api_key ) {
-			// No credentials means no connection — reflect that in the flag.
 			delete_option( 'beyondwords_valid_api_connection' );
 			return false;
 		}
 
 		$fingerprint = md5( (string) $project_id . '|' . (string) $api_key );
 
-		// Throttle: within the window, trust the last recorded result for these
-		// exact credentials and skip the network call entirely.
+		// Within the throttle window, trust the last result for these credentials.
 		if ( get_transient( self::CONNECTION_CHECK_TRANSIENT ) === $fingerprint ) {
 			return self::has_valid_api_connection();
 		}
@@ -189,8 +159,7 @@ class Utils {
 		$url      = sprintf( '%s/projects/%d', \BeyondWords\Core\Urls::get_api_url(), $project_id );
 		$response = \BeyondWords\Api\Client::call_api( 'GET', $url );
 
-		// Record the attempt whatever the outcome, so repeated page loads don't
-		// re-issue the request — a down API is throttled just like a healthy one.
+		// Record the attempt whatever the outcome — a down API is throttled too.
 		set_transient( self::CONNECTION_CHECK_TRANSIENT, $fingerprint, self::CONNECTION_CHECK_TTL );
 
 		$response_code = wp_remote_retrieve_response_code( $response );
@@ -200,9 +169,8 @@ class Utils {
 			return true;
 		}
 
-		// 403 is a definitive auth failure (revoked key or wrong project), so
-		// clear the flag; call_api() has already done so for 401. Every other
-		// response is treated as transient and leaves the flag untouched.
+		// 403 is a definitive auth failure (call_api() already handles 401); any
+		// other response is treated as transient and leaves the flag untouched.
 		if ( 403 === (int) $response_code ) {
 			delete_option( 'beyondwords_valid_api_connection' );
 		}
@@ -228,14 +196,8 @@ class Utils {
 	/**
 	 * Queue a settings error message for later rendering.
 	 *
-	 * Stored in a short-lived transient — not the object cache — so the message
-	 * survives the `wp_redirect()` the Settings API performs after a save. The
-	 * default WordPress object cache is request-scoped, so `wp_cache_*` is empty
-	 * by the time the redirected page load renders the notice on the majority of
-	 * hosts (those without a persistent Redis/Memcached drop-in). A transient
-	 * falls back to the options table on those hosts, so the message is never
-	 * lost. The 30-second TTL matches WordPress core's own `settings_errors`
-	 * transient and is ample for a single redirect.
+	 * Uses a short-lived transient rather than the object cache so the message
+	 * survives the Settings API's post-save redirect on any host.
 	 *
 	 * @param string $message  Error message (HTML allowed; rendered through `wp_kses`).
 	 * @param string $error_id Optional stable ID; auto-generated when blank.

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,6 +1,5 @@
 /**
- * Settings feature entry — registers the `beyondwords/settings` data store
- * for the block editor to read from.
+ * Settings feature entry — registers the `beyondwords/settings` data store.
  */
 import { register } from '@wordpress/data';
 import store from './store';

--- a/src/settings/preselect.js
+++ b/src/settings/preselect.js
@@ -1,18 +1,8 @@
 /*
- * Preferences → "Preselect 'Generate audio'" settings field.
+ * Preferences → "Preselect 'Generate audio'" field: progressive disclosure.
  *
- * Progressive disclosure:
- *   - the post-type checkbox reveals an "All" checkbox (and hides everything
- *     when unticked);
- *   - "All" ticked = preselect the whole post type, so the taxonomy term trees
- *     are hidden;
- *   - unticking "All" reveals the term trees so specific terms can be picked;
- *   - re-ticking "All" hides the term trees again WITHOUT clearing them.
- *
- * The server stores the resulting mode (all wins over terms). Checkboxes are
- * rendered with their correct initial visibility, so this is enhancement only.
- *
- * Vanilla JS — no jQuery.
+ * Checkboxes render server-side with their correct initial visibility, so this
+ * is enhancement only; hiding the term trees never clears their selections.
  */
 ( function () {
 	'use strict';

--- a/src/settings/store/index.js
+++ b/src/settings/store/index.js
@@ -4,13 +4,8 @@
 import apiFetch from '@wordpress/api-fetch';
 import { createReduxStore } from '@wordpress/data';
 
-// Shared editor state, fetched lazily by the resolvers below; each key has a
-// matching selector. Most keys hold a single session-wide value. `voices`,
-// `videoSizes` and `project` are maps keyed by their resolver's argument:
-// @wordpress/data marks resolution finished per selector-args, so each
-// argument's result needs its own slot — with one shared slot, a later fetch
-// (say, another language's voices) would overwrite it while the resolution
-// cache keeps reporting the overwritten entry as fresh.
+// `voices`/`videoSizes`/`project` are keyed by resolver argument: resolution is
+// cached per selector-args, so a shared slot would go stale yet report fresh.
 export const DEFAULT_STATE = {
 	settings: {},
 	languages: [],
@@ -27,8 +22,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		const empty = Array.isArray( DEFAULT_STATE[ action.key ] ) ? [] : {};
 		return { ...state, [ action.key ]: action.value || empty };
 	}
-	// Merge one argument's result into a per-argument key, leaving the other
-	// arguments' entries untouched.
+	// Merge one argument's result, leaving other arguments' entries untouched.
 	if ( action.type === 'SET_BY' && action.key in state ) {
 		return {
 			...state,
@@ -41,8 +35,6 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 	return state;
 };
 
-// The per-argument selectors (voices, video sizes, project) read the entry for
-// the requested argument only, with an empty value while it is unfetched.
 const selectors = {
 	getSettings: ( state ) => state.settings,
 	getLanguages: ( state ) => state.languages,
@@ -53,8 +45,7 @@ const selectors = {
 	getProject: ( state, projectId ) => state.project[ projectId ] ?? {},
 };
 
-// Both action shapes are private to this store — it registers no `actions`,
-// so the resolvers below are the only dispatchers.
+// Private to this store — no registered `actions`; only resolvers dispatch.
 const set = ( key, value ) => ( { type: 'SET', key, value } );
 const setBy = ( key, arg, value ) => ( { type: 'SET_BY', key, arg, value } );
 
@@ -94,8 +85,7 @@ const resolvers = {
 		} );
 		return setBy( 'videoSizes', projectId, r?.sizes ?? [] );
 	},
-	// The project carries the default `language` used to pre-select the Language
-	// dropdown when Customize is enabled. Fetched on demand (behind the toggle).
+	// The project's default `language` pre-selects the Language dropdown.
 	async getProject( projectId ) {
 		if ( ! projectId ) {
 			return setBy( 'project', projectId, {} );

--- a/src/settings/store/index.test.js
+++ b/src/settings/store/index.test.js
@@ -72,8 +72,7 @@ describe( 'beyondwords/settings store', () => {
 				VOICES.fr_FR
 			);
 
-			// Re-reading A must still return A's voices, not B's — no refetch is
-			// dispatched because resolution for [ 'en_US' ] is already finished.
+			// No refetch on re-read — resolution for [ 'en_US' ] is finished.
 			const select = registry.select( STORE );
 			expect( select.getVoices( 'en_US' ) ).toEqual( VOICES.en_US );
 			expect( select.getVoices( 'fr_FR' ) ).toEqual( VOICES.fr_FR );

--- a/src/site-health/class-site-health.php
+++ b/src/site-health/class-site-health.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * BeyondWords Site Health.
- *
- * Adds a "BeyondWords" section to the WordPress Site Health debugging info.
+ * BeyondWords section for the WordPress Site Health debugging info.
  *
  * @package BeyondWords\SiteHealth
  * @since   3.7.0
@@ -25,8 +23,7 @@ class SiteHealth {
 	/**
 	 * BeyondWords filter hooks that are still active.
 	 *
-	 * Used to surface "Registered filters" in Site Health so support can see
-	 * which extension points the site is using.
+	 * Surfaced in Site Health so support can see which extension points are in use.
 	 *
 	 * @var string[]
 	 */
@@ -195,23 +192,15 @@ class SiteHealth {
 	/**
 	 * Resolve the "Communication with REST API" value/debug pair.
 	 *
-	 * Deliberately **not** cached. This mirrors WordPress core's own
-	 * `dotorg_communication` field ({@see \WP_Debug_Data::get_wp_core()}), which
-	 * probes wordpress.org on every Info-screen render: Site Health is a
-	 * diagnostic, so a cached result would keep reporting "unreachable" to an
-	 * admin who has just fixed their credentials, DNS or firewall and hit
-	 * refresh to confirm. The request is instead bounded by the shared
-	 * {@see \BeyondWords\Api\Client::DEFAULT_REQUEST_TIMEOUT} and skipped
-	 * entirely when there are no credentials, which keeps the render cost
-	 * predictable without ever serving stale diagnostics.
+	 * Deliberately not cached: Site Health is a diagnostic, and core's own
+	 * `dotorg_communication` field likewise probes uncached on every render.
 	 *
 	 * @param string $api_url BeyondWords REST API base URL.
 	 *
 	 * @return array<string,string>
 	 */
 	private static function get_api_communication( string $api_url ): array {
-		// Nothing to probe until the site has API credentials — skip the
-		// blocking request on fresh installs entirely.
+		// Nothing to probe until the site has API credentials.
 		if ( ! \BeyondWords\Settings\Utils::has_api_creds() ) {
 			return [
 				'value' => __( 'Not checked — BeyondWords API credentials are not configured', 'speechkit' ),
@@ -219,11 +208,8 @@ class SiteHealth {
 			];
 		}
 
-		// A plain request, not `Client::call_api()`: this is a passive probe, and
-		// `call_api()` would clear `beyondwords_valid_api_connection` on a 401 as
-		// a side effect of merely viewing Site Health. `vip_safe_wp_remote_get()`
-		// is avoided for the same reason — its circuit breaker reports a failure
-		// without actually retrying, which would make the diagnostic lie.
+		// A plain request on purpose: `call_api()` would clear the valid-connection
+		// flag on a 401, and the VIP helper's circuit breaker can fake failures.
 		$response = wp_remote_request(
 			$api_url,
 			[
@@ -334,9 +320,6 @@ class SiteHealth {
 
 	/**
 	 * Mask a sensitive string for display in Site Health.
-	 *
-	 * Replaces all but the last `$count` characters with `$char` so the API key
-	 * is recognisable but unreadable.
 	 *
 	 * @param string|false $value Value to mask. `false` (e.g. missing option) renders empty.
 	 * @param int          $count Number of trailing characters to preserve.

--- a/tests/cypress/e2e/block-editor/add-post.cy.js
+++ b/tests/cypress/e2e/block-editor/add-post.cy.js
@@ -12,10 +12,7 @@ context( 'Block Editor: Add Post', () => {
 
 	const postTypes = require( '../../../../tests/fixtures/post-types.json' );
 
-	// @todo add tests for 'draft', 'pending', 'trash' statuses
-	// as these have different flows for publishing
-	// e.g. 'draft' and 'pending' use the Publish panel
-	// For now, we just statuses that use a standard "Publish" flow
+	// @todo add tests for 'draft', 'pending', 'trash' statuses (different publish flows)
 	const postStatuses = [ 'publish', 'future', 'private' ];
 
 	postTypes
@@ -36,7 +33,6 @@ context( 'Block Editor: Add Post', () => {
 
 					cy.publishWithConfirmation();
 
-					// "View post"
 					cy.viewPostViaSnackbar();
 
 					cy.getPlayerScriptTag().should( 'not.exist' );
@@ -46,7 +42,6 @@ context( 'Block Editor: Add Post', () => {
 						`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 					);
 
-					// See a [-] in the BeyondWords column
 					cy.get( 'tbody tr' )
 						.eq( 0 )
 						.within( () => {
@@ -71,7 +66,6 @@ context( 'Block Editor: Add Post', () => {
 
 					cy.publishWithConfirmation();
 
-					// "View post"
 					cy.viewPostViaSnackbar();
 
 					cy.getPlayerScriptTag().should( 'exist' );
@@ -81,7 +75,6 @@ context( 'Block Editor: Add Post', () => {
 						`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 					);
 
-					// See a [tick] in the BeyondWords column
 					cy.get( 'tbody tr' )
 						.eq( 0 )
 						.within( () => {
@@ -115,7 +108,6 @@ context( 'Block Editor: Add Post', () => {
 								`${ postType.slug }&orderby=date&order=desc`
 						);
 
-						// See a [-] in the BeyondWords column
 						cy.get( 'tbody tr' )
 							.eq( 0 )
 							.within( () => {
@@ -134,7 +126,6 @@ context( 'Block Editor: Add Post', () => {
 							status: postStatus,
 							postType: postType.slug,
 						} ).then( ( postId ) => {
-							// Explicitly save generate_audio as '0'
 							cy.task( 'setPostMeta', {
 								postId,
 								metaKey: 'beyondwords_generate_audio',
@@ -145,12 +136,10 @@ context( 'Block Editor: Add Post', () => {
 
 							cy.openBeyondwordsEditorPanel();
 
-							// Checkbox must stay unchecked despite preselect being enabled
 							cy.getGenerateAudioCheckbox().should(
 								'not.be.checked'
 							);
 
-							// Save and verify no audio was generated
 							cy.savePost();
 
 							cy.viewPostById( postId );
@@ -197,7 +186,6 @@ context( 'Block Editor: Add Post', () => {
 								`${ postType.slug }&orderby=date&order=desc`
 						);
 
-						// See a [tick] in the BeyondWords column
 						cy.get( 'tbody tr' )
 							.eq( 0 )
 							.within( () => {
@@ -227,7 +215,6 @@ context( 'Block Editor: Add Post', () => {
 
 				cy.hasAdminPlayerInstances( 0 );
 
-				// "Generate Audio" is replaced by "Pending" message'
 				cy.get( 'input#beyondwords_generate_audio' ).should(
 					'not.exist'
 				);
@@ -236,7 +223,6 @@ context( 'Block Editor: Add Post', () => {
 					'Listen to content saved as “Pending” in the BeyondWords dashboard.'
 				);
 
-				// "Pending review" message contains link to project
 				cy.get( '.beyondwords-sidebar a' )
 					.eq( 0 )
 					.invoke( 'attr', 'href' )
@@ -251,7 +237,6 @@ context( 'Block Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] and "Pending" in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -267,7 +252,6 @@ context( 'Block Editor: Add Post', () => {
 		.filter( ( x ) => ! x.supported )
 		.forEach( ( postType ) => {
 			it( `${ postType.name } has no BeyondWords support`, () => {
-				// BeyondWords column should not exist
 				cy.visit(
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
@@ -276,7 +260,6 @@ context( 'Block Editor: Add Post', () => {
 					'not.exist'
 				);
 
-				// BeyondWords metabox should not exist
 				cy.createPost( {
 					postType,
 				} );

--- a/tests/cypress/e2e/block-editor/content-id.cy.js
+++ b/tests/cypress/e2e/block-editor/content-id.cy.js
@@ -59,8 +59,7 @@ context( 'Block Editor: Content ID', () => {
 			status: 'draft',
 			postType: 'post',
 		} ).then( ( postId ) => {
-			// Explicitly set generate_audio so the preselect useEffect
-			// does not race with the Fetch editPost call.
+			// Explicit generate_audio stops the preselect useEffect racing the Fetch editPost call.
 			cy.task( 'setPostMeta', {
 				postId,
 				metaKey: 'beyondwords_generate_audio',
@@ -70,22 +69,18 @@ context( 'Block Editor: Content ID', () => {
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsDataPanel();
 
-			// Type a content ID into the field
 			cy.getLabel( 'Content ID' )
 				.parent()
 				.find( 'input' )
 				.clear( { force: true } )
 				.type( testContentId, { force: true } );
 
-			// Click Fetch
 			cy.get( '.beyondwords-sidebar__data' )
 				.contains( 'button', 'Fetch' )
 				.click( { force: true } );
 
-			// Wait for the fetch to complete and verify meta fields.
-			// Note: beyondwords_generate_audio is verified after reload
-			// because the GenerateAudio preselect useEffect can race
-			// with the Fetch editPost() call in-session.
+			// generate_audio is asserted after reload: the preselect
+			// useEffect can race the Fetch editPost() call in-session.
 			cy.window()
 				.its( 'wp.data' )
 				.should( ( data ) => {
@@ -107,8 +102,6 @@ context( 'Block Editor: Content ID', () => {
 					expect( meta.beyondwords_error_message ).to.equal( '' );
 				} );
 
-			// Verify persists after reload — including generate_audio,
-			// which is only reliably testable after a fresh page load.
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsDataPanel();
 
@@ -138,7 +131,6 @@ context( 'Block Editor: Content ID', () => {
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsDataPanel();
 
-			// Intercept the fetch request at browser level and return 404
 			cy.intercept(
 				'GET',
 				'**/beyondwords/v1/projects/*/content/not-found-content-id',
@@ -148,21 +140,18 @@ context( 'Block Editor: Content ID', () => {
 				}
 			).as( 'fetchContent' );
 
-			// Type the "not found" content ID
 			cy.getLabel( 'Content ID' )
 				.parent()
 				.find( 'input' )
 				.clear( { force: true } )
 				.type( 'not-found-content-id', { force: true } );
 
-			// Click Fetch
 			cy.get( '.beyondwords-sidebar__data' )
 				.contains( 'button', 'Fetch' )
 				.click( { force: true } );
 
 			cy.wait( '@fetchContent' );
 
-			// Verify error message is set in editor state
 			cy.window()
 				.its( 'wp.data' )
 				.should( ( data ) => {
@@ -175,7 +164,6 @@ context( 'Block Editor: Content ID', () => {
 					);
 				} );
 
-			// Verify error persists after reload
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsDataPanel();
 
@@ -201,7 +189,6 @@ context( 'Block Editor: Content ID', () => {
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsDataPanel();
 
-			// Type a content ID and fetch
 			cy.getLabel( 'Content ID' )
 				.parent()
 				.find( 'input' )
@@ -224,10 +211,8 @@ context( 'Block Editor: Content ID', () => {
 					);
 				} );
 
-			// View the post on the frontend
 			cy.viewPostById( postId );
 
-			// The player script tag should include the fetched content ID
 			cy.getPlayerScriptTag()
 				.should( 'have.attr', 'onload' )
 				.and( 'include', testContentId );

--- a/tests/cypress/e2e/block-editor/display-player.cy.js
+++ b/tests/cypress/e2e/block-editor/display-player.cy.js
@@ -6,9 +6,8 @@
 /* global cy, beforeEach, context, it */
 
 /*
- * The "Display player" checkbox was removed in v7 — the Player "Embed" dropdown
- * now controls front-end visibility, where "None" hides the player (equivalent
- * to the old unchecked box). This spec exercises that visibility behaviour.
+ * The v7 Player "Embed" dropdown replaced the "Display player" checkbox;
+ * Embed "None" hides the player. This spec exercises that behaviour.
  */
 context( 'Block Editor: Player visibility (Embed)', () => {
 	beforeEach( () => {
@@ -20,7 +19,6 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 	// The Embed dropdown now lives only in the plugin sidebar.
 	const embedSelect = () => cy.get( '.beyondwords--embed select' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -36,8 +34,7 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 
 				cy.publishWithConfirmation();
 
-				// "View post" — player shows by default (Embed defaults to the
-				// first asset).
+				// Player shows by default — Embed defaults to the first asset.
 				cy.viewPostViaSnackbar();
 
 				cy.getPlayerScriptTag().should( 'exist' );
@@ -47,7 +44,6 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] and no "Disabled" in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -60,15 +56,12 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 						cy.get( 'a.row-title' ).click();
 					} );
 
-				// Open the plugin sidebar (the Embed dropdown lives here).
 				cy.openBeyondwordsPluginSidebar();
 
-				// Set Embed = None to hide the player.
 				embedSelect().select( 'None', { force: true } );
 
 				cy.savePost();
 
-				// "View post"
 				cy.viewPostViaSnackbar();
 
 				cy.hasPlayerInstances( 0 );
@@ -77,7 +70,6 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] and "Disabled" in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -93,12 +85,10 @@ context( 'Block Editor: Player visibility (Embed)', () => {
 
 				cy.openBeyondwordsPluginSidebar();
 
-				// Pick an asset again to reshow the player.
 				embedSelect().select( 'Audio (post)', { force: true } );
 
 				cy.savePost();
 
-				// "View post"
 				cy.viewPostViaSnackbar();
 
 				cy.getPlayerScriptTag().should( 'exist' );

--- a/tests/cypress/e2e/block-editor/generate-audio.cy.js
+++ b/tests/cypress/e2e/block-editor/generate-audio.cy.js
@@ -6,13 +6,8 @@
 /* global Cypress, cy, before, beforeEach, afterEach, context, it, describe, expect */
 
 /**
- * Focused edge-case tests for the GenerateAudio component.
- *
- * These complement the broader post-type × status matrix in add-post.cy.js
- * by covering panel sync, preselect guards, and meta key precedence.
- *
- * Each test uses a single post type to stay efficient — the core logic is
- * in the React component, not WordPress post type handling.
+ * Edge-case tests for GenerateAudio, complementing the post-type × status
+ * matrix in add-post.cy.js: panel sync, preselect guards, meta precedence.
  */
 context( 'Block Editor: Generate Audio', () => {
 	beforeEach( () => {
@@ -28,13 +23,10 @@ context( 'Block Editor: Generate Audio', () => {
 
 			cy.openBeyondwordsEditorPanel();
 
-			// Sidebar checkbox should be checked via preselect
 			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
-			// Open pre-publish panel
 			cy.get( '.editor-post-publish-button__button' ).click();
 
-			// Pre-publish panel checkbox should also be checked
 			cy.get(
 				'.editor-post-publish-panel .beyondwords--generate-audio input[type="checkbox"]'
 			).should( 'be.checked' );
@@ -48,9 +40,8 @@ context( 'Block Editor: Generate Audio', () => {
 
 			cy.openBeyondwordsEditorPanel();
 
-			// Preselect is applied via a useEffect, so the box starts unchecked
-			// for a tick before flipping on. Wait for it to settle, otherwise an
-			// uncheck races the effect and is undone.
+			// Preselect applies via a useEffect — wait for the box to settle,
+			// otherwise the uncheck races the effect and is undone.
 			cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
 			// Toggle the input directly — clicking the CheckboxControl label
@@ -60,12 +51,10 @@ context( 'Block Editor: Generate Audio', () => {
 			} );
 			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
-			// Open pre-publish panel
 			cy.get( '.editor-post-publish-button__button' ).click();
 
-			// Pre-publish panel checkbox should also be unchecked.
-			// This validates the hasExplicitValue guard — the new
-			// GenerateAudio instance must not re-preselect.
+			// Validates the hasExplicitValue guard — the new GenerateAudio
+			// instance must not re-preselect.
 			cy.get(
 				'.editor-post-publish-panel .beyondwords--generate-audio input[type="checkbox"]'
 			).should( 'not.be.checked' );
@@ -81,13 +70,10 @@ context( 'Block Editor: Generate Audio', () => {
 
 				cy.openBeyondwordsEditorPanel();
 
-				// Sidebar checkbox should be checked via preselect
 				cy.getGenerateAudioCheckbox().should( 'be.checked' );
 
-				// Open pre-publish panel
 				cy.get( '.editor-post-publish-button__button' ).click();
 
-				// Verify checked in pre-publish, then uncheck
 				cy.get(
 					'.editor-post-publish-panel .beyondwords--generate-audio input[type="checkbox"]'
 				).should( 'be.checked' );
@@ -100,7 +86,6 @@ context( 'Block Editor: Generate Audio', () => {
 					'.editor-post-publish-panel .beyondwords--generate-audio input[type="checkbox"]'
 				).should( 'not.be.checked' );
 
-				// Confirm publish
 				cy.get(
 					'.editor-post-publish-panel__header-publish-button > .components-button'
 				).click();
@@ -119,7 +104,6 @@ context( 'Block Editor: Generate Audio', () => {
 					}
 				} );
 
-				// Close post-publish panel
 				cy.get( 'body' ).then( ( $body ) => {
 					if (
 						$body.find( 'button[aria-label="Close panel"]' ).length
@@ -128,7 +112,6 @@ context( 'Block Editor: Generate Audio', () => {
 					}
 				} );
 
-				// Verify no audio on frontend
 				cy.viewPostById( postId );
 				cy.getPlayerScriptTag().should( 'not.exist' );
 				cy.hasPlayerInstances( 0 );
@@ -154,7 +137,6 @@ context( 'Block Editor: Generate Audio', () => {
 				status: 'draft',
 				postType: 'post',
 			} ).then( ( postId ) => {
-				// Explicitly set generate_audio to '0'
 				cy.task( 'setPostMeta', {
 					postId,
 					metaKey: 'beyondwords_generate_audio',
@@ -165,10 +147,8 @@ context( 'Block Editor: Generate Audio', () => {
 
 				cy.openBeyondwordsEditorPanel();
 
-				// Sidebar should respect saved '0' despite preselect
 				cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
-				// Open pre-publish panel — should also respect saved '0'
 				cy.get( '.editor-post-publish-button__button' ).click();
 
 				cy.get(
@@ -197,7 +177,6 @@ context( 'Block Editor: Generate Audio', () => {
 				const meta = editor.getEditedPostAttribute( 'meta' ) || {};
 				expect( meta.beyondwords_generate_audio ).to.not.equal( '1' );
 
-				// Improvement #2: the auto-preselect must not dirty the post.
 				expect( editor.isEditedPostDirty() ).to.eq( false );
 			} );
 		} );
@@ -251,10 +230,8 @@ context( 'Block Editor: Generate Audio', () => {
 			cy.createPost( { postType: { slug: 'post' } } );
 			cy.openBeyondwordsEditorPanel();
 
-			// No matching term → not preselected.
 			cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 
-			// Add the matching term → preselected.
 			cy.window().then( ( win ) => {
 				win.wp.data
 					.dispatch( 'core/editor' )
@@ -294,7 +271,6 @@ context( 'Block Editor: Generate Audio', () => {
 
 				cy.openBeyondwordsEditorPanel();
 
-				// beyondwords_generate_audio=0 should take precedence
 				cy.getGenerateAudioCheckbox().should( 'not.be.checked' );
 			} );
 		} );
@@ -315,7 +291,6 @@ context( 'Block Editor: Generate Audio', () => {
 
 				cy.openBeyondwordsEditorPanel();
 
-				// Should fall back to speechkit_generate_audio=1
 				cy.getGenerateAudioCheckbox().should( 'be.checked' );
 			} );
 		} );

--- a/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
+++ b/tests/cypress/e2e/block-editor/insert-beyondwords-player.cy.js
@@ -34,8 +34,7 @@ context( 'Block Editor: Insert BeyondWords Player', () => {
 						.insertBlocks( block );
 				} );
 
-				// The block renders a static core Placeholder describing where
-				// the player will appear — assert on its label and instructions.
+				// The block renders a static core Placeholder in the editor canvas.
 				cy.getEditorCanvasBody()
 					.find( '.wp-block-beyondwords-player' )
 					.should( 'have.length', 1 );
@@ -55,8 +54,7 @@ context( 'Block Editor: Insert BeyondWords Player', () => {
 						'The BeyondWords audio player will appear here.'
 					);
 
-				// Guard against regressing to an in-editor live player preview:
-				// the block must not embed the player box in the editor canvas.
+				// Guard against regressing to an in-editor live player preview.
 				cy.getEditorCanvasBody()
 					.find(
 						'.wp-block-beyondwords-player .beyondwords-player-box-wrapper'

--- a/tests/cypress/e2e/block-editor/select-voice.cy.js
+++ b/tests/cypress/e2e/block-editor/select-voice.cy.js
@@ -25,7 +25,6 @@ context( 'Block Editor: Select Voice', () => {
 		'Legacy',
 	];
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -39,7 +38,6 @@ context( 'Block Editor: Select Voice', () => {
 				// switching to the plugin sidebar, where the Voice settings live.
 				cy.checkGenerateAudio( postType );
 
-				// Voice/Language are exposed only in the plugin sidebar now.
 				cy.openBeyondwordsPluginSidebar();
 
 				// "Customize" is opt-in and off by default, so the Language/Model/
@@ -81,7 +79,6 @@ context( 'Block Editor: Select Voice', () => {
 					'Voice'
 				).should( 'not.exist' );
 
-				// The Language dropdown still lists every language, placeholder first.
 				cy.getBlockEditorSelect( 'Language' )
 					.find( 'option' )
 					.should( ( $els ) => {
@@ -92,9 +89,8 @@ context( 'Block Editor: Select Voice', () => {
 						expect( values ).to.include( 'English (British)' );
 					} );
 
-				// Changing the Language re-fetches its voices and seeds that
-				// language's default body voice (en_GB → Ollie, a Standard voice),
-				// so the Model resolves to Standard and the Voice to Ollie.
+				// Changing the Language re-fetches voices and seeds that
+				// language's default body voice, resolving Model + Voice.
 				cy.getBlockEditorSelect( 'Language' ).select(
 					'English (British)',
 					{ force: true }
@@ -127,7 +123,6 @@ context( 'Block Editor: Select Voice', () => {
 					.find( 'option:selected' )
 					.should( 'have.text', 'Bridget' );
 
-				// Pick a specific Voice within the model.
 				cy.getBlockEditorSelect( 'Voice' ).select( 'Caleb', {
 					force: true,
 				} );
@@ -151,14 +146,11 @@ context( 'Block Editor: Select Voice', () => {
 
 				cy.publishWithConfirmation();
 
-				// "View post"
 				cy.viewPostViaSnackbar();
 
-				// Check Player appears frontend
 				cy.getPlayerScriptTag().should( 'exist' );
 				cy.hasPlayerInstances( 1 );
 
-				// Check Player content has also been saved in admin
 				cy.get( '#wp-admin-bar-edit' ).find( 'a' ).click();
 				cy.openBeyondwordsPluginSidebar();
 
@@ -182,8 +174,7 @@ context( 'Block Editor: Select Voice', () => {
 					'.beyondwords--customize input[type="checkbox"]'
 				).should( 'be.checked' );
 
-				// Language, Model and Voice persist after reload (derived from the
-				// saved voice id).
+				// Language/Model/Voice persist after reload, derived from the saved voice id.
 				cy.getBlockEditorSelect( 'Language' )
 					.find( 'option:selected' )
 					.should( 'have.text', 'English (British)' );
@@ -258,7 +249,6 @@ context( 'Block Editor: Select Voice', () => {
 			.find( 'option:selected' )
 			.should( 'have.text', 'Bridget' );
 
-		// Returning to the placeholder clears the voice and hides the Voice list.
 		cy.getBlockEditorSelect( 'Model' ).select( 'Select a model', {
 			force: true,
 		} );
@@ -283,8 +273,7 @@ context( 'Block Editor: Select Voice', () => {
 			expect( meta?.beyondwords_body_voice_id || '' ).to.not.eq( '' );
 		} );
 
-		// Turning Customize off reverts to the project defaults: meta is cleared
-		// and the fields are hidden.
+		// Turning Customize off reverts to the project defaults.
 		cy.get( '.beyondwords--customize label' ).click( { force: true } );
 		cy.contains( '.components-select-control label', 'Language' ).should(
 			'not.exist'
@@ -295,10 +284,6 @@ context( 'Block Editor: Select Voice', () => {
 		} );
 	} );
 
-	// The single-bucket branch (a language offering one model, so the Model
-	// dropdown is hidden and the Voice list shows directly) is covered
-	// end-to-end by the classic-editor spec and by the getLanguageModels()
-	// jest unit tests. The block editor reads voices through the wp.data
-	// store, which cy.intercept does not stub reliably, so it is not
-	// duplicated here.
+	// The single-bucket branch (Model dropdown hidden) is covered by the
+	// classic-editor spec and jest — cy.intercept can't stub the wp.data voices store.
 } );

--- a/tests/cypress/e2e/block-editor/settings-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/settings-panel.cy.js
@@ -8,12 +8,8 @@
 /**
  * Block-editor Settings panel: Content, Format, Voice (+ Model), Player.
  *
- * Targets the SelectControl className hooks (`beyondwords--source` etc.), which
- * are unique and only rendered when their control is shown — so a missing
- * control is asserted with `should('not.exist')`. The document-setting panel's
- * Voice/Player sections aren't mounted while the plugin sidebar is open, so the
- * hooks resolve to a single element. `.select()` is forced because the section
- * PanelBody may be collapsed/scrolled.
+ * Asserts via the unique `beyondwords--*` className hooks; `.select()` is
+ * forced because the section PanelBody may be collapsed/scrolled.
  */
 context( 'Block Editor: Settings panel', () => {
 	const postTypes = require( '../../../fixtures/post-types.json' );
@@ -34,8 +30,7 @@ context( 'Block Editor: Settings panel', () => {
 				cy.createPost( { postType } );
 				cy.openBeyondwordsPluginSidebar();
 
-				// Generate audio toggle sits at the top of the Content panel,
-				// above Source.
+				// Generate audio sits above Source at the top of the Content panel.
 				cy.get( '.beyondwords--generate-audio' ).should( 'exist' );
 				cy.get( '.beyondwords--generate-audio, .beyondwords--source' )
 					.first()
@@ -54,7 +49,6 @@ context( 'Block Editor: Settings panel', () => {
 				// Script template hidden while Source = Post.
 				cy.get( '.beyondwords--script-template' ).should( 'not.exist' );
 
-				// Switching to Script reveals it, Project default first.
 				select( 'beyondwords--source' ).select( 'Script', {
 					force: true,
 				} );
@@ -123,8 +117,7 @@ context( 'Block Editor: Settings panel', () => {
 					.find( 'option:selected' )
 					.should( 'have.text', 'English (American)' );
 
-				// Model is a language-level filter: each ElevenLabs model plus a
-				// "Standard" bucket, "Select a model" first. The Voice list is
+				// Model is a language-level filter; the Voice list stays
 				// hidden until a model is chosen.
 				select( 'beyondwords--model' )
 					.find( 'option' )

--- a/tests/cypress/e2e/bulk-actions.cy.js
+++ b/tests/cypress/e2e/bulk-actions.cy.js
@@ -36,11 +36,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -49,11 +47,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -62,17 +58,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Generate audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select( 'Delete audio' );
 				cy.get( '#doaction' ).click();
 
@@ -83,11 +76,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -96,11 +87,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -109,17 +98,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Generate audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select(
 					'Generate audio'
 				);
@@ -133,7 +119,6 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
@@ -146,7 +131,6 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
@@ -159,7 +143,6 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
@@ -169,7 +152,6 @@ context( 'Bulk Actions', () => {
 						).check();
 					} );
 
-				// "Bulk actions" > "Delete audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select( 'Delete audio' );
 				cy.get( '#doaction' ).click();
 
@@ -181,17 +163,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Generate audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select(
 					'Generate audio'
 				);
@@ -205,11 +184,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -218,11 +195,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -231,17 +206,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Generate audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select(
 					'Generate audio'
 				);
@@ -255,17 +227,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Delete audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select( 'Delete audio' );
 				cy.get( '#doaction' ).click();
 
@@ -277,11 +246,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -290,11 +257,9 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 1 )
 					.within( () => {
-						// See a [—] in the BeyondWords column
 						cy.get( 'td.beyondwords.column-beyondwords' ).contains(
 							'—'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
@@ -303,17 +268,14 @@ context( 'Bulk Actions', () => {
 				cy.get( 'tbody tr' )
 					.eq( 2 )
 					.within( () => {
-						// See a [tick] in the BeyondWords column
 						cy.get(
 							'td.beyondwords.column-beyondwords > span.dashicons.dashicons-yes'
 						);
-						// Check the checkbox
 						cy.get(
 							'input[type="checkbox"][name="post[]"]'
 						).check();
 					} );
 
-				// "Bulk actions" > "Delete audio" > "Apply"
 				cy.get( '#bulk-action-selector-top' ).select( 'Delete audio' );
 				cy.get( '#doaction' ).click();
 

--- a/tests/cypress/e2e/classic-editor/add-post.cy.js
+++ b/tests/cypress/e2e/classic-editor/add-post.cy.js
@@ -28,7 +28,6 @@ context( 'Classic Editor: Add Post', () => {
 					postType,
 				} );
 
-				// BeyondWords metabox is shown for supported post types
 				cy.get( 'div#beyondwords.postbox' )
 					.find( 'div.postbox-header' )
 					.contains( 'BeyondWords' )
@@ -49,7 +48,6 @@ context( 'Classic Editor: Add Post', () => {
 
 				cy.contains( 'input[type="submit"]', 'Publish' ).click();
 
-				// "Generate Audio" is still on page
 				cy.get( 'input#beyondwords_generate_audio' );
 
 				cy.get( '#sample-permalink' ).click();
@@ -60,7 +58,6 @@ context( 'Classic Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [-] in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -73,7 +70,6 @@ context( 'Classic Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [—] in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -100,7 +96,6 @@ context( 'Classic Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [-] in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -113,7 +108,6 @@ context( 'Classic Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [—] in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -157,19 +151,16 @@ context( 'Classic Editor: Add Post', () => {
 
 				cy.contains( 'input[type="submit"]', 'Publish' ).click();
 
-				// "Generate Audio" checkbox is now always visible
 				cy.get( 'input#beyondwords_generate_audio' ).should( 'exist' );
 
 				cy.get( '#sample-permalink' ).click();
 
 				cy.hasPlayerInstances( 1 );
 
-				// See a [tick] in the BeyondWords column' )
 				cy.visit(
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -200,27 +191,22 @@ context( 'Classic Editor: Add Post', () => {
 					`I can add a ${ postType.name } with "Pending review" audio`
 				);
 
-				// Show Status select box
 				cy.get( '.misc-pub-post-status a.edit-post-status' ).click();
 
-				// Select "Pending Review"
 				cy.get( '#post_status', { timeout: 20000 } ).select(
 					'Pending Review'
 				);
 
-				// Click "OK"
 				cy.get( 'a.save-post-status', { timeout: 20000 } ).click();
 
 				// Wait for permalink to update
 				cy.get( '#sample-permalink' );
 
-				// Click "Save as Pending" button
 				cy.get( 'input[value="Save as Pending"]' ).click();
 
 				// Wait for success message
 				cy.get( 'div#message.notice-success' );
 
-				// "Generate Audio" checkbox remains but is unchecked
 				cy.get( 'input#beyondwords_generate_audio' ).should(
 					'not.be.checked'
 				);
@@ -229,7 +215,6 @@ context( 'Classic Editor: Add Post', () => {
 					'Listen to content saved as “Pending” in the BeyondWords dashboard.'
 				);
 
-				// "Pending review" message contains link to project
 				cy.get( 'div#beyondwords-pending-review-message a' )
 					.invoke( 'attr', 'href' )
 					.should(
@@ -243,7 +228,6 @@ context( 'Classic Editor: Add Post', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] and "Pending" in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -262,7 +246,6 @@ context( 'Classic Editor: Add Post', () => {
 		.filter( ( x ) => ! x.supported )
 		.forEach( ( postType ) => {
 			it( `${ postType.name } has no BeyondWords support`, () => {
-				// BeyondWords column should not exist
 				cy.visit(
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
@@ -270,7 +253,6 @@ context( 'Classic Editor: Add Post', () => {
 					'not.exist'
 				);
 
-				// BeyondWords metabox should not exist
 				cy.createPost( {
 					postType,
 				} );

--- a/tests/cypress/e2e/classic-editor/content-id.cy.js
+++ b/tests/cypress/e2e/classic-editor/content-id.cy.js
@@ -57,21 +57,16 @@ context( 'Classic Editor: Content ID', () => {
 		} ).then( ( postId ) => {
 			cy.visit( `/wp-admin/post.php?post=${ postId }&action=edit` );
 
-			// Spy on the REST API save call
 			cy.intercept( 'POST', '**/wp/v2/posts/**' ).as( 'savePostMeta' );
 
-			// Type a content ID into the field
 			cy.get( '#beyondwords_content_id' )
 				.clear()
 				.type( testContentId );
 
-			// Click Fetch
 			cy.get( '#beyondwords__content-id--fetch' ).click();
 
-			// Wait for the REST API save to complete
 			cy.wait( '@savePostMeta', { timeout: 30000 } );
 
-			// Verify post meta was updated
 			cy.task( 'getPostMeta', {
 				postId,
 				metaKey: 'beyondwords_content_id',
@@ -112,7 +107,6 @@ context( 'Classic Editor: Content ID', () => {
 		} ).then( ( postId ) => {
 			cy.visit( `/wp-admin/post.php?post=${ postId }&action=edit` );
 
-			// Intercept the fetch request and return 404
 			cy.intercept(
 				'GET',
 				'**/beyondwords/v1/projects/*/content/not-found-content-id',
@@ -122,23 +116,19 @@ context( 'Classic Editor: Content ID', () => {
 				}
 			).as( 'fetchContent' );
 
-			// Spy on the error meta save
 			cy.intercept( 'POST', '**/wp/v2/posts/**' ).as(
 				'saveErrorMeta'
 			);
 
-			// Type the "not found" content ID
 			cy.get( '#beyondwords_content_id' )
 				.clear()
 				.type( 'not-found-content-id' );
 
-			// Click Fetch
 			cy.get( '#beyondwords__content-id--fetch' ).click();
 
 			cy.wait( '@fetchContent' );
 			cy.wait( '@saveErrorMeta', { timeout: 30000 } );
 
-			// Verify error message was saved
 			cy.task( 'getPostMeta', {
 				postId,
 				metaKey: 'beyondwords_error_message',

--- a/tests/cypress/e2e/classic-editor/display-player.cy.js
+++ b/tests/cypress/e2e/classic-editor/display-player.cy.js
@@ -6,9 +6,8 @@
 /* global cy, before, beforeEach, after, context, it */
 
 /*
- * The "Display player" checkbox was removed in v7 — the Player "Embed" dropdown
- * now controls front-end visibility, where "None" hides the player (equivalent
- * to the old unchecked box). This spec exercises that visibility behaviour.
+ * The v7 Player "Embed" dropdown replaced the "Display player" checkbox;
+ * Embed "None" hides the player. This spec exercises that behaviour.
  */
 context( 'Classic Editor: Player visibility (Embed)', () => {
 	before( () => {
@@ -25,7 +24,6 @@ context( 'Classic Editor: Player visibility (Embed)', () => {
 
 	const postTypes = require( '../../../../tests/fixtures/post-types.json' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -57,7 +55,6 @@ context( 'Classic Editor: Player visibility (Embed)', () => {
 						cy.get( 'a.row-title' ).click();
 					} );
 
-				// Set Embed = None to hide the player.
 				cy.get( 'select#beyondwords_embed' ).select( 'None' );
 
 				cy.get( '#publish' ).click(); // Click "Update" Button
@@ -73,7 +70,6 @@ context( 'Classic Editor: Player visibility (Embed)', () => {
 					`/wp-admin/edit.php?post_type=${ postType.slug }&orderby=date&order=desc`
 				);
 
-				// See a [tick] and "Disabled" in the BeyondWords column
 				cy.get( 'tbody tr' )
 					.eq( 0 )
 					.within( () => {
@@ -87,7 +83,6 @@ context( 'Classic Editor: Player visibility (Embed)', () => {
 						cy.get( 'a.row-title' ).click();
 					} );
 
-				// Pick an asset again to reshow the player.
 				cy.get( 'select#beyondwords_embed' ).select( 'Audio (post)' );
 
 				cy.get( '#publish' ).click(); // Click "Update" Button

--- a/tests/cypress/e2e/classic-editor/generate-audio.cy.js
+++ b/tests/cypress/e2e/classic-editor/generate-audio.cy.js
@@ -65,10 +65,8 @@ context( 'Classic Editor: term-gated Generate audio', () => {
 		} );
 		cy.createPost( { postType: { slug: 'post' } } );
 
-		// New post has no matching term → not preselected.
 		cy.get( 'input#beyondwords_generate_audio' ).should( 'not.be.checked' );
 
-		// Tick the matching category → JS checks Generate audio.
 		cy.get( `input[name="post_category[]"][value="${ newsId }"]` ).check();
 		cy.get( 'input#beyondwords_generate_audio' ).should( 'be.checked' );
 
@@ -85,14 +83,12 @@ context( 'Classic Editor: term-gated Generate audio', () => {
 		} );
 		cy.createPost( { postType: { slug: 'post' } } );
 
-		// Auto-check via the matching term.
 		cy.get( `input[name="post_category[]"][value="${ newsId }"]` ).check();
 		cy.get( 'input#beyondwords_generate_audio' ).should( 'be.checked' );
 
 		// Manually override → freezes auto-management.
 		cy.get( 'input#beyondwords_generate_audio' ).uncheck();
 
-		// Re-toggling the term no longer changes Generate audio.
 		cy.get(
 			`input[name="post_category[]"][value="${ newsId }"]`
 		).uncheck();

--- a/tests/cypress/e2e/classic-editor/insert-beyondwords-player.cy.js
+++ b/tests/cypress/e2e/classic-editor/insert-beyondwords-player.cy.js
@@ -20,7 +20,6 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 
 	const postTypes = require( '../../../../tests/fixtures/post-types.json' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -31,7 +30,6 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 
 				cy.get( 'input#beyondwords_generate_audio' ).check();
 
-				// Add 3x players
 				cy.get( 'div[aria-label="Insert BeyondWords player"]' )
 					.children( 'button' )
 					.click();
@@ -42,7 +40,6 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 					.children( 'button' )
 					.click();
 
-				// Count 3x players in editor iframe
 				cy.getTinyMceIframeBody()
 					.find(
 						'div[data-beyondwords-player="true"][contenteditable="false"]'
@@ -56,7 +53,6 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 
 				cy.get( '#sample-permalink' ).click();
 
-				// Count 3x players in frontend
 				cy.hasPlayerInstances( 3 );
 			} );
 
@@ -67,10 +63,8 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 
 				cy.get( 'input#beyondwords_generate_audio' ).check();
 
-				// Focus TinyMCE
 				cy.getTinyMceIframeBody().click();
 
-				// Add 3x shortcodes
 				cy.getTinyMceIframeBody().type(
 					// eslint-disable-next-line max-len
 					'Shortcode 1:{enter}[beyondwords_player]{enter}Shortcode 2:{enter}[beyondwords_player]{enter}Shortcode 3:{enter}[beyondwords_player]{enter}'
@@ -83,7 +77,6 @@ context( 'Classic Editor: Insert BeyondWords Player', () => {
 
 				cy.get( '#sample-permalink' ).click();
 
-				// Count 3x players in frontend
 				cy.hasPlayerInstances( 3 );
 			} );
 		} );

--- a/tests/cypress/e2e/classic-editor/select-voice.cy.js
+++ b/tests/cypress/e2e/classic-editor/select-voice.cy.js
@@ -23,7 +23,6 @@ context( 'Classic Editor: Select Voice', () => {
 		cy.task( 'deactivatePlugin', 'classic-editor' );
 	} );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -44,7 +43,6 @@ context( 'Classic Editor: Select Voice', () => {
 					'en_US'
 				);
 
-				// Assert we have the expected Languages
 				cy.get( 'select#beyondwords_language_code' )
 					.find( 'option' )
 					.should( ( $els ) => {
@@ -57,8 +55,6 @@ context( 'Classic Editor: Select Voice', () => {
 						expect( values ).to.include( 'Welsh (Welsh)' );
 					} );
 
-				// The Model dropdown lists every model the language offers,
-				// "Select a model" first, with the Standard bucket last.
 				cy.get( '#beyondwords-metabox-select-voice--model' ).should(
 					'be.visible'
 				);
@@ -97,7 +93,6 @@ context( 'Classic Editor: Select Voice', () => {
 						] );
 					} );
 
-				// v3 → only the voices that offer it (Bridget + Caleb).
 				cy.get( 'select#beyondwords_model' ).select( 'v3' );
 				cy.get( 'select#beyondwords_voice_id' )
 					.find( 'option' )
@@ -109,7 +104,6 @@ context( 'Classic Editor: Select Voice', () => {
 						] );
 					} );
 
-				// Multilingual v2 → only Bridget offers it.
 				cy.get( 'select#beyondwords_model' ).select(
 					'Multilingual v2'
 				);
@@ -128,13 +122,11 @@ context( 'Classic Editor: Select Voice', () => {
 
 				cy.get( '#beyondwords_customize' ).check();
 
-				// The project's default language (en_US) is pre-selected.
 				cy.get( 'select#beyondwords_language_code' ).should(
 					'have.value',
 					'en_US'
 				);
 
-				// Pick a Model, then a Voice within it.
 				cy.get( 'select#beyondwords_model' ).select( 'Flash v2.5' );
 				cy.get( 'select#beyondwords_voice_id' ).select( 'Bridget' );
 
@@ -158,7 +150,6 @@ context( 'Classic Editor: Select Voice', () => {
 				// so the fields are visible after the page refresh.
 				cy.get( '#beyondwords_customize' ).should( 'be.checked' );
 
-				// Language, Model and Voice persist after a page refresh.
 				cy.get( 'select#beyondwords_language_code' )
 					.find( 'option:selected' )
 					.should( 'have.text', 'English (American)' );
@@ -176,8 +167,7 @@ context( 'Classic Editor: Select Voice', () => {
 					.should( 'have.text', 'Bridget' );
 
 				// Regression: after reload the in-memory voices are hydrated, so
-				// changing the Model still narrows the Voice list rather than
-				// emptying it (which would drop the saved voice on the next save).
+				// changing the Model narrows the Voice list instead of emptying it.
 				cy.get( 'select#beyondwords_model' ).select( 'v3' );
 				cy.get( 'select#beyondwords_voice_id' )
 					.find( 'option' )
@@ -233,7 +223,6 @@ context( 'Classic Editor: Select Voice', () => {
 			'be.visible'
 		);
 
-		// Returning to the placeholder hides the (empty) Voice dropdown.
 		cy.get( 'select#beyondwords_model' ).select( 'Select a model' );
 		cy.get( '#beyondwords-metabox-select-voice--voice-id' ).should(
 			'not.be.visible'

--- a/tests/cypress/e2e/classic-editor/settings-fields.cy.js
+++ b/tests/cypress/e2e/classic-editor/settings-fields.cy.js
@@ -7,10 +7,10 @@
 /* global cy, before, beforeEach, after, context, expect, it */
 
 /**
- * Classic-editor Content/Format/Player settings fields — the metabox
- * counterparts of the block editor's settings panel. Mirrors
- * tests/cypress/e2e/block-editor/settings-panel.cy.js using native <select>
- * controls and their #id hooks.
+ * Classic-editor Content/Format/Player settings fields.
+ *
+ * Mirrors tests/cypress/e2e/block-editor/settings-panel.cy.js using native
+ * <select> controls and their #id hooks.
  */
 context( 'Classic Editor: Settings fields', () => {
 	const postTypes = require( '../../../fixtures/post-types.json' );
@@ -51,7 +51,6 @@ context( 'Classic Editor: Settings fields', () => {
 					'#beyondwords-metabox-settings--beyondwords-script-template-id'
 				).should( 'not.be.visible' );
 
-				// Switching to Script reveals it, Project default first.
 				cy.get( 'select#beyondwords_source' ).select( 'Script' );
 				cy.get(
 					'#beyondwords-metabox-settings--beyondwords-script-template-id'
@@ -161,7 +160,6 @@ context( 'Classic Editor: Settings fields', () => {
 
 				cy.contains( 'input[type="submit"]', 'Publish' ).click();
 
-				// Selections persist after a page refresh.
 				cy.get( 'select#beyondwords_source' )
 					.find( 'option:selected' )
 					.should( 'have.text', 'Post + script' );

--- a/tests/cypress/e2e/filters.cy.js
+++ b/tests/cypress/e2e/filters.cy.js
@@ -12,7 +12,6 @@ describe( 'WordPress Filters', () => {
 
 	const postTypes = require( '../../../tests/fixtures/post-types.json' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -24,8 +23,7 @@ describe( 'WordPress Filters', () => {
 					title: `I can filter Player SDK params for a ${ postType.name }`,
 				} );
 
-				// Frontend should have a player div with expected SDK params from
-				// tests/fixtures/wp-content/plugins/beyondwords-filter-player-sdk-params
+				// Expected SDK params come from the beyondwords-filter-player-sdk-params fixture plugin.
 				cy.viewPostViaSnackbar();
 				cy.getPlayerScriptTag().should( 'exist' );
 				cy.hasPlayerInstances( 1, {
@@ -47,7 +45,6 @@ describe( 'WordPress Filters', () => {
 					title: `I can filter Player script onload for a ${ postType.name }`,
 				} );
 
-				// Frontend should have a player div
 				cy.viewPostViaSnackbar();
 				cy.getPlayerScriptTag().should( 'exist' );
 				cy.hasPlayerInstances( 1 );
@@ -82,7 +79,6 @@ describe( 'WordPress Filters', () => {
 			// Should have 2 player script tags: auto + footer shortcode
 			cy.hasPlayerInstances( 2 );
 
-			// Verify contexts via the data attribute
 			cy.get( '[data-beyondwords-player-context="auto"]' ).should(
 				'have.length',
 				1

--- a/tests/cypress/e2e/plugins/amp.cy.js
+++ b/tests/cypress/e2e/plugins/amp.cy.js
@@ -20,7 +20,6 @@ context( 'Plugins: AMP', () => {
 
 	const postTypes = require( '../../../../tests/fixtures/post-types.json' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => [ 'post', 'page' ].includes( x.slug ) )
 		.forEach( ( postType ) => {
@@ -30,7 +29,6 @@ context( 'Plugins: AMP', () => {
 					title: `A ${ postType.slug } has an AMP iframe player`,
 				} );
 
-				// "View post"
 				cy.viewPostViaSnackbar();
 
 				// Non-AMP requests have a JS player.

--- a/tests/cypress/e2e/plugins/wpgraphql.cy.js
+++ b/tests/cypress/e2e/plugins/wpgraphql.cy.js
@@ -20,7 +20,6 @@ context( 'Plugins: WPGraphQL', () => {
 
 	const postTypes = require( '../../../../tests/fixtures/post-types.json' );
 
-	// Only test priority post types
 	postTypes
 		.filter( ( x ) => x.priority )
 		.forEach( ( postType ) => {
@@ -32,7 +31,6 @@ context( 'Plugins: WPGraphQL', () => {
 
 				cy.visit( '/wp-admin/admin.php?page=graphiql-ide' );
 
-				// Construct GraphQL query
 				cy.get( '.query-editor > .CodeMirror' )
 					.first()
 					.then( ( editor ) => {
@@ -55,10 +53,8 @@ context( 'Plugins: WPGraphQL', () => {
         }` );
 					} );
 
-				// Run the query
 				cy.get( '.execute-button' ).click().wait( 1000 );
 
-				// Test the query results
 				cy.get( '.result-window > .CodeMirror' )
 					.first()
 					.then( ( editor ) => {

--- a/tests/cypress/e2e/settings/authentication.cy.js
+++ b/tests/cypress/e2e/settings/authentication.cy.js
@@ -79,7 +79,6 @@ context( 'Settings > Authentication', () => {
 			cy.get( '.notice.notice-info' ).should( 'not.exist' );
 			cy.showsAllSettingsTabs();
 
-			// No notices
 			cy.get( '.notice-error' ).should( 'not.exist' );
 
 			cy.contains(

--- a/tests/cypress/e2e/settings/integration.cy.js
+++ b/tests/cypress/e2e/settings/integration.cy.js
@@ -27,7 +27,6 @@ context( 'Settings > Integration', () => {
 	} );
 
 	it( 'persists Magic Embed (client-side) and round-trips back to REST API', () => {
-		// Switch to client-side.
 		cy.visit(
 			'/wp-admin/options-general.php?page=beyondwords&tab=integration'
 		);
@@ -37,7 +36,6 @@ context( 'Settings > Integration', () => {
 		cy.get( 'input[type="submit"]' ).click();
 		cy.get( '.notice-success' );
 
-		// Reload — value should persist.
 		cy.visit(
 			'/wp-admin/options-general.php?page=beyondwords&tab=integration'
 		);
@@ -46,7 +44,6 @@ context( 'Settings > Integration', () => {
 			'client-side'
 		);
 
-		// Switch back to REST API.
 		cy.get( 'select[name="beyondwords_integration_method"]' ).select(
 			'REST API'
 		);

--- a/tests/cypress/e2e/settings/player-ui.cy.js
+++ b/tests/cypress/e2e/settings/player-ui.cy.js
@@ -19,7 +19,6 @@ context( 'Settings > Player UI', () => {
 
 		cy.publishPostWithAudio( { title: '"Enabled" Player UI' } );
 
-		// Frontend should have a player div
 		cy.viewPostViaSnackbar();
 
 		cy.hasPlayerInstances( 1, {
@@ -38,7 +37,6 @@ context( 'Settings > Player UI', () => {
 
 		cy.viewPostViaSnackbar();
 
-		// Frontend should have a player with showUserInterface set to false
 		cy.hasPlayerInstances( 1, {
 			showUserInterface: false,
 		} );
@@ -53,7 +51,6 @@ context( 'Settings > Player UI', () => {
 
 		cy.publishPostWithAudio( { title: '"Disabled" Player UI' } );
 
-		// Frontend should not have a player div
 		cy.viewPostViaSnackbar();
 		cy.hasPlayerInstances( 0 );
 	} );

--- a/tests/cypress/e2e/settings/preselect.cy.js
+++ b/tests/cypress/e2e/settings/preselect.cy.js
@@ -7,13 +7,10 @@
 /* global cy, beforeEach, context, it */
 
 /**
- * Progressive-disclosure behaviour of the "Preselect 'Generate audio'"
- * settings field (preselect.js): the post-type checkbox reveals an "All"
- * checkbox; "All" hides the hierarchical term trees; unticking "All" reveals
- * them. These tests only toggle the controls (no save), so they don't change
- * the stored option for other specs.
+ * Progressive-disclosure behaviour of the "Preselect 'Generate audio'" field.
  *
- * The seeded state has 'post' = mode 'all' (enabled, "All" ticked, terms hidden).
+ * Tests only toggle the controls (no save), so the stored option is unchanged
+ * for other specs. Seeded state: 'post' = mode 'all' ("All" ticked, terms hidden).
  */
 context( 'Settings: Preselect Generate audio field', () => {
 	beforeEach( () => {
@@ -33,13 +30,11 @@ context( 'Settings: Preselect Generate audio field', () => {
 				'not.be.visible'
 			);
 
-			// Untick "All" → terms revealed.
 			cy.get( '.beyondwords-setting__preselect--all' ).uncheck();
 			cy.get( '.beyondwords-setting__preselect--taxonomies' ).should(
 				'be.visible'
 			);
 
-			// Re-tick "All" → terms hidden again.
 			cy.get( '.beyondwords-setting__preselect--all' ).check();
 			cy.get( '.beyondwords-setting__preselect--taxonomies' ).should(
 				'not.be.visible'
@@ -51,18 +46,15 @@ context( 'Settings: Preselect Generate audio field', () => {
 		cy.get( '[data-post-type="post"]' ).within( () => {
 			cy.get( '.beyondwords-setting__preselect--all' ).uncheck();
 
-			// Tick the first term.
 			cy.get(
 				'.beyondwords-setting__preselect--taxonomies input[type="checkbox"]'
 			)
 				.first()
 				.check();
 
-			// Re-tick "All" (terms hidden), then untick again.
 			cy.get( '.beyondwords-setting__preselect--all' ).check();
 			cy.get( '.beyondwords-setting__preselect--all' ).uncheck();
 
-			// The previously-ticked term is still ticked.
 			cy.get(
 				'.beyondwords-setting__preselect--taxonomies input[type="checkbox"]'
 			)
@@ -73,13 +65,11 @@ context( 'Settings: Preselect Generate audio field', () => {
 
 	it( 'hides options when the post type is disabled and restores "All" when re-enabled', () => {
 		cy.get( '[data-post-type="post"]' ).within( () => {
-			// Disable the post type → all options hidden.
 			cy.get( '.beyondwords-setting__preselect--enabled' ).uncheck();
 			cy.get( '.beyondwords-setting__preselect--options' ).should(
 				'not.be.visible'
 			);
 
-			// Re-enable → "All" ticked by default, terms hidden.
 			cy.get( '.beyondwords-setting__preselect--enabled' ).check();
 			cy.get( '.beyondwords-setting__preselect--all' )
 				.should( 'be.visible' )

--- a/tests/cypress/e2e/settings/save-settings.cy.js
+++ b/tests/cypress/e2e/settings/save-settings.cy.js
@@ -8,11 +8,8 @@
 /**
  * Exercises the settings-form submission paths end-to-end.
  *
- * Most tests bypass the UI and write options directly via WP-CLI tasks. This
- * spec is the single place that drives the actual <form> submissions, so the
- * sanitisers, validators, and `register_setting` callbacks all get hit. Keep
- * the tab-by-tab structure — if a new tab/field lands in the settings page,
- * it should be wired in here, not duplicated into other specs.
+ * The single spec driving real <form> submissions (sanitisers, validators,
+ * register_setting callbacks) — wire new tabs/fields in here, not other specs.
  */
 context( 'Settings: form submission', () => {
 	beforeEach( () => {
@@ -34,7 +31,6 @@ context( 'Settings: form submission', () => {
 			cy.get( 'input[type=submit]' ).click();
 			cy.get( '.notice-success' );
 
-			// Verify written values are reflected back into the form.
 			cy.get( 'input[name="beyondwords_api_key"]' ).should(
 				'have.value',
 				apiKey
@@ -72,7 +68,6 @@ context( 'Settings: form submission', () => {
 			cy.get( 'input[type=submit]' ).click();
 			cy.get( '.notice-success' );
 
-			// Re-load and verify Preferences persisted.
 			cy.visit(
 				'/wp-admin/options-general.php?page=beyondwords&tab=preferences'
 			);
@@ -112,7 +107,6 @@ context( 'Settings: form submission', () => {
 			);
 			cy.dismissPointers();
 
-			// Term-gate posts: untick the whole-post-type box, tick a term.
 			cy.get(
 				'input[name="beyondwords_preselect[post][all]"]'
 			).uncheck();
@@ -123,7 +117,6 @@ context( 'Settings: form submission', () => {
 			cy.get( 'input[type=submit]' ).click();
 			cy.get( '.notice-success' );
 
-			// Reload and verify the post-type box is off and the term persisted.
 			cy.visit(
 				'/wp-admin/options-general.php?page=beyondwords&tab=preferences'
 			);

--- a/tests/cypress/e2e/site-health.cy.js
+++ b/tests/cypress/e2e/site-health.cy.js
@@ -28,30 +28,25 @@ context( 'Site Health', () => {
 		cy.visitPluginSiteHealth();
 
 		cy.get( '#health-check-accordion-block-beyondwords' ).within( () => {
-			// Plugin version
 			cy.getSiteHealthValue( 'Plugin version' )
 				.invoke( 'text' )
 				.should( 'match', semverRegex );
 
-			// REST API URL
 			cy.getSiteHealthValue( 'REST API URL' ).should(
 				'have.text',
 				Cypress.expose('apiUrl')
 			);
 
-			// Communication with REST API
 			cy.getSiteHealthValue( 'Communication with REST API' ).should(
 				'have.text',
 				'BeyondWords API is reachable'
 			);
 
-			// Compatible post types
 			cy.getSiteHealthValue( 'Compatible post types' ).should(
 				'have.text',
 				'post, page, cpt_active, cpt_inactive'
 			);
 
-			// Integration method
 			cy.getSiteHealthValue( 'Integration method' ).should(
 				'have.text',
 				'rest-api'
@@ -64,31 +59,26 @@ context( 'Site Health', () => {
 					.should( 'match', new RegExp( `[X]+${ apiKey.slice( -4 ) }$` ) );
 			} );
 
-			// Project ID
 			cy.getSiteHealthValue( 'Project ID' ).should(
 				'have.text',
 				Cypress.expose('projectId')
 			);
 
-			// Include excerpt (Preferences tab)
 			cy.getSiteHealthValue( 'Include excerpt' ).should(
 				'have.text',
 				'No'
 			);
 
-			// Player UI (Preferences tab)
 			cy.getSiteHealthValue( 'Player UI' ).should(
 				'have.text',
 				'enabled'
 			);
 
-			// Preselect 'Generate audio' (Preferences tab)
 			cy.getSiteHealthValue( 'Preselect ‘Generate audio’' ).should(
 				'have.text',
 				'{\n    "post": {\n        "mode": "all"\n    },\n    "page": {\n        "mode": "all"\n    },\n    "cpt_active": {\n        "mode": "all"\n    }\n}'
 			);
 
-			// Filter registries
 			cy.getSiteHealthValue( 'Registered filters' ).should(
 				'have.text',
 				'None'
@@ -98,7 +88,6 @@ context( 'Site Health', () => {
 				'None'
 			);
 
-			// Notice timestamps
 			cy.getSiteHealthValue( 'Date Activated' )
 				.invoke( 'text' )
 				.should( 'satisfy', ( val ) => ! isNaN( Date.parse( val ) ) );

--- a/tests/cypress/scripts/setup-ci.js
+++ b/tests/cypress/scripts/setup-ci.js
@@ -1,7 +1,5 @@
 /**
- * One-time setup script for CI environment
- * Run this ONCE before the Cypress test suite starts
- * This ensures the WordPress database is initialized properly
+ * One-time CI setup: initialise the WordPress database before the Cypress suite runs.
  */
 
 const util = require( 'util' );

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,13 +1,11 @@
 /* global cy, Cypress, expect */
 
 // Custom Cypress commands for the BeyondWords test suite.
-// See https://on.cypress.io/custom-commands
 
 import _ from 'lodash';
 
 const postTypes = require( '../../fixtures/post-types.json' );
 
-// Set keystroke delay
 Cypress.Commands.overwrite(
 	'type',
 	( originalFn, subject, text, options = {} ) => {
@@ -19,22 +17,12 @@ Cypress.Commands.overwrite(
 /**
  * Get the block editor canvas body.
  *
- * WordPress 6.8+ renders the editor inside an iframe. This command
- * checks for the iframe first and falls back to the top-level document
- * for older versions.
+ * WordPress 6.8+ renders the editor inside an iframe; falls back to the
+ * top-level document for older versions.
  */
 Cypress.Commands.add( 'getEditorCanvasBody', () => {
-	// WordPress 6.8+ renders the editor inside an iframe. Whether that iframe
-	// exists is stable for a given WP version, so detect it once synchronously
-	// and return a *retryable query chain* for the canvas <body> — note there is
-	// no `.then( cy.wrap )` boundary at the end.
-	//
-	// That boundary matters: it would pin the resolved <body> as a static
-	// subject, so a caller's chained `.find()`/`.type()` could not re-query. The
-	// block editor re-renders its iframe during hydration, which detaches that
-	// pinned <body> and fails the chain ("subject is no longer attached to the
-	// DOM") — flaky on slower PHP/CI (seen on PHP 8.0). Keeping it a pure query
-	// chain lets Cypress re-read a fresh canvas <body> on every retry.
+	// Deliberately no `.then( cy.wrap )` boundary: pinning the resolved <body>
+	// breaks retries when the iframe re-renders during hydration (flaky on slow CI).
 	if ( Cypress.$( 'iframe[name="editor-canvas"]' ).length ) {
 		return cy
 			.get( 'iframe[name="editor-canvas"]' )
@@ -45,18 +33,12 @@ Cypress.Commands.add( 'getEditorCanvasBody', () => {
 } );
 
 Cypress.Commands.add( 'getTinyMceIframeBody', () => {
-	// get the iframe > document > body
-	// and retry until the body element is not empty
 	return (
 		cy
 			.get( '#content_ifr' )
 			.its( '0.contentDocument.body' )
 			.should( 'not.be.empty' )
-			/*
-			 * Wraps "body" DOM element to allow
-			 * chaining more Cypress commands, like ".find(...)"
-			 * https://on.cypress.io/wrap
-			 */
+			// Wrap the body element so further commands can chain from it.
 			.then( cy.wrap )
 	);
 } );
@@ -64,9 +46,8 @@ Cypress.Commands.add( 'getTinyMceIframeBody', () => {
 Cypress.Commands.add( 'login', () => {
 	cy.env( [ 'wpUsername', 'wpPassword' ] ).then(
 		( { wpUsername, wpPassword } ) => {
-			// Visiting from a dirty editor (a prior test that opened the
-			// pre-publish panel) can otherwise trip the unsaved-changes
-			// prompt; auto-confirm so navigation isn't blocked.
+			// A dirty editor from a prior test can trip the unsaved-changes
+			// prompt; clear onbeforeunload so navigation isn't blocked.
 			cy.window().then( ( win ) => {
 				win.onbeforeunload = null;
 			} );
@@ -121,7 +102,6 @@ Cypress.Commands.add( 'visitPostEditorById', ( postId ) => {
 } );
 
 Cypress.Commands.add( 'disableWelcomeGuides', () => {
-	// Wait for editor and dismiss welcome modal if it appears
 	cy.window()
 		.its( 'wp.data' )
 		.then( ( data ) => {
@@ -192,7 +172,6 @@ Cypress.Commands.add( 'dismissPointers', () => {
 	// Dismiss WordPress admin pointers/tooltips that may be covering elements
 	cy.get( 'body' ).then( ( $body ) => {
 		if ( $body.find( '.wp-pointer' ).length > 0 ) {
-			// Try clicking the close button (X in top right)
 			cy.get(
 				'.wp-pointer .wp-pointer-buttons a.close, .wp-pointer button.wp-pointer-close'
 			).each( ( $closeBtn ) => {
@@ -217,9 +196,8 @@ Cypress.Commands.add( 'getSiteHealthValue', ( label, ...args ) => {
 		.then( ( $el ) => cy.wrap( $el, args ) );
 } );
 
-// Use the className selector instead of the label text — the GenerateAudio
-// caption flips between "Generation enabled" and "Generation disabled" to
-// reflect the toggle state, so it can't be used to locate the control.
+// The GenerateAudio caption flips between "Generation enabled/disabled" to
+// reflect state, so locate the control by className rather than label text.
 const GENERATE_AUDIO_CHECKBOX =
 	'.beyondwords--generate-audio input[type="checkbox"]';
 const GENERATE_AUDIO_LABEL = '.beyondwords--generate-audio label';
@@ -334,8 +312,7 @@ Cypress.Commands.add( 'openBeyondwordsPluginSidebar', () => {
 
 Cypress.Commands.add( 'openBeyondwordsDataPanel', () => {
 	cy.openBeyondwordsPluginSidebar();
-	// The Data panel is collapsed by default; expand it to reach the Content
-	// ID field and the Fetch button.
+	// The Data panel is collapsed by default; expand it.
 	cy.get( '.beyondwords-sidebar__data' ).then( ( $panel ) => {
 		if ( ! $panel.hasClass( 'is-opened' ) ) {
 			cy.wrap( $panel ).contains( 'button', 'Data' ).click();
@@ -352,8 +329,6 @@ Cypress.Commands.add( 'getBlockEditorCheckbox', ( text, ...args ) => {
 		.then( ( $el ) => cy.wrap( $el ) );
 } );
 
-// The GenerateAudio caption is state-reflecting ("Generation enabled/disabled"),
-// so locate its checkbox by the stable className rather than by label text.
 Cypress.Commands.add( 'getGenerateAudioCheckbox', () => {
 	return cy.get( GENERATE_AUDIO_CHECKBOX );
 } );
@@ -375,10 +350,8 @@ Cypress.Commands.add( 'setPostStatus', ( status ) => {
 } );
 
 Cypress.Commands.add( 'publishWithConfirmation', () => {
-	// "Publish" in top bar
 	cy.get( '.editor-post-publish-button__button' ).click();
 
-	// Confirm "Publish" in the Prepublish panel
 	cy.get(
 		'.editor-post-publish-panel__header-publish-button > .components-button'
 	).click();
@@ -396,7 +369,6 @@ Cypress.Commands.add( 'publishWithConfirmation', () => {
 		}
 	} );
 
-	// Close Prepublish panel if it's still open
 	cy.get( 'body' ).then( ( $body ) => {
 		if ( $body.find( 'button[aria-label="Close panel"]' ).length ) {
 			cy.get( 'button[aria-label="Close panel"]' ).click();
@@ -420,12 +392,10 @@ Cypress.Commands.add( 'viewPostViaSnackbar', () => {
 		.click();
 } );
 
-// Get label element from text
 Cypress.Commands.add( 'getLabel', ( text, ...args ) => {
 	return cy.get( 'label', ...args ).contains( text );
 } );
 
-// Check for a number of admin player instances.
 Cypress.Commands.add( 'hasAdminPlayerInstances', ( num = 1 ) => {
 	if ( num < 0 ) {
 		throw new Error( 'Number of player instances cannot be negative.' );
@@ -439,9 +409,7 @@ Cypress.Commands.add( 'hasAdminPlayerInstances', ( num = 1 ) => {
 	cy.get( '.beyondwords-player-box-wrapper' ).should( 'exist' );
 } );
 
-// Check for a number of player instances.
 Cypress.Commands.add( 'hasPlayerInstances', ( num = 1, params = {} ) => {
-	// Ensure the player script tag count matches the expected number of instances.
 	if ( num < 0 ) {
 		throw new Error( 'Number of player instances cannot be negative.' );
 	}
@@ -458,7 +426,7 @@ Cypress.Commands.add( 'hasPlayerInstances', ( num = 1, params = {} ) => {
 		return;
 	}
 
-	// Check params exist in the params of the player script tag's onload init object.
+	// Assert each expected param appears in the script tag's onload init object.
 	cy.getPlayerScriptTag().each( ( $el ) => {
 		const onload = $el.attr( 'onload' );
 		const match = onload.match( /\{target:this, \.\.\.(.+)\}\)/ );
@@ -490,7 +458,6 @@ Cypress.Commands.add( 'hasPlayerInstances', ( num = 1, params = {} ) => {
 	} );
 } );
 
-// Check for no Beyondwords Player object.
 Cypress.Commands.add( 'hasNoBeyondwordsWindowObject', () => {
 	cy.window( { timeout: 4000 } ).should( ( win ) => {
 		if ( 'BeyondWords' in win ) {
@@ -501,7 +468,6 @@ Cypress.Commands.add( 'hasNoBeyondwordsWindowObject', () => {
 	} );
 } );
 
-// Get frontend audio player script tag.
 Cypress.Commands.add( 'getPlayerScriptTag', ( ...args ) => {
 	return cy.get(
 		// eslint-disable-next-line max-len
@@ -557,7 +523,7 @@ Cypress.Commands.add( 'cleanupTestPosts', () => {
 
 /**
  * Reset BeyondWords plugin settings to defaults.
- * This ensures tests start with a clean slate for plugin configuration.
+ *
  * Preserves infrastructure options set by setupDatabase: API credentials
  * (to avoid 403 errors) and preselect (whose PHP default excludes cpt_active).
  */
@@ -568,9 +534,8 @@ Cypress.Commands.add( 'resetPluginSettings', () => {
 			'beyondwords_api_key',
 			'beyondwords_project_id',
 			'beyondwords_preselect',
-			// Keep the validation flag so Integration/Preferences tabs stay
-			// visible between tests — Tabs::get_visible_tabs() hides them
-			// when this option is missing.
+			// Tabs::get_visible_tabs() hides Integration/Preferences when this
+			// validation flag is missing; keep the tabs visible between tests.
 			'beyondwords_valid_api_connection',
 		],
 	} );
@@ -585,7 +550,6 @@ Cypress.Commands.add( 'resetPluginSettings', () => {
  */
 Cypress.Commands.add( 'createTestPost', ( options = {} ) => {
 	if ( 'future' === options.postStatus ) {
-		// Set future date 10 years from now
 		const futureDate = new Date();
 		const year = futureDate.getFullYear() + 10;
 		options.postDate = `${ year }-01-01T00:00:00Z`;
@@ -601,7 +565,6 @@ Cypress.Commands.add( 'createTestPost', ( options = {} ) => {
  */
 Cypress.Commands.add( 'createTestPostWithAudio', ( options = {} ) => {
 	return cy.createTestPost( options ).then( ( postId ) => {
-		// Set the meta to generate audio for this post
 		return cy
 			.task( 'setPostMeta', {
 				postId,

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -1,30 +1,12 @@
 /* global Cypress, cy, before, beforeEach */
 
-// ***********************************************************
-// This example support/e2e.js is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
-// ***********************************************************
+// Loaded automatically before every spec; global Cypress configuration lives here.
 
-// Import commands.js using ES2015 syntax:
 import './commands';
 
 // Cypress fail-fast support (v8+ requires explicit import)
 import 'cypress-fail-fast';
 
-// Alternatively you can use CommonJS syntax:
-// require( './commands' )
-
-// MochAwesome Reporting
 import addContext from 'mochawesome/addContext';
 
 // Extra Cypress query commands for v12+
@@ -52,13 +34,11 @@ Cypress.on( 'uncaught:exception', () => {
 } );
 
 before( () => {
-	// Clean up test posts from previous test (fast - 100-500ms)
 	cy.task( 'setupDatabase' );
 } );
 
 beforeEach( () => {
 	cy.resetPluginSettings();
-	// Clean up test posts from previous test (fast - 100-500ms)
 	cy.cleanupTestPosts();
 	// disable Cypress's default behavior of logging all XMLHttpRequests and fetches
 	cy.intercept( { resourceType: /xhr|fetch/ }, { log: false } );

--- a/tests/phpunit/api/test-client.php
+++ b/tests/phpunit/api/test-client.php
@@ -9,7 +9,6 @@ class ClientTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
         // Register the http_request_args filter that production runs from
@@ -23,14 +22,12 @@ class ClientTest extends TestCase
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         remove_filter('http_request_args', [Client::class, 'filter_http_request_args'], 10);
 
         // Clear existing admin notices, so we can test notices in isolation
         remove_all_actions('admin_notices');
         remove_all_actions('all_admin_notices');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -541,11 +538,8 @@ class ClientTest extends TestCase
      * @test
      * @group settings
      *
-     * Voices is materially slower to prepare than the other dropdowns (~3.7s p95
-     * vs ~250ms), so it is the one endpoint with its own longer bound — the
-     * shared DEFAULT_REQUEST_TIMEOUT would abandon cold-cache fetches and,
-     * because failures are negative-cached, blank the Voice dropdown for a whole
-     * CACHE_TTL_ON_ERROR.
+     * Voices is materially slower (~3.7s p95 vs ~250ms), so it has its own longer bound —
+     * the short default would abandon cold-cache fetches and negative-cache a blank dropdown.
      */
     public function voices_get_uses_longer_timeout()
     {
@@ -580,11 +574,8 @@ class ClientTest extends TestCase
      * @test
      * @group settings
      *
-     * A failed editor-dropdown fetch is negative-cached for a short TTL, so a
-     * slow or unreachable API is probed at most once per interval instead of
-     * blocking every admin edit-screen render. The second call within the TTL
-     * is served from the transient (the empty-array sentinel) and makes no HTTP
-     * request.
+     * A failed fetch is negative-cached for a short TTL, so an unreachable API is probed
+     * at most once per interval; the second call gets the empty-array sentinel, no HTTP.
      */
     public function failed_responses_are_negative_cached()
     {
@@ -611,12 +602,8 @@ class ClientTest extends TestCase
      * @test
      * @group settings
      *
-     * Every request — cached editor-dropdown GETs and direct call_api requests
-     * alike — uses the short default timeout: the API responds quickly on every
-     * endpoint (content writes return the content ID immediately; audio
-     * generation is asynchronous server-side), so no request may tie up a PHP
-     * worker beyond VIP's 3-second ceiling. Voices, the one slow endpoint, is
-     * covered by voices_get_uses_longer_timeout().
+     * Every request uses the short default timeout — the API responds quickly everywhere
+     * (audio generation is async server-side) and VIP caps workers at 3s. Voices excepted.
      */
     public function all_requests_use_the_short_default_timeout()
     {
@@ -657,8 +644,7 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * 401 when the option-supplied API key is invalid (covers both the
-     * "missing" and "wrong" cases — the BeyondWords API treats them the same).
+     * 401 when the API key is invalid ("missing" and "wrong" are treated the same).
      */
     public function call_api_with_invalid_api_key()
     {
@@ -674,7 +660,6 @@ class ClientTest extends TestCase
 
         $this->assertSame(401, wp_remote_retrieve_response_code($response));
 
-        // We should find the error code & message in the post_meta table
         $error = sprintf(Client::ERROR_FORMAT, 401, 'Authentication token was not recognized.');
         $this->assertSame($error, get_post_meta($postId, 'beyondwords_error_message', true));
 
@@ -727,7 +712,6 @@ class ClientTest extends TestCase
 
         $this->assertSame(404, wp_remote_retrieve_response_code($response));
 
-        // We should find the error code & message in the post_meta table
         $this->assertSame('#404: Not Found', get_post_meta($postId, 'beyondwords_error_message', true));
 
         wp_delete_post($postId, true);
@@ -798,15 +782,13 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * Test that 404 errors are saved for REST_API posts even when global setting is CLIENT_SIDE.
-     * This tests the bug where saveErrorMessage checked the global option instead of post meta.
+     * 404 errors ARE saved for REST_API posts even when the global is CLIENT_SIDE —
+     * regression: saveErrorMessage checked the global option instead of post meta.
      */
     public function save_error_message404_for_rest_api_post_when_global_is_client_side()
     {
-        // Set global integration method to CLIENT_SIDE
         update_option('beyondwords_integration_method', 'client-side');
 
-        // Create a post with REST_API integration method in post meta
         $postId = self::factory()->post->create([
             'post_title' => 'ClientTest::saveErrorMessage404ForRestApiPostWhenGlobalIsClientSide',
             'meta_input' => [
@@ -814,11 +796,9 @@ class ClientTest extends TestCase
             ],
         ]);
 
-        // Call saveErrorMessage with a 404 error
         Client::save_error_message($postId, 'Not Found', 404);
 
-        // The error SHOULD be saved because the post uses REST_API integration
-        // (even though the global setting is CLIENT_SIDE)
+        // Saved: the post's REST_API meta wins over the global CLIENT_SIDE setting.
         $error = get_post_meta($postId, 'beyondwords_error_message', true);
         $this->assertEquals('#404: Not Found', $error);
 
@@ -829,14 +809,12 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * Test that 404 errors are NOT saved for CLIENT_SIDE posts.
+     * 404 errors are NOT saved for CLIENT_SIDE posts.
      */
     public function save_error_message404_not_saved_for_client_side_post()
     {
-        // Set global integration method to REST_API
         update_option('beyondwords_integration_method', 'rest-api');
 
-        // Create a post with CLIENT_SIDE integration method in post meta
         $postId = self::factory()->post->create([
             'post_title' => 'ClientTest::saveErrorMessage404NotSavedForClientSidePost',
             'meta_input' => [
@@ -844,10 +822,9 @@ class ClientTest extends TestCase
             ],
         ]);
 
-        // Call saveErrorMessage with a 404 error
         Client::save_error_message($postId, 'Not Found', 404);
 
-        // The error should NOT be saved because the post uses CLIENT_SIDE integration
+        // Not saved: the post's CLIENT_SIDE meta wins over the global REST_API setting.
         $error = get_post_meta($postId, 'beyondwords_error_message', true);
         $this->assertEmpty($error);
 
@@ -858,15 +835,12 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * Test legacy posts (no integration method meta) with global=REST_API.
-     * 404 errors SHOULD be saved because legacy posts default to REST_API.
+     * Legacy posts (no integration meta, pre-v6.0) with global=REST_API: 404s ARE saved.
      */
     public function save_error_message404_for_legacy_post_when_global_is_rest_api()
     {
-        // Set global integration method to REST_API
         update_option('beyondwords_integration_method', 'rest-api');
 
-        // Create a legacy post with NO integration method meta (simulating pre-v6.0 post)
         $postId = self::factory()->post->create([
             'post_title' => 'ClientTest::saveErrorMessage404ForLegacyPostWhenGlobalIsRestApi',
             'meta_input' => [
@@ -875,10 +849,9 @@ class ClientTest extends TestCase
             ],
         ]);
 
-        // Call saveErrorMessage with a 404 error
         Client::save_error_message($postId, 'Not Found', 404);
 
-        // The error SHOULD be saved because legacy posts fall back to global (REST_API)
+        // Saved: legacy posts fall back to the global setting (REST_API).
         $error = get_post_meta($postId, 'beyondwords_error_message', true);
         $this->assertEquals('#404: Not Found', $error);
 
@@ -889,15 +862,12 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * Test legacy posts (no integration method meta) with global=CLIENT_SIDE.
-     * 404 errors should NOT be saved because the post falls back to global CLIENT_SIDE.
+     * Legacy posts (no integration meta, pre-v6.0) with global=CLIENT_SIDE: 404s are NOT saved.
      */
     public function save_error_message404_for_legacy_post_when_global_is_client_side()
     {
-        // Set global integration method to CLIENT_SIDE
         update_option('beyondwords_integration_method', 'client-side');
 
-        // Create a legacy post with NO integration method meta (simulating pre-v6.0 post)
         $postId = self::factory()->post->create([
             'post_title' => 'ClientTest::saveErrorMessage404ForLegacyPostWhenGlobalIsClientSide',
             'meta_input' => [
@@ -906,10 +876,9 @@ class ClientTest extends TestCase
             ],
         ]);
 
-        // Call saveErrorMessage with a 404 error
         Client::save_error_message($postId, 'Not Found', 404);
 
-        // The error should NOT be saved because legacy posts fall back to global (CLIENT_SIDE)
+        // Not saved: legacy posts fall back to the global setting (CLIENT_SIDE).
         $error = get_post_meta($postId, 'beyondwords_error_message', true);
         $this->assertEmpty($error);
 
@@ -1030,9 +999,8 @@ class ClientTest extends TestCase
     }
 
     /**
-     * The Content ID is charset-validated before storage, but Client must still
-     * defensively rawurlencode() it so any value that reaches the URL builder
-     * can't inject extra path or query segments into the authenticated request.
+     * Content IDs are charset-validated before storage, but Client must still defensively
+     * rawurlencode() so no value can inject path/query segments into the request.
      *
      * @test
      */
@@ -1052,8 +1020,7 @@ class ClientTest extends TestCase
 
         remove_filter('pre_http_request', $filter, 1);
 
-        // The slash and query characters are percent-encoded, so the URL keeps
-        // its intended `/content/<id>` shape instead of gaining an attacker path.
+        // Percent-encoding keeps the intended /content/<id> shape — no attacker path.
         $this->assertStringContainsString('/content/a%2Fb%3Fc%3D1', (string) $captured_url);
         $this->assertStringNotContainsString('/content/a/b?c=1', (string) $captured_url);
 
@@ -1064,11 +1031,8 @@ class ClientTest extends TestCase
     /**
      * @test
      *
-     * A transport-level failure (DNS error, timeout, refused/blocked connection)
-     * makes wp_remote_request() — and therefore call_api() — return a WP_Error.
-     * get_content() must surface that WP_Error rather than throwing a TypeError,
-     * so InspectPanel::rest_api_response() can fall through to its is_wp_error()
-     * branch and degrade to a "Could not connect to BeyondWords API" response.
+     * A transport-level failure makes call_api() return a WP_Error; get_content() must
+     * surface it (not TypeError) so InspectPanel can degrade to a could-not-connect response.
      */
     public function get_content_returns_wp_error_on_connection_failure()
     {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -7,8 +7,8 @@ require dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/yoast/phpunit-polyf
  * @package Speechkit
  */
 
-// PHP 8.4+: Suppress deprecation warnings from Symfony 5.4 (required for PHP 8.0 support)
-// When PHP 8.0 support is dropped, upgrade to Symfony 6.4+ and remove this.
+// PHP 8.4+: suppress deprecations from Symfony 5.4 (needed while PHP 8.0 is supported);
+// remove once upgraded to Symfony 6.4+.
 if ( PHP_VERSION_ID >= 80400 ) {
 	error_reporting( E_ALL & ~E_DEPRECATED );
 }
@@ -19,7 +19,6 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
 $_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
 if ( false !== $_phpunit_polyfills_path ) {
 	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
@@ -33,15 +32,8 @@ if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
 // Give access to tests_add_filter() function.
 require_once "{$_tests_dir}/includes/functions.php";
 
-/*
- * Define plugin constants for tests.
- *
- * Two sources, in priority order:
- *   1. Environment variables (set by CI, e.g. via GitHub Actions secrets).
- *   2. The `config` block of `.wp-env.tests.override.json` (used locally —
- *      the WP test framework uses its own `wp-tests-config.php`, so the
- *      `define()` calls wp-env injects into wp-config.php don't reach us).
- */
+// Plugin constants come from env vars (CI) or `.wp-env.tests.override.json` (local) —
+// the test framework's own wp-tests-config.php never sees wp-env's wp-config.php defines.
 $bw_constants = array(
 	'BEYONDWORDS_API_URL',
 	'BEYONDWORDS_MOCK_API',
@@ -92,7 +84,6 @@ function _manually_load_plugin() {
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-// Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
 
 // Load mock API responses plugin if enabled (after WP boots so filters work).
@@ -100,5 +91,4 @@ if ( defined( 'BEYONDWORDS_MOCK_API' ) && BEYONDWORDS_MOCK_API ) {
 	require dirname( __DIR__ ) . '/fixtures/wp-content/plugins/beyondwords-mock-rest-api-responses/mock-rest-api-responses.php';
 }
 
-// Load base TestCase class
 require __DIR__ . '/class-test-case.php';

--- a/tests/phpunit/class-clean-output-printer.php
+++ b/tests/phpunit/class-clean-output-printer.php
@@ -7,8 +7,7 @@ use PHPUnit\TextUI\DefaultResultPrinter;
 /**
  * Custom PHPUnit Result Printer that suppresses test output.
  *
- * This prevents HTML output from tests that render components
- * from cluttering the console output.
+ * Prevents HTML from component-rendering tests cluttering the console.
  */
 class CleanOutputPrinter extends DefaultResultPrinter
 {
@@ -19,7 +18,6 @@ class CleanOutputPrinter extends DefaultResultPrinter
      */
     protected function write_progress(string $progress): void
     {
-        // Suppress any captured output, only show progress
         parent::write_progress($progress);
     }
 }

--- a/tests/phpunit/class-test-case.php
+++ b/tests/phpunit/class-test-case.php
@@ -4,39 +4,30 @@ declare(strict_types=1);
 
 /**
  * Base Test Case.
- *
- * This extends WP_UnitTestCase to provide additional functionality.
  */
 abstract class TestCase extends WP_UnitTestCase
 {
     /**
      * Capture output from a callback without printing it to console.
      *
-     * This method tells PHPUnit to expect output, which prevents it from
-     * printing the output to the console while still allowing assertions
-     * on the captured output.
+     * expectOutputRegex() makes PHPUnit swallow the output while still allowing assertions on it.
      *
      * @param callable $callback The function that produces output
      * @return string The captured output
      */
     protected function capture_output(callable $callback): string
     {
-        // Tell PHPUnit we expect output (this prevents console printing)
         $this->expectOutputRegex('/.*/s');
 
-        // Execute the callback (output will be captured by PHPUnit)
         $callback();
 
-        // Return the captured output for assertions
         return $this->getActualOutput();
     }
 
     /**
      * Intercept HTTP requests to a URL containing $contentId and return a 404.
      *
-     * Only requests whose method is in $methods and whose URL contains
-     * `/content/{$contentId}` are intercepted; everything else passes through
-     * to the mock API server.
+     * Non-matching requests pass through to the mock API server.
      *
      * @param string   $contentId The content ID that should trigger a 404.
      * @param string[] $methods   HTTP methods to intercept (e.g. ['PUT']).

--- a/tests/phpunit/compatibility/test-wpgraphql.php
+++ b/tests/phpunit/compatibility/test-wpgraphql.php
@@ -8,17 +8,11 @@ class WPGraphQLTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -29,7 +23,6 @@ class WPGraphQLTest extends TestCase
     {
         WPGraphQL::init();
 
-        // Actions
         $this->assertEquals(10, has_action('graphql_register_types', array(WPGraphQL::class, 'graphql_register_types')));
     }
 }

--- a/tests/phpunit/core/test-plugin.php
+++ b/tests/phpunit/core/test-plugin.php
@@ -32,10 +32,6 @@ class PluginTest extends TestCase
     {
         Plugin::init();
 
-        // Verify that various hooks have been registered by components
-        // These prove that the Plugin::init() method is initializing all components
-
-        // Core components
         $this->assertTrue(
             has_action('init') !== false,
             'Should register Core component hooks'
@@ -51,7 +47,6 @@ class PluginTest extends TestCase
             'Should register Settings component hooks'
         );
 
-        // Verify components with valid API connection are initialized
         $this->assertTrue(
             has_action('admin_enqueue_scripts') !== false,
             'Should register admin scripts when API connection is valid'

--- a/tests/phpunit/core/test-uninstaller.php
+++ b/tests/phpunit/core/test-uninstaller.php
@@ -8,17 +8,11 @@ class UninstallerTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -36,9 +30,6 @@ class UninstallerTest extends TestCase
         $this->assertFalse(get_option($name));
     }
 
-    /**
-     * Option names provider.
-     */
     public function option_names_provider()
     {
         return [
@@ -183,9 +174,8 @@ class UninstallerTest extends TestCase
         set_transient('beyondwords_voices_en', ['voice1'], 60);
         set_transient('unrelated_transient', 'keep-me', 60);
 
-        // Each expiring transient writes a value row AND a `_transient_timeout_`
-        // row; the cleanup must sweep both. Confirm the timeout rows exist up
-        // front so the post-cleanup assertion below isn't vacuous.
+        // Each expiring transient also writes a `_transient_timeout_` row; confirm those
+        // exist up front so the post-cleanup assertion below isn't vacuous.
         $timeoutsBefore = (int) $wpdb->get_var(
             "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_beyondwords_%'"
         );
@@ -193,14 +183,12 @@ class UninstallerTest extends TestCase
 
         $count = Uninstaller::cleanup_plugin_transients();
 
-        // The Uninstaller does a raw SQL delete; clear the object cache so the
-        // next get_transient() reads from the database (not stale cache).
+        // The Uninstaller deletes with raw SQL; flush so get_transient() re-reads the DB.
         wp_cache_flush();
 
         // 2 beyondwords transients × (value + timeout) = 4 rows deleted.
         $this->assertGreaterThanOrEqual(4, $count);
 
-        // Neither the value rows nor the timeout rows should remain.
         $remaining = $wpdb->get_var(
             "SELECT COUNT(*) FROM {$wpdb->options}
              WHERE option_name LIKE '_transient_beyondwords_%'
@@ -208,7 +196,6 @@ class UninstallerTest extends TestCase
         );
         $this->assertSame('0', (string) $remaining);
 
-        // Unrelated transient (and its own timeout row) left untouched.
         $this->assertSame('keep-me', get_transient('unrelated_transient'));
 
         delete_transient('unrelated_transient');
@@ -216,9 +203,6 @@ class UninstallerTest extends TestCase
 
     /**
      * @test
-     *
-     * run() performs the whole cleanup in a single call on a single-site
-     * install: options, transients and post-meta are all removed.
      */
     public function run_cleans_options_transients_and_meta_on_single_site()
     {
@@ -234,8 +218,7 @@ class UninstallerTest extends TestCase
 
         Uninstaller::run();
 
-        // The Uninstaller deletes transients/meta with raw SQL, so drop the
-        // caches before re-reading from the database.
+        // The Uninstaller deletes with raw SQL; drop caches before re-reading the DB.
         wp_cache_flush();
         clean_post_cache($postId);
 
@@ -249,14 +232,8 @@ class UninstallerTest extends TestCase
     /**
      * @test
      *
-     * run() must visit EVERY site on a multisite network: the API key and other
-     * per-site values must not survive on any site, not just the main one.
-     *
-     * Regression test for the multisite uninstall leak — cleanup previously
-     * called delete_site_option() (which targets wp_sitemeta) while every
-     * option is stored per-site via update_option(), so nothing was deleted and
-     * the beyondwords_api_key secret survived. Skipped on single-site installs
-     * because it needs a real network (WP_TESTS_MULTISITE=1).
+     * run() must visit EVERY site on the network. Regression for the multisite uninstall
+     * leak: delete_site_option() targets wp_sitemeta, but every option is stored per-site.
      */
     public function run_cleans_every_site_on_multisite()
     {
@@ -267,8 +244,7 @@ class UninstallerTest extends TestCase
         $blogId  = self::factory()->blog->create();
         $siteIds = [get_current_blog_id(), $blogId];
 
-        // Seed an option (the API key), a transient and a post-meta value on
-        // each site so we can prove all three are cleaned everywhere.
+        // Seed all three value types on each site to prove cleanup reaches every site.
         $postIds = [];
         foreach ($siteIds as $siteId) {
             switch_to_blog($siteId);

--- a/tests/phpunit/core/test-updater.php
+++ b/tests/phpunit/core/test-updater.php
@@ -13,17 +13,11 @@ class UpdaterTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -208,15 +202,12 @@ class UpdaterTest extends TestCase
 
         Updater::migrate_disabled_to_embed_none();
 
-        // Legacy opt-out → Embed = None, flag removed.
         $this->assertSame('none', get_post_meta($disabledPost, 'beyondwords_embed', true));
         $this->assertSame('', get_post_meta($disabledPost, 'beyondwords_disabled', true));
 
-        // Existing Embed preserved, flag still removed.
         $this->assertSame('audio_post', get_post_meta($embedPost, 'beyondwords_embed', true));
         $this->assertSame('', get_post_meta($embedPost, 'beyondwords_disabled', true));
 
-        // Post without the flag is unaffected.
         $this->assertSame('', get_post_meta($untouchedPost, 'beyondwords_embed', true));
 
         wp_delete_post($disabledPost, true);
@@ -225,26 +216,20 @@ class UpdaterTest extends TestCase
     }
 
     /**
-     * The migration gate must close once the recorded version matches this
-     * build — otherwise the pre-release `< 7.0.0` comparison keeps the v7
-     * migrations firing on every request.
+     * The gate must close once the recorded version matches this build, else the pre-release `< 7.0.0` comparison re-fires v7 migrations every request.
      *
      * @test
      */
     public function run_is_a_noop_once_the_recorded_version_matches_this_build()
     {
-        // Simulate an install that has already booted this exact build.
         update_option('beyondwords_version', BEYONDWORDS__PLUGIN_VERSION);
 
-        // A post still carrying the legacy opt-out flag. If run() re-executed
-        // the v7 block it would strip this flag and set Embed = None; the
-        // version guard must leave it untouched.
+        // Sentinel: if run() re-executed the v7 block it would strip this flag and set Embed = None.
         $post = self::factory()->post->create();
         update_post_meta($post, 'beyondwords_disabled', '1');
 
         Updater::run();
 
-        // Migration did not run: legacy flag preserved, no Embed written.
         $this->assertSame('1', get_post_meta($post, 'beyondwords_disabled', true));
         $this->assertSame('', get_post_meta($post, 'beyondwords_embed', true));
 
@@ -253,8 +238,7 @@ class UpdaterTest extends TestCase
     }
 
     /**
-     * When the recorded version predates a migration, run() must execute it and
-     * normalise the stored version to this build.
+     * When the recorded version predates a migration, run() must execute it and record this build's version.
      *
      * @test
      */
@@ -267,11 +251,10 @@ class UpdaterTest extends TestCase
 
         Updater::run();
 
-        // v7 migration ran: legacy flag converted to Embed = None and removed.
         $this->assertSame('none', get_post_meta($post, 'beyondwords_embed', true));
         $this->assertSame('', get_post_meta($post, 'beyondwords_disabled', true));
 
-        // Stored version normalised to this build, so the next run() is a no-op.
+        // Version normalised to this build, so the next run() is a no-op.
         $this->assertSame(BEYONDWORDS__PLUGIN_VERSION, get_option('beyondwords_version'));
 
         wp_delete_post($post, true);

--- a/tests/phpunit/core/test-urls.php
+++ b/tests/phpunit/core/test-urls.php
@@ -13,17 +13,11 @@ class UrlsTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 

--- a/tests/phpunit/core/test-utils.php
+++ b/tests/phpunit/core/test-utils.php
@@ -8,15 +8,11 @@ class UtilsTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -36,9 +32,6 @@ class UtilsTest extends TestCase
         $this->assertEquals($expected, Utils::is_gutenberg_page());
     }
 
-    /**
-     *
-     */
     public function is_gutenberg_page_provider()
     {
         return [
@@ -49,8 +42,6 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Get the BeyondWords post meta keys.
-     *
      * @since 4.1.0
      *
      * @test
@@ -82,8 +73,6 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Get the BeyondWords post meta keys.
-     *
      * @since 4.1.0
      *
      * @test
@@ -91,7 +80,6 @@ class UtilsTest extends TestCase
     public function get_post_meta_keys_deprecated()
     {
         $keys = [
-            // Deprecated
             'beyondwords_player_content',
             'beyondwords_player_style',
             'beyondwords_title_voice_id',
@@ -121,8 +109,6 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * Get the BeyondWords post meta keys.
-     *
      * @since 4.1.0
      *
      * @test

--- a/tests/phpunit/editor/classic/test-metabox.php
+++ b/tests/phpunit/editor/classic/test-metabox.php
@@ -12,10 +12,7 @@ class MetaboxTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
 
         global $wp_meta_boxes;
         $wp_meta_boxes = null;
@@ -23,9 +20,6 @@ class MetaboxTest extends TestCase
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -62,7 +56,6 @@ class MetaboxTest extends TestCase
      */
     public function render_meta_box_content($expectPlayer, $postArgs)
     {
-        // Set up API credentials for metabox rendering
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -74,15 +67,12 @@ class MetaboxTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // Generate audio checkbox is always rendered.
         $this->assertCount(1, $crawler->filter('p#beyondwords-metabox-generate-audio'));
 
-        // The sections render as headings in the required order.
         $headings = $crawler->filter('h4.beyondwords-metabox__heading')
             ->each(fn ($node) => $node->text());
         $this->assertSame(['Player', 'Content', 'Format', 'Voice', 'Data'], $headings);
 
-        // Each section's primary control is present.
         $this->assertCount(1, $crawler->filter('select#beyondwords_embed'));
         $this->assertCount(1, $crawler->filter('select#beyondwords_source'));
         $this->assertCount(1, $crawler->filter('select#beyondwords_output'));
@@ -93,7 +83,6 @@ class MetaboxTest extends TestCase
 
         wp_delete_post($postId, true);
 
-        // Clean up
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
     }
@@ -144,7 +133,6 @@ class MetaboxTest extends TestCase
      */
     public function render_meta_box_content_with_invalid_post()
     {
-        // Set up API credentials
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -155,7 +143,6 @@ class MetaboxTest extends TestCase
 
         $this->assertEmpty($html);
 
-        // Clean up
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
     }
@@ -163,14 +150,8 @@ class MetaboxTest extends TestCase
     /**
      * A crafted Content ID must not break out of the inline player onload handler.
      *
-     * Regression test for a stored XSS. The Content ID is editable post meta,
-     * saved with only sanitize_text_field() (which keeps double quotes), and was
-     * emitted into the `onload` JS string with esc_attr(). esc_attr() encodes `"`
-     * as `&quot;`, but the browser HTML-decodes the attribute before compiling the
-     * handler, so `&quot;` became a real `"` that closed the JS string literal and
-     * ran the rest of the value as code. player_embed() now JSON-encodes the
-     * config with the HEX flags, so an injected quote is hex-encoded and stays
-     * inside the string literal instead of closing it.
+     * Stored-XSS regression: the browser HTML-decodes the attribute before compiling the
+     * handler, so esc_attr()'s &quot; became a real " — the HEX-flag JSON encoding must hold.
      *
      * @test
      */
@@ -182,15 +163,11 @@ class MetaboxTest extends TestCase
             'post_title' => 'MetaboxTest::player_embed_neutralises_content_id_xss',
         ]);
 
-        // Set the meta after creation so no save_post handler can overwrite the
-        // payload before we render — this keeps the assertions meaningful.
+        // Set meta after creation so no save_post handler can overwrite it before render.
         update_post_meta($postId, 'beyondwords_project_id', 12345);
 
-        // Content IDs are charset-validated on save (Meta::sanitize_content_id), so
-        // update_post_meta() would blank this payload and nothing would render. Write
-        // it straight to the DB instead — a hostile value can now only reach the
-        // renderer via a raw row (legacy data, a direct DB write, or a future
-        // regression), which is exactly the case this escaping defence must survive.
+        // Meta::sanitize_content_id() would blank this payload, so write it straight to
+        // the DB — a raw legacy row is exactly the case this escaping defence must survive.
         $this->store_raw_content_id($postId, $payload);
 
         $html = $this->capture_output(function () use ($postId) {
@@ -203,13 +180,11 @@ class MetaboxTest extends TestCase
         $script = $crawler->filter('#beyondwords-metabox-player script');
         $this->assertCount(1, $script);
 
-        // Crawler::attr() returns the HTML-decoded attribute — exactly what the
-        // browser hands to the JS engine when the onload handler fires.
+        // Crawler::attr() HTML-decodes — exactly what the browser hands the JS engine.
         $onload = $script->attr('onload');
 
-        // The Content ID is still passed to the player, but wp_json_encode() has
-        // hex-encoded its quotes so they stay inside the JS string literal. Assert
-        // the exact encoded value (structural quotes included) is present verbatim.
+        // Quotes are hex-encoded so they stay inside the JS string literal; assert
+        // the exact encoded value is present verbatim.
         $encoded = wp_json_encode(
             $payload,
             JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
@@ -219,16 +194,13 @@ class MetaboxTest extends TestCase
         // The raw break-out sequence (a bare " closing the string) must be absent.
         $this->assertStringNotContainsString('"});alert(document.domain)', $onload);
 
-        // The player is still initialised with the real (decoded) Content ID value.
         $this->assertStringContainsString('new BeyondWords.Player(', $onload);
 
         wp_delete_post($postId, true);
     }
 
     /**
-     * Write a Content ID straight into post meta, bypassing the
-     * Meta::sanitize_content_id() callback registered on the meta key, so a
-     * hostile value can still be put in front of the renderer.
+     * Write a Content ID straight into post meta, bypassing Meta::sanitize_content_id().
      */
     private function store_raw_content_id($post_id, $value)
     {

--- a/tests/phpunit/editor/components/add-player/test-add-player.php
+++ b/tests/phpunit/editor/components/add-player/test-add-player.php
@@ -6,17 +6,11 @@ class AddPlayerTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -93,11 +87,9 @@ class AddPlayerTest extends TestCase
      */
     public function filter_tiny_mce_settings()
     {
-        // No existing styles
         $settings = AddPlayer::filter_tiny_mce_settings([]);
         $this->assertSame(AddPlayer::player_preview_i18n_styles() . ' ', $settings['content_style']);
 
-        // Existing styles
         $settings = AddPlayer::filter_tiny_mce_settings(['content_style' => 'p { color: red; }']);
         $this->assertSame('p { color: red; } ' . AddPlayer::player_preview_i18n_styles() . ' ', $settings['content_style']);
     }

--- a/tests/phpunit/editor/components/block-attributes/test-block-attributes.php
+++ b/tests/phpunit/editor/components/block-attributes/test-block-attributes.php
@@ -6,17 +6,11 @@ class BlockAttributesTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 

--- a/tests/phpunit/editor/components/content-id/test-content-id.php
+++ b/tests/phpunit/editor/components/content-id/test-content-id.php
@@ -50,16 +50,13 @@ class ContentIdTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // Nonce field
         $this->assertCount(1, $crawler->filter('#beyondwords_content_id_nonce'));
 
-        // Text input with empty value
         $input = $crawler->filter('#beyondwords_content_id');
         $this->assertCount(1, $input);
         $this->assertSame('', $input->attr('value'));
         $this->assertSame('beyondwords_content_id', $input->attr('name'));
 
-        // Fetch button
         $button = $crawler->filter('#beyondwords__content-id--fetch');
         $this->assertCount(1, $button);
         $this->assertStringContainsString('Fetch', $button->text());
@@ -170,9 +167,8 @@ class ContentIdTest extends TestCase
                 'postValue' => 'abc<b>def</b>ghi',
                 'expect'    => 'abcdefghi',
             ],
-            // A crafted Content ID must not be able to inject path/query segments
-            // into the authenticated BeyondWords API URL — see the fix in
-            // Meta::sanitize_content_id().
+            // A crafted Content ID must not inject path/query segments into the
+            // authenticated BeyondWords API URL — see Meta::sanitize_content_id().
             'Path traversal + query blanked' => [
                 'postValue' => 'x/../../projects/999/content/abc?force=1',
                 'expect'    => '',

--- a/tests/phpunit/editor/components/generate-audio/test-generate-audio.php
+++ b/tests/phpunit/editor/components/generate-audio/test-generate-audio.php
@@ -11,7 +11,6 @@ class GenerateAudioTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
         unset($_POST, $_REQUEST);
 
@@ -21,7 +20,6 @@ class GenerateAudioTest extends TestCase
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         unset($_POST, $_REQUEST);
 
         wp_dequeue_script('beyondwords-metabox--generate-audio');
@@ -32,7 +30,6 @@ class GenerateAudioTest extends TestCase
 
         delete_option('beyondwords_preselect');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -51,8 +48,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * The classic term-gating script is enqueued (and localized) only for
-     * post types configured with 'terms' mode.
+     * The classic term-gating script is enqueued (and localized) only for 'terms'-mode post types.
      *
      * @test
      */
@@ -73,7 +69,6 @@ class GenerateAudioTest extends TestCase
 
         $this->assertTrue(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
 
-        // The localized payload carries the mode + resolved selected terms.
         $data = wp_scripts()->get_data('beyondwords-metabox--generate-audio', 'data');
         $this->assertStringContainsString('"mode":"terms"', $data);
         $this->assertStringContainsString('"category":[1]', $data);
@@ -82,8 +77,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * 'all' mode still enqueues the script — the state-reflecting caption needs
-     * it — but carries no term-gating preselect payload.
+     * 'all' mode still enqueues the script (the caption needs it) but carries no preselect payload.
      *
      * @test
      */
@@ -102,7 +96,6 @@ class GenerateAudioTest extends TestCase
 
         $this->assertTrue(wp_script_is('beyondwords-metabox--generate-audio', 'enqueued'));
 
-        // No term-gating payload in 'all' mode.
         $data = wp_scripts()->get_data('beyondwords-metabox--generate-audio', 'data');
         $this->assertStringNotContainsString('beyondwordsPreselect', (string) $data);
 
@@ -110,8 +103,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * The block editor handles preselect in React, so the classic script is
-     * never enqueued on a Gutenberg screen.
+     * The block editor handles preselect in React, so the classic script never enqueues there.
      *
      * @test
      */
@@ -136,8 +128,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * 'terms' mode with no usable terms still enqueues the script (for the
-     * caption) but adds no term-gating payload.
+     * 'terms' mode with no usable terms still enqueues the script (for the caption) but no payload.
      *
      * @test
      */
@@ -259,8 +250,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * Delegates to Preselect::should_preselect_for_post, which now honours
-     * both whole-post-type ('all') and term-gated ('terms') preselection.
+     * Delegates to Preselect::should_preselect_for_post, honouring both 'all' and 'terms' modes.
      *
      * @test
      */
@@ -302,8 +292,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * The classic metabox checkbox is checked when preselect matches and no
-     * explicit meta is stored — via Meta::has_generate_audio.
+     * The checkbox is checked when preselect matches and no explicit meta is stored (Meta::has_generate_audio).
      *
      * @test
      */
@@ -326,8 +315,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * The classic metabox checkbox is unchecked when preselect is off and no
-     * explicit meta is stored.
+     * The checkbox is unchecked when preselect is off and no explicit meta is stored.
      *
      * @test
      */
@@ -350,8 +338,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * Terms mode: the classic checkbox is checked when the post has a listed
-     * term, and unchecked when it does not.
+     * Terms mode: the checkbox is checked only when the post has a listed term.
      *
      * @test
      */
@@ -405,8 +392,7 @@ class GenerateAudioTest extends TestCase
     }
 
     /**
-     * The caption reads out the checked state and exposes both label variants
-     * as data attributes for classic-metabox.js to swap between when toggled.
+     * The caption reads the checked state and exposes both label variants for classic-metabox.js to swap.
      *
      * @test
      */
@@ -419,11 +405,9 @@ class GenerateAudioTest extends TestCase
             GenerateAudio::element($post);
         });
 
-        // Both label variants are exposed as data attributes.
         $this->assertStringContainsString('data-label-enabled="Generation enabled"', $html);
         $this->assertStringContainsString('data-label-disabled="Generation disabled"', $html);
 
-        // The rendered caption reads out the (checked) state.
         $this->assertMatchesRegularExpression(
             '/id="beyondwords-generate-audio-label"[^>]*>Generation enabled</s',
             $html

--- a/tests/phpunit/editor/components/inspect-panel/test-inspect-panel.php
+++ b/tests/phpunit/editor/components/inspect-panel/test-inspect-panel.php
@@ -17,10 +17,8 @@ class InspectTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         set_current_screen('index.php');
 
         // save() requires a user who can edit the post.
@@ -32,9 +30,6 @@ class InspectTest extends TestCase
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -94,7 +89,7 @@ class InspectTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // Get post meta including meta_ids, needed below
+        // has_meta() includes the meta_ids needed for the input selectors below.
         $meta = has_meta($post->ID);
 
         foreach ($meta as $data) {
@@ -102,7 +97,7 @@ class InspectTest extends TestCase
                 continue;
             }
 
-            // Remove from post meta array so we can check they are all output later
+            // Remove each rendered key so the assertEmpty() below proves all were output.
             unset($postMeta[$data['meta_key']]);
 
             $nameInput = $crawler->filter('input#beyondwords-inspect-'.$data['meta_id'].'-key');
@@ -113,7 +108,6 @@ class InspectTest extends TestCase
             $valueTextarea = $crawler->filter('textarea#beyondwords-inspect-'.$data['meta_id'].'-value');
 
             if ($data['meta_key'] === 'post_id') {
-                // Special case for WordPress Post ID
                 $expect = "$post->ID";
             } else {
                 $expect = get_post_meta($post->ID, $data['meta_key'], true);
@@ -123,7 +117,6 @@ class InspectTest extends TestCase
             $this->assertEquals($expect, html_entity_decode($valueTextarea->html()));
         }
 
-        // Assert all post meta has been output
         $this->assertEmpty($postMeta);
 
         wp_delete_post($post->ID, true);

--- a/tests/phpunit/editor/components/select-voice/test-select-voice.php
+++ b/tests/phpunit/editor/components/select-voice/test-select-voice.php
@@ -17,24 +17,20 @@ class SelectVoiceTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
         // save() requires a user who can edit the post.
         wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
 
-        // Your set up methods here.
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -87,8 +83,7 @@ class SelectVoiceTest extends TestCase
         $this->assertSame('cy_GB', $languageSelect->filter('option:nth-child(93)')->attr('value'));
         $this->assertSame('Welsh (Welsh)', $languageSelect->filter('option:nth-child(93)')->text());
 
-        // en_US offers several models, so the Model dropdown is visible with a
-        // "Select a model" placeholder leading the buckets (Standard last).
+        // en_US offers several models, so the Model dropdown is visible.
         $modelLabel = $crawler->filter('#beyondwords-metabox-select-voice--model label');
         $this->assertEquals('Model', $modelLabel->text());
 
@@ -142,7 +137,6 @@ class SelectVoiceTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // Model dropdown is visible with every bucket; Bridget's model selected.
         $modelWrapper = $crawler->filter('#beyondwords-metabox-select-voice--model');
         $this->assertStringNotContainsString('display: none', (string) $modelWrapper->attr('style'));
 
@@ -156,15 +150,12 @@ class SelectVoiceTest extends TestCase
             $crawler->filter('#beyondwords_model option[selected]')->attr('value')
         );
 
-        // Voice dropdown is visible and scoped to the selected model: only
-        // Bridget offers Multilingual v2.
         $voiceWrapper = $crawler->filter('#beyondwords-metabox-select-voice--voice-id');
         $this->assertStringNotContainsString('display: none', (string) $voiceWrapper->attr('style'));
 
         $voiceOptions = $crawler->filter('#beyondwords_voice_id option')->each(fn ($node) => $node->text());
         $this->assertSame(['Select a voice', 'Bridget'], $voiceOptions);
 
-        // The persisted voice id stays selected.
         $this->assertSame(
             '9001',
             $crawler->filter('#beyondwords_voice_id option[selected]')->attr('value')
@@ -174,18 +165,16 @@ class SelectVoiceTest extends TestCase
     }
 
     /**
-     * Regression: a failed languages API call returns null (network error,
-     * WP_Error, non-2xx, empty body or invalid JSON). Passed unguarded into
-     * render_language_select()'s array-typed parameter under strict_types this
-     * threw an uncatchable TypeError, crashing the classic-editor metabox. The
-     * language dropdown must now render empty instead of fataling.
+     * Regression: a failed languages API call returns null, which crashed the classic-editor metabox.
+     *
+     * Null hit render_language_select()'s array-typed parameter — an uncatchable
+     * TypeError under strict_types. The dropdown must render empty instead.
      *
      * @test
      */
     public function element_degrades_gracefully_when_languages_api_fails()
     {
-        // Simulate the languages API being unreachable. Priority 1 short-circuits
-        // before the mock API filter, which respects an earlier preempt.
+        // Priority 1 short-circuits before the mock API filter, which respects an earlier preempt.
         $filter = function ($preempt, $args, $url) {
             if (str_contains($url, '/organization/languages')) {
                 return new \WP_Error('http_request_failed', 'Connection refused');
@@ -194,8 +183,7 @@ class SelectVoiceTest extends TestCase
         };
         add_filter('pre_http_request', $filter, 1, 3);
 
-        // No language code, so no voices API call is made — the languages call
-        // is the only one exercised here.
+        // No language code → no voices API call; only the languages call is exercised.
         $post = self::factory()->post->create_and_get([
             'post_title' => 'PostSelectVoiceTest::element_languages_api_fails',
         ]);
@@ -208,38 +196,30 @@ class SelectVoiceTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // The language dropdown still renders, with only the empty "Select a
-        // language…" placeholder option — the failed API yields no languages.
+        // Only the empty placeholder option remains — the failed API yields no languages.
         $languageSelect = $crawler->filter('#beyondwords_language_code');
         $this->assertCount(1, $languageSelect);
         $this->assertCount(1, $languageSelect->filter('option'));
         $this->assertSame('', $languageSelect->filter('option')->attr('value'));
 
-        // Render continued past the language select to the voice select, proving
-        // no TypeError was thrown.
+        // Render reached the voice select — no TypeError was thrown.
         $this->assertCount(1, $crawler->filter('#beyondwords_voice_id'));
 
         wp_delete_post($post->ID, true);
     }
 
     /**
-     * Regression: a non-2xx voices response can carry the BeyondWords API's own
-     * error shape — e.g. {"message": "Too many requests"} on a 429 — which
-     * json_decode()s to ['message' => '<string>']. That passed the top-level
-     * is_array() check, so the string element flowed into the render helpers
-     * (find_voice() / voice_model_key()), which are typed for arrays, and threw
-     * an uncatchable TypeError under strict_types — crashing the classic-editor
-     * metabox mid-render on every load for the duration of an API incident. The
-     * Model/Voice dropdowns must now degrade to empty instead of fataling.
+     * Regression: a voices error body like {"message": "…"} crashed the classic-editor metabox.
+     *
+     * It passes the top-level is_array() check, so its string element hit array-typed
+     * render helpers — an uncatchable TypeError. Dropdowns must degrade to empty.
      *
      * @test
      */
     public function element_degrades_gracefully_when_voices_api_returns_error_object()
     {
-        // Answer the voices request with the API's {"message": ...} error body
-        // and a 429. Priority 1 short-circuits before the mock API filter, which
-        // respects an earlier preempt; the languages request is left to the mock
-        // so only the voices path is exercised here.
+        // Priority 1 short-circuits before the mock API filter; the languages request
+        // stays with the mock so only the voices path is exercised here.
         $filter = function ($preempt, $args, $url) {
             if (str_contains($url, '/organization/voices')) {
                 return [
@@ -272,8 +252,7 @@ class SelectVoiceTest extends TestCase
         // Render reached the Voice select — no TypeError was thrown.
         $this->assertCount(1, $crawler->filter('#beyondwords_voice_id'));
 
-        // The error body yields no voice records, so both dropdowns hide and
-        // carry only their placeholder option.
+        // The error body yields no voice records, so both dropdowns hide with only placeholders.
         $modelWrapper = $crawler->filter('#beyondwords-metabox-select-voice--model');
         $this->assertStringContainsString('display: none', (string) $modelWrapper->attr('style'));
         $this->assertSame(
@@ -301,15 +280,13 @@ class SelectVoiceTest extends TestCase
             SelectVoice::voice_model_key(['service' => 'ElevenLabs', 'model_id' => 'eleven_v3'])
         );
 
-        // Non-ElevenLabs voices, and ElevenLabs voices without a string
-        // model_id, fall into the shared Standard bucket.
+        // Non-ElevenLabs voices, and ElevenLabs voices without a string model_id, bucket as Standard.
         $this->assertSame('standard', SelectVoice::voice_model_key(['name' => 'Ada (Multilingual)']));
         $this->assertSame('standard', SelectVoice::voice_model_key(['service' => 'Azure', 'model_id' => null]));
         $this->assertSame('standard', SelectVoice::voice_model_key(['service' => 'ElevenLabs']));
 
-        // Defensive: a non-record value — e.g. a scalar left by a decoded API
-        // error body — buckets as Standard rather than fataling against the
-        // parameter type. Mirrors the JS `voice?.` guard.
+        // Defensive: a non-record value (e.g. from a decoded API error body) buckets
+        // as Standard rather than fataling. Mirrors the JS `voice?.` guard.
         $this->assertSame('standard', SelectVoice::voice_model_key('Too many requests'));
         $this->assertSame('standard', SelectVoice::voice_model_key(null));
     }

--- a/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
+++ b/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
@@ -272,8 +272,7 @@ class SettingsFieldsTest extends TestCase
         $labels = $crawler->filter('select#beyondwords_embed option')->each(fn ($node) => $node->text());
         $this->assertSame(['None', 'Audio (post)'], $labels);
 
-        // With no stored value the first asset is selected (player shows) rather
-        // than None.
+        // With no stored value the first asset is selected (player shows) rather than None.
         $this->assertSame(
             'audio_post',
             $crawler->filter('select#beyondwords_embed option[selected]')->attr('value')
@@ -393,8 +392,7 @@ class SettingsFieldsTest extends TestCase
     {
         $postId = self::factory()->post->create(['post_title' => 'SettingsFieldsTest::save_cap']);
 
-        // A subscriber cannot edit the post, so nothing is written even with a
-        // valid nonce.
+        // A subscriber cannot edit the post, so nothing is written even with a valid nonce.
         wp_set_current_user(self::factory()->user->create(['role' => 'subscriber']));
 
         $_POST['beyondwords_settings_fields_nonce'] = wp_create_nonce('beyondwords_settings_fields');

--- a/tests/phpunit/player/renderer/test-amp.php
+++ b/tests/phpunit/player/renderer/test-amp.php
@@ -7,27 +7,22 @@ use \Symfony\Component\DomCrawler\Crawler;
 /**
  * Test the Amp player renderer.
  *
- * Note that we are are not testing Amp::check() here due to limitations
- * with mocking the amp_is_request() function in the current test environment.
- * The Amp::check() method is covered by integration tests when the AMP plugin is active.
+ * Amp::check() isn't tested here — amp_is_request() can't be mocked in this
+ * environment; integration tests with the AMP plugin active cover it.
  */
 class AmpTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         delete_option('beyondwords_project_id');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -50,7 +45,6 @@ class AmpTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // <amp-iframe>
         $iframe = $crawler->filter('amp-iframe');
         $this->assertCount(1, $iframe);
         $this->assertSame('0', $iframe->attr('frameborder'));
@@ -61,7 +55,6 @@ class AmpTest extends TestCase
         $this->assertSame($src, $iframe->attr('src'));
         $this->assertSame('295', $iframe->attr('width'));
 
-        // <amp-img>
         $img = $iframe->filter('amp-img');
         $this->assertCount(1, $img);
         $this->assertSame('150', $img->attr('height'));

--- a/tests/phpunit/player/renderer/test-base.php
+++ b/tests/phpunit/player/renderer/test-base.php
@@ -6,27 +6,21 @@ use BeyondWords\Player\Renderer\Base;
 use \Symfony\Component\DomCrawler\Crawler;
 
 /**
- * Class Amp
- *
- * Renders the AMP-compatible BeyondWords player.
+ * Class BaseTest
  */
 class BaseTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         delete_option('beyondwords_project_id');
 
-        // Then...
         parent::tearDown();
     }
 

--- a/tests/phpunit/player/renderer/test-javascript.php
+++ b/tests/phpunit/player/renderer/test-javascript.php
@@ -5,25 +5,17 @@ use BeyondWords\Player\Renderer\Javascript;
 use \Symfony\Component\DomCrawler\Crawler;
 
 /**
- * Class Javascript.
- *
- * Responsible for rendering the JavaScript BeyondWords player.
+ * Class JavascriptTest
  */
 class JavascriptTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -40,8 +32,6 @@ class JavascriptTest extends TestCase
             ],
         ]);
 
-        // setup_postdata($post);
-
         $html = Javascript::render($post);
 
         $crawler = new Crawler($html);
@@ -51,24 +41,14 @@ class JavascriptTest extends TestCase
         $this->assertSame(Urls::get_js_sdk_url(), $script->attr('src'));
         $this->assertNotEmpty($script->attr('onload'));
 
-        // wp_reset_postdata();
-
         wp_delete_post($post->ID, true);
     }
 
     /**
-     * Stored-XSS regression: dangerous characters in a Content ID must never
-     * break out of the single-quoted onload='...' attribute, whatever the value.
+     * Stored-XSS regression: a dangerous Content ID must never break out of the single-quoted onload attribute.
      *
-     * Content IDs are now charset-validated on save (Meta::sanitize_content_id),
-     * so a hostile value can only reach the renderer via a raw row — legacy data,
-     * a direct DB write, or a future regression. We store one straight in the DB,
-     * bypassing the meta sanitiser, to keep the renderer's output-escaping second
-     * line of defence under test.
-     *
-     * Asserts the security *property* — one intact <script> and the value survives
-     * as inert JSON data — rather than a specific escaping mechanism, so it stays
-     * valid if the escaping strategy is ever refactored.
+     * Asserts the security *property* (one intact <script>, value inert JSON), not a
+     * specific escaping mechanism, so refactoring the escaping keeps it valid.
      *
      * @test
      * @dataProvider dangerousContentIdProvider
@@ -88,8 +68,7 @@ class JavascriptTest extends TestCase
 
         $html = Javascript::render($post);
 
-        // A real HTML parser must see exactly one <script> — a breakout would
-        // truncate the attribute and/or inject sibling elements.
+        // A breakout would truncate the attribute and/or inject sibling elements.
         $crawler = new Crawler($html);
         $this->assertCount(1, $crawler->filter('script'));
 
@@ -98,8 +77,7 @@ class JavascriptTest extends TestCase
         $this->assertStringStartsWith('new BeyondWords.Player(', $onload);
         $this->assertStringEndsWith('}});', $onload);
 
-        // The spread params are valid JSON and the payload survived verbatim as a
-        // string value (inert data) — proving it can't execute and isn't corrupted.
+        // Valid JSON with the payload verbatim: inert data, not executable, not corrupted.
         $this->assertSame(1, preg_match('/\.\.\.(\{.*\})\}\);$/', $onload, $matches));
         $params = json_decode($matches[1]);
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
@@ -109,10 +87,9 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * Write a Content ID straight into post meta, bypassing the
-     * Meta::sanitize_content_id() callback registered on the meta key, to
-     * reproduce a hostile value that predates or otherwise circumvents input
-     * validation so the renderer's output escaping stays under test.
+     * Write a Content ID straight into post meta, bypassing Meta::sanitize_content_id().
+     *
+     * Reproduces a hostile legacy/raw row so the renderer's output escaping stays under test.
      */
     private function store_raw_content_id($post_id, $value)
     {
@@ -128,11 +105,9 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * Values that would break out of, or corrupt, the onload attribute if the
-     * renderer didn't neutralise them — quotes, ampersands and Unicode. They no
-     * longer survive the beyondwords_content_id meta sanitiser (which blanks
-     * anything outside [a-zA-Z0-9-]), so the test injects them via a raw DB write
-     * to isolate the renderer's own output-escaping defence. Tag-based payloads
+     * Values that would break out of, or corrupt, the onload attribute.
+     *
+     * The meta sanitiser blanks these, hence the raw DB write; tag-based payloads
      * are covered by render_neutralises_dangerous_sdk_params_from_filter().
      */
     public function dangerousContentIdProvider()
@@ -147,10 +122,10 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * The `beyondwords_player_script_onload` filter output is escaped too, so a
-     * third-party filter that injects raw single quotes cannot break out of the
-     * attribute. This isolates the esc_attr() defense: the filter result bypasses
-     * wp_json_encode(), so the HEX flags do not protect it — only esc_attr() does.
+     * The `beyondwords_player_script_onload` filter output is escaped too.
+     *
+     * The filter result bypasses wp_json_encode(), so the JSON HEX flags do not
+     * protect it — this isolates the esc_attr() defense.
      *
      * @test
      */
@@ -174,8 +149,7 @@ class JavascriptTest extends TestCase
 
         remove_filter('beyondwords_player_script_onload', $filter);
 
-        // esc_attr() + the browser's attribute decoding round-trip to the exact
-        // filter output; a raw-apostrophe breakout would instead truncate it.
+        // The attribute must round-trip to the exact filter output; a breakout would truncate it.
         $crawler = new Crawler($html);
         $this->assertCount(1, $crawler->filter('script'));
         $this->assertSame($injected, $crawler->filter('script')->attr('onload'));
@@ -184,19 +158,16 @@ class JavascriptTest extends TestCase
     }
 
     /**
-     * Defense-in-depth via the beyondwords_player_sdk_params filter — the other
-     * injection vector named in the advisory. Third-party code can put *arbitrary*
-     * unsanitised values into a param (here bypassing the sanitize_text_field()
-     * that strips tags on meta save), so the renderer must neutralise ', ", <, >, &
-     * in the JSON layer (JSON_HEX_APOS|QUOT|TAG|AMP) and still emit one intact
-     * <script> whose params round-trip to the original value.
+     * Defense-in-depth via the beyondwords_player_sdk_params filter, the advisory's other injection vector.
+     *
+     * Filters can inject arbitrary unsanitised values, so the JSON layer itself
+     * (JSON_HEX_APOS|QUOT|TAG|AMP) must neutralise ' " < > &.
      *
      * @test
      */
     public function render_neutralises_dangerous_sdk_params_from_filter()
     {
-        // contentId containing ' " < > & — the quote-style juggling keeps both
-        // quote characters in the value without any backslash escaping.
+        // Quote-style juggling keeps both quote chars in the value without backslash escaping.
         $dangerous = "a'b" . '"c<d>e&f';
         $filter    = static function ($params) use ($dangerous) {
             $params['contentId'] = $dangerous;
@@ -216,8 +187,7 @@ class JavascriptTest extends TestCase
 
         remove_filter('beyondwords_player_sdk_params', $filter);
 
-        // Still exactly one intact script, and the value round-trips as inert JSON
-        // (including the < > tags that the meta sanitiser would otherwise strip).
+        // The value must round-trip as inert JSON — including < >, which the meta sanitiser would strip.
         $crawler = new Crawler($html);
         $this->assertCount(1, $crawler->filter('script'));
         $onload = $crawler->filter('script')->attr('onload');
@@ -226,10 +196,8 @@ class JavascriptTest extends TestCase
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame($dangerous, $params->contentId);
 
-        // Each dangerous character is HEX-encoded in the raw markup; a dropped flag
-        // would surface it in another form (e.g. &#039; or \") and fail the match.
-        // The needle is built from the same encoder so no literal backslashes are
-        // embedded in the test source.
+        // A dropped HEX flag would surface the char in another form (e.g. &#039;) and fail
+        // the match; building needles via the same encoder avoids literal backslashes.
         $hex = static function ($char) {
             return trim(wp_json_encode($char, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP), '"');
         };

--- a/tests/phpunit/player/test-config-builder.php
+++ b/tests/phpunit/player/test-config-builder.php
@@ -6,26 +6,20 @@ use BeyondWords\Player\ConfigBuilder;
 
 /**
  * Class ConfigBuilderTest
- *
- * Constructs the parameters object for the BeyondWords JS SDK.
  */
 class ConfigBuilderTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         delete_option('beyondwords_project_id');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -327,8 +321,7 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * With no Embed chosen, the default for Source=Post × Output=Audio is
-     * "audio_post", which adds no asset params.
+     * With no Embed chosen, Source=Post × Output=Audio defaults to "audio_post" (no asset params).
      *
      * @test
      */
@@ -348,8 +341,7 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * With no Embed chosen, the default for Output=Video is "video_post", which
-     * sets video:true.
+     * With no Embed chosen, Output=Video defaults to "video_post", setting video:true.
      *
      * @test
      */
@@ -369,8 +361,7 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * A stored Embed value that no longer fits the current Source × Output falls
-     * back to None — no asset params are emitted.
+     * A stored Embed that no longer fits the current Source × Output falls back to None.
      *
      * @test
      */
@@ -417,8 +408,7 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * Embed asset params compose with Magic Embed (client-side) mode, where the
-     * post has no content ID so the SDK fetches by source ID.
+     * Embed asset params compose with Magic Embed — no content ID, so the SDK fetches by source ID.
      *
      * @test
      */

--- a/tests/phpunit/player/test-player.php
+++ b/tests/phpunit/player/test-player.php
@@ -9,9 +9,8 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class PlayerTest extends TestCase
 {
-    // The structural JSON quotes are emitted as &quot; because the renderer now
-    // esc_attr()s the onload value (the browser decodes them back to " for the JS
-    // engine). See BeyondWords\Player\Renderer\Javascript::render().
+    // Structural JSON quotes appear as &quot; — the renderer esc_attr()s the onload value
+    // and the browser decodes them back. See BeyondWords\Player\Renderer\Javascript::render().
     public const PLAYER_HTML_FORMAT = '<script data-beyondwords-player-context="%s" async defer src="https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js" onload=\'new BeyondWords.Player({target:this, ...{&quot;projectId&quot;:9969,&quot;contentId&quot;:&quot;9279c9e0-e0b5-4789-9040-f44478ed3e9e&quot;}});\'></script>';
 
     /**
@@ -24,10 +23,8 @@ class PlayerTest extends TestCase
 
         do_action('wp_loaded');
 
-        // Actions
         $this->assertEquals(10, has_action('init', array(Player::class, 'register_shortcodes')));
 
-        // Filters
         $this->assertEquals(1000000, has_filter('the_content', array(Player::class, 'auto_prepend_player')));
         $this->assertEquals(10, has_filter('newsstand_the_content', array(Player::class, 'auto_prepend_player')));
     }
@@ -123,12 +120,10 @@ class PlayerTest extends TestCase
 
         $output = Player::auto_prepend_player($content);
 
-        // We are now is_singular() so player should be prepended
         $this->assertSame(sprintf(self::PLAYER_HTML_FORMAT, 'auto') . $content, $output);
 
-        // Player UI = Disabled makes is_enabled() false, so auto_prepend_player()
-        // now short-circuits (before the has_custom_player() DOM scan) and returns
-        // the content unchanged — no player is prepended.
+        // Player UI = Disabled makes is_enabled() false, so auto_prepend_player() short-circuits
+        // (before the has_custom_player() DOM scan) and returns the content unchanged.
         update_option(Fields::OPTION_PLAYER_UI, Fields::PLAYER_UI_DISABLED);
         $this->assertSame($content, Player::auto_prepend_player($content));
         delete_option(Fields::OPTION_PLAYER_UI);
@@ -168,7 +163,6 @@ class PlayerTest extends TestCase
 
         $output = Player::replace_legacy_custom_player($content);
 
-        // We are now is_singular() so player div should be replaced with player shortcode
         $this->assertSame($expected, $output);
 
         wp_reset_postdata();
@@ -274,10 +268,8 @@ class PlayerTest extends TestCase
                 "<p>Before</p>\n<div data-foo=\"data-beyondwords-player\"></div>\n<p>After</p>",
                 "<p>Before</p>\n<div data-foo=\"data-beyondwords-player\"></div>\n<p>After</p>",
             ],
-            // Note: HTML comments are NOT handled specially by the regex.
-            // This is a known limitation but is acceptable because:
-            // 1. It's extremely unlikely someone would put a player div in a comment
-            // 2. Even if replaced, the shortcode in a comment won't render (invisible to users)
+            // HTML comments are NOT handled specially by the regex — an acceptable known
+            // limitation: a shortcode inside a comment never renders anyway.
             'HTML comment with player div - known limitation' => [
                 "<p>Before</p>\n<!-- <div data-beyondwords-player=\"true\"></div> -->\n<p>After</p>",
                 "<p>Before</p>\n<!-- [beyondwords_player] -->\n<p>After</p>",
@@ -365,7 +357,6 @@ class PlayerTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // <div id="wrapper">
         $wrapper = $crawler->filter('#wrapper');
         $this->assertCount(1, $wrapper);
         $this->assertSame("$post->ID", $wrapper->attr('data-post-id'));
@@ -440,13 +431,11 @@ class PlayerTest extends TestCase
             'Legacy player with contenteditable attribute' => [true, '<p>Before.</p><div data-beyondwords-player="true" contenteditable="false"></div><p>After.</p>'],
             'New player shortcode' => [true, '<p>Before.</p>[beyondwords_player]<p>After.</p>'],
             'New player shortcode with project_id attribute' => [true, '<p>Before.</p>[beyondwords_player project_id="1234"]<p>After.</p>'],
-            // SDK <script> markup counts as a custom player — this is the only path
-            // gated by the get_js_sdk_url() substring in the has_custom_player()
-            // fast-path guard, so keep it covered.
+            // SDK <script> markup is the only path gated by the get_js_sdk_url() substring
+            // in the has_custom_player() fast-path guard, so keep it covered.
             'JS SDK player script' => [true, '<p>Before.</p><script async defer src="' . $sdkUrl . '"></script><p>After.</p>'],
-            // The SDK URL appearing as plain text passes the cheap substring guard
-            // but must still resolve to false via the XPath — proving the guard is a
-            // pre-filter, not a replacement for the parse.
+            // The SDK URL as plain text passes the cheap substring guard but must still
+            // resolve to false via the XPath — the guard is a pre-filter, not the parse.
             'SDK URL in text only, no script tag' => [false, '<p>Listen via ' . $sdkUrl . '</p>'],
         ];
     }

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -8,12 +8,10 @@ class ContentTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // A project id is required for Client::get_video_settings() (used when
-        // building the video_settings payload) to resolve a project and return
-        // the mocked defaults rather than false.
+        // Client::get_video_settings() needs a project id to resolve a project and
+        // return the mocked defaults rather than false.
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
     }
@@ -23,7 +21,6 @@ class ContentTest extends TestCase
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
-        // Then...
         parent::tearDown();
     }
 
@@ -107,9 +104,8 @@ class ContentTest extends TestCase
             'post_content' => $content,
         ]);
 
-        // Newer Gutenberg adds class="wp-block-paragraph" to rendered
-        // paragraphs; strip it so the assertion tracks block-exclusion logic,
-        // not core markup churn.
+        // Newer Gutenberg adds class="wp-block-paragraph"; strip it so the assertion
+        // tracks block-exclusion logic, not core markup churn.
         $actual = str_replace(' class="wp-block-paragraph"', '', Content::get_content_without_excluded_blocks($post));
 
         $this->assertSame($expect, $actual);
@@ -145,12 +141,9 @@ class ContentTest extends TestCase
     /**
      * @test
      *
-     * Passing a post ID (int) must behave identically to passing the WP_Post
-     * object — the method resolves the argument internally like its siblings.
-     *
-     * Regression test: previously an int argument fell straight through to
-     * `$post->post_content`, emitting a PHP warning ("Attempt to read property
-     * on int") and returning an empty string instead of the post content.
+     * Passing a post ID (int) must behave identically to passing the WP_Post object.
+     * Regression: an int fell through to `$post->post_content`, emitting a PHP
+     * warning and returning an empty string instead of the content.
      */
     public function get_content_without_excluded_blocks_accepts_post_id()
     {
@@ -194,7 +187,7 @@ class ContentTest extends TestCase
      */
     public function get_post_body($postType, $postContent, $expected)
     {
-        // A shortcode which tests both attribues and content
+        // A shortcode which tests both attributes and content
         add_shortcode('shortcode_test', function($atts, $content="") {
             return sprintf('<em>%s, %s, %s</em>', strtolower($atts['to_lower']), strtoupper($atts['to_upper']), $content);
         });
@@ -314,19 +307,15 @@ class ContentTest extends TestCase
         ];
     }
 
-    /**
-     *
-     */
     public function exported_data_helper($path)
     {
         $handle = fopen($path, 'r');
 
         $output = [];
 
-        // Ignore first line of CSV
+        // Skip the CSV header line.
         fgetcsv($handle, 0, ',', '"', "\0");
 
-        // Process remaining lines
         while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
             // Only test Posts with a state of "Processed"
             if (strtolower($data[11]) == 'processed') {
@@ -337,9 +326,6 @@ class ContentTest extends TestCase
         return $output;
     }
 
-    /**
-     *
-     */
     public function has_generate_audio_provider()
     {
         return [
@@ -362,7 +348,6 @@ class ContentTest extends TestCase
      **/
     public function get_content_params()
     {
-        // Create the user
         $user = self::factory()->user->create_and_get([
             'role' => 'editor',
             'display_name' => 'Jane Smith',
@@ -502,12 +487,10 @@ class ContentTest extends TestCase
         $this->assertArrayHasKey('video_settings', $body);
         $this->assertTrue($body['video_settings']['enabled']);
 
-        // The backend skips generation unless `variants` is non-empty, so we
-        // echo the project defaults.
+        // The backend skips generation unless `variants` is non-empty, so we echo the project defaults.
         $this->assertSame(['article', 'summary'], $body['video_settings']['variants']);
 
-        // The full project `sizes` are sent (each carrying width/height), with
-        // only the chosen size enabled.
+        // Full project `sizes` are sent (with width/height); only the chosen size is enabled.
         $this->assertSame(
             [
                 ['name' => 'landscape', 'width' => 1920, 'height' => 1080, 'enabled' => true],
@@ -571,11 +554,8 @@ class ContentTest extends TestCase
      *
      * @group getContentParams
      *
-     * Regression test: the plugin previously sent a partial payload (only
-     * `enabled` + `template.id` + `sizes[].name`/`enabled`) which left `variants`
-     * empty server-side, so the BeyondWords backend silently skipped video
-     * generation. The full object must always carry non-empty `variants` and
-     * `sizes` whose entries include `width`/`height`.
+     * Regression: a partial payload left `variants` empty server-side, so the backend
+     * silently skipped video generation. Must carry non-empty variants and full sizes.
      **/
     public function get_content_params_video_settings_always_carry_variants_and_sized_entries()
     {
@@ -639,7 +619,6 @@ class ContentTest extends TestCase
      **/
     public function get_content_params_for_pending_review_status()
     {
-        // Create the user
         $user = self::factory()->user->create_and_get([
             'role' => 'editor',
             'display_name' => 'Jane Smith',
@@ -672,13 +651,9 @@ class ContentTest extends TestCase
         $this->assertArrayHasKey('published', $body);
         $this->assertFalse($body['published']);
 
-        /*
-         * Posts with "Pending Review" status will not have a `publish_date` date because
-         * get_post_time() returns `false` for posts which are "Pending Review".
-         */
+        // No `publish_date`: get_post_time() returns false for "Pending Review" posts.
         $this->assertArrayNotHasKey('publish_date', $body);
 
-        // Set auto-publish to false
         update_option('beyondwords_project_auto_publish_enabled', false);
 
         $body = Content::get_content_params($postId);
@@ -707,10 +682,8 @@ class ContentTest extends TestCase
         ]);
 
         $filter = function($params, $postId) {
-            // Custom body
             $params['body'] = '[POST ID: ' . $postId. ']' . $params['body'] . '[ADDED AFTER]';
 
-            // Custom metadata
             $params['metadata']->custom = $postId;
 
             return $params;
@@ -763,13 +736,11 @@ class ContentTest extends TestCase
         $flatTaxonomy = 'flat';
         $hierarchicalTaxonomy = 'hierarchical';
 
-        // Create flat taxonomy & terms (Tag-like)
         register_taxonomy($flatTaxonomy, 'post');
         foreach (['flat1', 'flat2', 'flat3'] as $term) {
             wp_insert_term($term, $flatTaxonomy);
         }
 
-        // Create hierarchical taxonomy & terms (Category-like)
         register_taxonomy($hierarchicalTaxonomy, 'post', ['hierarchical' => true]);
         $hierarchicalTerms = [];
         foreach (['hier1', 'hier2', 'hier3'] as $term) {
@@ -782,7 +753,6 @@ class ContentTest extends TestCase
 
         wp_set_current_user($editor);
 
-        // Create a post with selected terms
         $postId = self::factory()->post->create([
             'post_title' => 'Testing Content::get_all_taxonomies_and_terms()',
             'post_status' => 'publish',
@@ -818,7 +788,6 @@ class ContentTest extends TestCase
     {
         $name = 'Jane Smith';
 
-        // Create the user
         $user = self::factory()->user->create_and_get([
             'role' => 'editor',
             'display_name' => $name,

--- a/tests/phpunit/post/test-head.php
+++ b/tests/phpunit/post/test-head.php
@@ -15,7 +15,6 @@ class HeadTest extends TestCase
     {
         parent::setUp();
 
-        // Create a test post
         $this->postId = self::factory()->post->create([
             'post_title' => 'Test Post Title',
             'post_author' => 1,
@@ -54,7 +53,6 @@ class HeadTest extends TestCase
      */
     public function add_meta_tags_does_nothing_on_non_singular_page(): void
     {
-        // Simulate archive page
         $this->go_to('/');
 
         $html = $this->capture_output(function () {
@@ -69,11 +67,9 @@ class HeadTest extends TestCase
      */
     public function add_meta_tags_does_nothing_without_project_id(): void
     {
-        // Ensure no project ID is set
         delete_post_meta($this->postId, 'beyondwords_project_id');
         delete_option('beyondwords_project_id');
 
-        // Go to singular post
         $this->go_to(get_permalink($this->postId));
 
         $html = $this->capture_output(function () {
@@ -136,7 +132,6 @@ class HeadTest extends TestCase
 
         $this->assertStringContainsString('name="beyondwords-author"', $html);
         $this->assertStringContainsString('data-beyondwords-author=', $html);
-        // Should contain the author's display name
         $this->assertNotEmpty($html);
     }
 
@@ -155,7 +150,7 @@ class HeadTest extends TestCase
 
         $this->assertStringContainsString('name="beyondwords-publish-date"', $html);
         $this->assertStringContainsString('data-beyondwords-publish-date=', $html);
-        // Date should be in ISO 8601 format (contains 'T' for time separator)
+        // ISO 8601 expected — the 'T' is the date/time separator.
         $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}T/', $html);
     }
 
@@ -250,9 +245,8 @@ class HeadTest extends TestCase
             Head::add_meta_tags();
         });
 
-        // Should escape HTML entities (WordPress may use smart quotes &#8220; instead of literal quotes)
+        // No exact-string match: WordPress may swap in smart quotes (&#8220;) while escaping.
         $this->assertStringNotContainsString('<script>', $html, 'Should not contain unescaped script tag');
-        // The escaped output should be safe for HTML attributes
         $this->assertMatchesRegularExpression('/content="[^"]*alert[^"]*"/', $html, 'Should have escaped content in attribute');
     }
 
@@ -261,7 +255,6 @@ class HeadTest extends TestCase
      */
     public function integration_full_meta_tags_output(): void
     {
-        // Set up all possible meta values
         update_post_meta($this->postId, 'beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
         update_post_meta($this->postId, 'beyondwords_body_voice_id', 222);
         update_post_meta($this->postId, 'beyondwords_language_code', 'en');
@@ -272,14 +265,12 @@ class HeadTest extends TestCase
             Head::add_meta_tags();
         });
 
-        // Should contain all meta tags
         $this->assertStringContainsString('beyondwords-title', $html);
         $this->assertStringContainsString('beyondwords-author', $html);
         $this->assertStringContainsString('beyondwords-publish-date', $html);
         $this->assertStringContainsString('beyondwords-body-voice-id', $html);
         $this->assertStringContainsString('beyondwords-article-language', $html);
 
-        // Should have the body voice value
         $this->assertStringContainsString('222', $html);
     }
 }

--- a/tests/phpunit/post/test-meta.php
+++ b/tests/phpunit/post/test-meta.php
@@ -14,17 +14,11 @@ class MetaTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -50,9 +44,6 @@ class MetaTest extends TestCase
         wp_delete_post($postId, true);
     }
 
-    /**
-     *
-     */
     public function get_project_id_with_plugin_setting_provider()
     {
         return [
@@ -84,9 +75,6 @@ class MetaTest extends TestCase
         wp_delete_post($postId, true);
     }
 
-    /**
-     *
-     */
     public function get_project_id_without_plugin_setting_provider()
     {
         return [
@@ -103,8 +91,7 @@ class MetaTest extends TestCase
     }
 
     /**
-     * Test a Post's Project ID remains fixed after the plugin
-     * Project ID setting changes.
+     * A Post's Project ID remains fixed after the plugin Project ID setting changes.
      *
      * @test
      */
@@ -125,10 +112,8 @@ class MetaTest extends TestCase
             'post_title' => 'UtilsTest:getProjectIdWhenSettingChanges::2',
         ]);
 
-        // The first Post should still have the original Project ID
         $this->assertEquals(1234, Meta::get_project_id($firstPostId));
 
-        // The second Post should be using the updated plugin setting
         $this->assertEquals(5678, Meta::get_project_id($secondPostId));
 
         delete_option('beyondwords_project_id');
@@ -155,9 +140,6 @@ class MetaTest extends TestCase
         wp_delete_post($postId, true);
     }
 
-    /**
-     *
-     */
     public function get_content_id_provider()
     {
         return [
@@ -186,9 +168,8 @@ class MetaTest extends TestCase
     }
 
     /**
-     * A Content ID is interpolated into BeyondWords API URL paths, so only the
-     * `[a-zA-Z0-9\-]+` charset the inspect REST route allows may be stored —
-     * anything with path/query characters is blanked to defeat URL injection.
+     * Content IDs are interpolated into API URL paths, so only `[a-zA-Z0-9\-]+` may be
+     * stored — path/query characters are blanked to defeat URL injection.
      *
      * @test
      * @dataProvider sanitize_content_id_provider
@@ -246,9 +227,6 @@ class MetaTest extends TestCase
         delete_option('beyondwords_project_id');
     }
 
-    /**
-     *
-     */
     public function get_http_response_body_from_post_meta_provider()
     {
         $json = '{"foo":"bar","baz":42}';
@@ -261,14 +239,7 @@ class MetaTest extends TestCase
     }
 
     /**
-     * Legacy `speechkit_response` meta that was stored as a WordPress HTTP response
-     * array or a WP_Error object (plugin ~3.x) must be read back without a fatal error.
-     *
-     * These non-scalar shapes cannot be seeded via `meta_input` / update_post_meta,
-     * because Sync::register_meta() registers `speechkit_response` with a
-     * `sanitize_text_field` sanitize_callback that coerces any write to a string. Real
-     * legacy rows predate that registration, so we reproduce them by writing the
-     * serialized value straight to wp_postmeta — exactly as an old plugin version did.
+     * Legacy `speechkit_response` meta stored as an HTTP response array or WP_Error (~3.x) must read back without fataling.
      *
      * @test
      * @dataProvider get_http_response_body_from_post_meta_legacy_provider
@@ -284,8 +255,8 @@ class MetaTest extends TestCase
 
         $postId = self::factory()->post->create(['post_title' => 'MetaTest:getHttpResponseBodyFromPostMetaLegacy']);
 
-        // Write the serialized value directly, bypassing the registered sanitize_callback,
-        // to mimic a legacy row already present in the database.
+        // Write the serialized value directly — Sync::register_meta()'s sanitize_callback
+        // coerces update_post_meta() writes to strings, but real legacy rows predate it.
         $wpdb->insert(
             $wpdb->postmeta,
             [
@@ -303,9 +274,6 @@ class MetaTest extends TestCase
         delete_option('beyondwords_project_id');
     }
 
-    /**
-     *
-     */
     public function get_http_response_body_from_post_meta_legacy_provider()
     {
         $json = '{"foo":"bar","baz":42}';
@@ -325,19 +293,15 @@ class MetaTest extends TestCase
         ];
     }
 
-    /**
-     *
-     */
     public function exported_data_helper($path)
     {
         $handle = fopen($path, 'r');
 
         $output = [];
 
-        // Ignore first line of CSV
+        // Skip the CSV header line.
         fgetcsv($handle, 0, ',', '"', "\0");
 
-        // Process remaining lines
         while (($data = fgetcsv($handle, 0, ',', '"', "\0")) !== false) {
             // Only test Posts with a state of "Processed"
             if (strtolower($data[11]) == 'processed') {
@@ -349,8 +313,6 @@ class MetaTest extends TestCase
     }
 
     /**
-     * Test if we can get a content ID from all the various places it can be.
-     *
      * @test
      * @dataProvider has_generate_audio_provider
      *
@@ -359,9 +321,8 @@ class MetaTest extends TestCase
      */
     public function has_generate_audio($expected, $postArgs)
     {
-        // Isolate the meta-reading + fallback from the preselect setting, whose
-        // default ('post' => all) would otherwise make an empty-meta post
-        // preselect. Preselect-driven behaviour is covered in PreselectTest.
+        // Isolate the meta fallback from the preselect setting, whose default ('post' => all)
+        // would otherwise make an empty-meta post preselect. PreselectTest covers that path.
         update_option('beyondwords_preselect', []);
 
         $postId = self::factory()->post->create($postArgs);
@@ -372,9 +333,6 @@ class MetaTest extends TestCase
         delete_option('beyondwords_preselect');
     }
 
-    /**
-     *
-     */
     public function has_generate_audio_provider()
     {
         return [
@@ -391,8 +349,7 @@ class MetaTest extends TestCase
     }
 
     /**
-     * Test removeAllBeyondwordsMetadata removes all BeyondWords keys
-     * without affecting other post meta.
+     * removeAllBeyondwordsMetadata removes all BeyondWords keys without touching other post meta.
      *
      * @since 6.0.1
      *
@@ -404,9 +361,8 @@ class MetaTest extends TestCase
             'post_title' => 'MetaTest:removeAllBeyondwordsMetadata',
         ]);
 
-        // Set all BeyondWords meta keys. Use a hyphen rather than an underscore so
-        // the value survives beyondwords_content_id's strict sanitiser
-        // (Meta::sanitize_content_id) while remaining valid for every other key.
+        // 'test-value' uses a hyphen so it survives beyondwords_content_id's strict
+        // sanitiser (Meta::sanitize_content_id) while staying valid for every other key.
         $beyondwordsKeys = Utils::get_post_meta_keys('all');
 
         foreach ($beyondwordsKeys as $key) {
@@ -417,7 +373,6 @@ class MetaTest extends TestCase
         $customKey = 'my_custom_meta_key';
         update_post_meta($postId, $customKey, 'custom_value');
 
-        // Verify all keys are set
         foreach ($beyondwordsKeys as $key) {
             $this->assertNotEmpty(
                 get_post_meta($postId, $key, true),
@@ -426,10 +381,8 @@ class MetaTest extends TestCase
         }
         $this->assertEquals('custom_value', get_post_meta($postId, $customKey, true));
 
-        // Remove all BeyondWords metadata
         Meta::remove_all_beyondwords_metadata($postId);
 
-        // Verify all BeyondWords keys are removed
         foreach ($beyondwordsKeys as $key) {
             $this->assertEmpty(
                 get_post_meta($postId, $key, true),
@@ -437,7 +390,6 @@ class MetaTest extends TestCase
             );
         }
 
-        // Verify non-BeyondWords key is still present
         $this->assertEquals(
             'custom_value',
             get_post_meta($postId, $customKey, true),

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -9,17 +9,11 @@ class SyncTest extends TestCase
 {
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -229,9 +223,6 @@ class SyncTest extends TestCase
         delete_option('beyondwords_project_id');
     }
 
-    /**
-     *
-     */
     public function should_process_post_status_provider() {
         return [
             'draft' => [
@@ -415,9 +406,6 @@ class SyncTest extends TestCase
         remove_filter('beyondwords_settings_post_statuses', $filter);
     }
 
-    /**
-     *
-     */
     public function post_statuses_to_process_provider() {
         return [
             'pending' => ['pending'],
@@ -427,9 +415,6 @@ class SyncTest extends TestCase
         ];
     }
 
-    /**
-     *
-     */
     public function post_statuses_to_exclude_provider() {
         return [
             'draft' => ['draft'],
@@ -518,9 +503,8 @@ class SyncTest extends TestCase
         $this->assertSame($language, get_post_meta($postId, 'beyondwords_language_code', true));
         $this->assertSame($bodyVoiceId, get_post_meta($postId, 'beyondwords_body_voice_id', true));
 
-        // `language` and `body_voice_id` are no longer copied back from the API
-        // response — those meta keys hold the editor's explicit choices, so the
-        // resolved project defaults must not overwrite them (asserted above).
+        // `language`/`body_voice_id` are not copied back from the response — those keys
+        // hold the editor's explicit choices, which project defaults must not overwrite.
 
         // Deprecated keys are no longer copied from the API response.
         $this->assertSame('', get_post_meta($postId, 'beyondwords_summary_voice_id', true));
@@ -627,12 +611,8 @@ class SyncTest extends TestCase
     }
 
     /**
-     * Meta registered with `show_in_rest` is readable by anyone in the `view`
-     * context — WP performs no capability check there. This test locks in that
-     * secrets and internal data never reach the REST API (registered
-     * `show_in_rest => false`), that the sensitive keys the block editor does
-     * need are stripped from unauthenticated responses, and that an authenticated
-     * editor still sees them via the `edit` context.
+     * Meta with `show_in_rest` is readable by anyone in the `view` context (no capability
+     * check) — secrets stay unregistered or stripped publicly; `edit` context keeps them.
      *
      * @test
      */
@@ -709,18 +689,15 @@ class SyncTest extends TestCase
         // But the secret access key is never exposed, even to editors.
         $this->assertArrayNotHasKey('speechkit_access_key', $meta);
 
-        // Reset the current user before deleting it, so we don't leave the
-        // global pointing at a user row that no longer exists.
+        // Reset the current user before deleting it so the global doesn't point at a missing row.
         wp_set_current_user(0);
         wp_delete_user($editorId);
         wp_delete_post($postId, true);
     }
 
     /**
-     * The beyondwords_content_id meta is registered with a strict sanitize
-     * callback so the block-editor / REST write path can't persist a Content ID
-     * that would inject path or query segments into an authenticated BeyondWords
-     * API URL (see Meta::sanitize_content_id).
+     * beyondwords_content_id has a strict sanitize callback so the REST write path can't
+     * persist a Content ID that injects URL path/query segments (Meta::sanitize_content_id).
      *
      * @test
      */
@@ -744,7 +721,6 @@ class SyncTest extends TestCase
     }
 
     function remove_delete_actions($core) {
-        // Actions for deleting/trashing/restoring posts
         remove_action('before_delete_post', array($core, 'onDeletePost'));
     }
 
@@ -841,8 +817,7 @@ class SyncTest extends TestCase
             ],
         ]);
 
-        // When meta_key is null (e.g. when get_post_meta is called without a key),
-        // the function should return the value unchanged
+        // A null meta_key (get_post_meta without a key) must return the value unchanged.
         $this->assertNull(Sync::get_lang_code_from_json_if_empty(null, $postId, null));
         $this->assertSame('foo', Sync::get_lang_code_from_json_if_empty('foo', $postId, null));
         $this->assertSame(['bar'], Sync::get_lang_code_from_json_if_empty(['bar'], $postId, null));
@@ -980,7 +955,6 @@ class SyncTest extends TestCase
             ],
         ]);
 
-        // Save the original state to restore later
         $hadMetaBoxLoader = isset($_REQUEST['meta-box-loader']);
         $originalMetaBoxLoader = $hadMetaBoxLoader ? $_REQUEST['meta-box-loader'] : null;
 
@@ -990,10 +964,8 @@ class SyncTest extends TestCase
 
             $result = Sync::on_add_or_update_post($postId);
 
-            // Should return false without making any API calls
             $this->assertFalse($result);
         } finally {
-            // Restore original state
             if ($hadMetaBoxLoader) {
                 $_REQUEST['meta-box-loader'] = $originalMetaBoxLoader;
             } else {
@@ -1023,20 +995,16 @@ class SyncTest extends TestCase
             ],
         ]);
 
-        // Save the original state to restore later
         $hadMetaBoxLoader = isset($_REQUEST['meta-box-loader']);
         $originalMetaBoxLoader = $hadMetaBoxLoader ? $_REQUEST['meta-box-loader'] : null;
 
         try {
-            // Ensure meta-box-loader is not set
             unset($_REQUEST['meta-box-loader']);
 
             $result = Sync::on_add_or_update_post($postId);
 
-            // Should not be false — the method should proceed to generateAudioForPost
             $this->assertTrue($result);
         } finally {
-            // Restore original state
             if ($hadMetaBoxLoader) {
                 $_REQUEST['meta-box-loader'] = $originalMetaBoxLoader;
             } else {
@@ -1069,7 +1037,7 @@ class SyncTest extends TestCase
 
         $revisionId = wp_save_post_revision($postId);
 
-        // Intercept any HTTP request — if deleteAudio fires, this will record it
+        // Spy on HTTP — if deleteAudio fires, this records it.
         $apiCalled = false;
         $filter = function () use (&$apiCalled) {
             $apiCalled = true;
@@ -1081,7 +1049,7 @@ class SyncTest extends TestCase
 
         remove_filter('pre_http_request', $filter);
 
-        // The revision has no BeyondWords content, so no API call should have been made
+        // Revisions are skipped, so no API call should have been made.
         $this->assertFalse($apiCalled);
 
         wp_delete_post($postId, true);
@@ -1170,7 +1138,6 @@ class SyncTest extends TestCase
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
-        // Post with no BeyondWords meta
         $postId = self::factory()->post->create([
             'post_title' => 'CoreTest::onTrashPostSkipsPostsWithoutContent',
         ]);
@@ -1221,16 +1188,13 @@ class SyncTest extends TestCase
 
         remove_filter('pre_http_request', $filter);
 
-        // Should have recovered by creating new content
         $this->assertIsArray($response);
         $this->assertArrayHasKey('id', $response);
 
-        // The stale content ID should have been replaced with a new one
         $newContentId = get_post_meta($postId, 'beyondwords_content_id', true);
         $this->assertNotEmpty($newContentId);
         $this->assertNotEquals($staleContentId, $newContentId);
 
-        // No error message should remain
         $this->assertEmpty(get_post_meta($postId, 'beyondwords_error_message', true));
 
         wp_delete_post($postId, true);
@@ -1268,11 +1232,9 @@ class SyncTest extends TestCase
 
         remove_filter('pre_http_request', $filter);
 
-        // Legacy ID fields should be cleared
         $this->assertEmpty(get_post_meta($postId, 'beyondwords_podcast_id', true));
         $this->assertEmpty(get_post_meta($postId, 'speechkit_podcast_id', true));
 
-        // New content ID should be set
         $newContentId = get_post_meta($postId, 'beyondwords_content_id', true);
         $this->assertNotEmpty($newContentId);
         $this->assertNotEquals($staleContentId, $newContentId);
@@ -1427,8 +1389,7 @@ class SyncTest extends TestCase
 
         $result = Sync::on_add_or_update_post($postId);
 
-        // The save returns immediately: the job is queued and no content ID is
-        // written yet.
+        // The save returns immediately: the job is queued and no content ID is written yet.
         $this->assertTrue($result);
         $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
         $this->assertSame('', get_post_meta($postId, 'beyondwords_content_id', true));
@@ -1462,9 +1423,8 @@ class SyncTest extends TestCase
         // trashed/deleted between a deferred job being queued and the cron firing.
         wp_delete_post($postId, true);
 
-        // Regression: this previously threw an uncaught TypeError under
-        // strict_types because get_post_status() returns false for a missing post
-        // and should_process_post_status() requires a non-nullable string.
+        // Regression: an uncaught TypeError under strict_types — get_post_status() returns
+        // false for a missing post but should_process_post_status() requires a string.
         $this->assertFalse(Sync::should_generate_audio_for_post($postId));
 
         delete_option('beyondwords_api_key');
@@ -1487,8 +1447,7 @@ class SyncTest extends TestCase
 
         wp_delete_post($postId, true);
 
-        // The deferred cron callback must no-op rather than fatal when its post
-        // has already been removed.
+        // The deferred cron callback must no-op rather than fatal when its post is gone.
         $this->assertFalse(Sync::generate_audio_for_post($postId));
 
         delete_option('beyondwords_api_key');
@@ -1679,8 +1638,7 @@ class SyncTest extends TestCase
 
         remove_filter('pre_http_request', $filter, 1);
 
-        // Off-VIP the DELETE runs inline, bounded by the short delete timeout, and
-        // nothing is queued.
+        // Off-VIP the DELETE runs inline, bounded by the short timeout; nothing is queued.
         $this->assertSame('DELETE', $captured['method']);
         $this->assertSame(\BeyondWords\Api\Client::DEFAULT_REQUEST_TIMEOUT, $captured['timeout']);
         $this->assertFalse(wp_next_scheduled(Sync::DELETE_AUDIO_CRON_HOOK, [$projectId, $contentId]));

--- a/tests/phpunit/posts-list/test-bulk-edit-ajax.php
+++ b/tests/phpunit/posts-list/test-bulk-edit-ajax.php
@@ -5,14 +5,8 @@ use BeyondWords\PostsList\BulkEdit;
 /**
  * AJAX response/error handling for BulkEdit::save_bulk_edit().
  *
- * save_bulk_edit() always terminates the request via wp_send_json_success() /
- * wp_send_json_error() (both call wp_die()), so it is exercised through
- * WP_Ajax_UnitTestCase. That base pretends DOING_AJAX is true, routes wp_die()
- * to a handler that captures the JSON body into $this->_last_response and throws
- * a WPAjaxDie*Exception, and suppresses the "headers already sent" warning that
- * wp_send_json() would otherwise raise under PHPUnit.
- *
- * The non-AJAX BulkEdit tests live in test-bulk-edit.php.
+ * save_bulk_edit() always terminates via wp_send_json_*() (wp_die()), so it runs under
+ * WP_Ajax_UnitTestCase, which captures the JSON body. Non-AJAX tests: test-bulk-edit.php.
  */
 final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
 {
@@ -23,8 +17,7 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
         $_POST = [];
         $this->_last_response = '';
 
-        // save_bulk_edit() requires the edit_posts capability, so default these
-        // tests to a capable user. Capability-specific tests override the role.
+        // save_bulk_edit() requires edit_posts, so default to a capable user; capability tests override.
         wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
     }
 
@@ -39,9 +32,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     /**
      * Invoke save_bulk_edit() and return the decoded wp_send_json_* envelope.
      *
-     * The handler always ends in a wp_die() (via wp_send_json_*() or
-     * wp_nonce_ays()), which the AJAX harness converts into a WPDieException
-     * after flushing any JSON body into $this->_last_response.
+     * The handler always ends in wp_die(); the AJAX harness converts that into a
+     * WPDieException after flushing any JSON body into $this->_last_response.
      *
      * @return array Decoded JSON envelope, or [] when no body was emitted.
      */
@@ -166,13 +158,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     /**
      * Regression test for the AJAX delete path.
      *
-     * A 'delete' selection where no post has both a project_id and a content_id
-     * makes Client::batch_delete_audio() throw. Previously the exception
-     * propagated out of save_bulk_edit() uncaught, producing a PHP fatal /
-     * HTTP 500 on admin-ajax. It must now be reported as a JSON error response.
-     *
-     * The exception is thrown before any HTTP request is attempted, so this
-     * needs no API credentials or mock.
+     * With no post carrying both project_id and content_id, Client::batch_delete_audio() throws
+     * before any HTTP request (so no mock needed); it must surface as a JSON error, not a 500.
      *
      * @test
      */
@@ -250,9 +237,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     }
 
     /**
-     * A nonce proves intent, not authorisation. A logged-in user without the
-     * `edit_posts` capability (e.g. a Subscriber) must get a 403 JSON error,
-     * before any post meta is touched.
+     * A nonce proves intent, not authorisation: without `edit_posts` a Subscriber
+     * must get a 403 JSON error before any post meta is touched.
      *
      * @test
      */
@@ -266,8 +252,7 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
         $_POST['beyondwords_bulk_edit'] = 'generate';
         $_POST['post_ids'] = [$postId];
 
-        // Nonce is valid for this user, so the *only* thing that can stop the
-        // request is the capability gate — not the nonce check.
+        // The nonce is valid, so only the capability gate can stop the request.
         $this->assertNotFalse(wp_verify_nonce($_POST['beyondwords_bulk_edit_nonce'], 'beyondwords_bulk_edit'));
 
         $response = $this->getJsonResponse();
@@ -311,16 +296,14 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
         $this->assertFalse($response['success']);
         $this->assertStringContainsString('not allowed to bulk edit', $response['data']['message']);
         $this->assertFalse($httpAttempted, 'No API delete should be attempted for an unauthorized user.');
-        // Nothing was deleted.
         $this->assertSame('content-no-cap', get_post_meta($postId, 'beyondwords_content_id', true));
 
         wp_delete_post($postId, true);
     }
 
     /**
-     * A user with `edit_posts` may still lack `edit_post` for an individual post
-     * they do not own. On generate, those posts are filtered out; editable ones
-     * are still processed.
+     * A user with `edit_posts` may still lack `edit_post` on an individual post;
+     * on generate those posts are filtered out while editable ones are processed.
      *
      * @test
      */
@@ -359,9 +342,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     }
 
     /**
-     * On the delete branch the per-post `edit_post` filter must drop posts the
-     * user cannot edit, so the API batch-delete request only ever carries the
-     * editable post's content — and only that post's meta is cleared.
+     * On delete the per-post `edit_post` filter must drop uneditable posts, so the API
+     * batch-delete only carries the editable post's content — and only its meta clears.
      *
      * @test
      */
@@ -412,16 +394,13 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
 
         remove_filter('pre_http_request', $mockHttp, 10);
 
-        // Only the editable post is processed.
         $this->assertTrue($response['success']);
         $this->assertSame([$ownPostId], $response['data']);
 
-        // Exactly one batch-delete request, carrying only the editable post's content.
         $this->assertCount(1, $requests);
         $this->assertStringContainsString('own-content-aaa', $requests[0]);
         $this->assertStringNotContainsString('other-content-bbb', $requests[0]);
 
-        // The editable post's meta is cleared; the other post is untouched.
         $this->assertSame('', get_post_meta($ownPostId, 'beyondwords_content_id', true));
         $this->assertSame('other-content-bbb', get_post_meta($otherPostId, 'beyondwords_content_id', true));
 
@@ -430,10 +409,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     }
 
     /**
-     * The per-post gate is `edit_post`, not mere ownership. A Contributor holds
-     * `edit_posts` (clearing the coarse gate) but lacks `edit_published_posts`,
-     * so cannot edit a *published* post even when they own it. Such a post is
-     * filtered out, leaving a clean no-op (success with no processed IDs).
+     * The per-post gate is `edit_post`, not ownership: a Contributor clears `edit_posts`
+     * but cannot edit their own *published* post, so it's filtered out (clean no-op).
      *
      * @test
      */
@@ -460,7 +437,6 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
 
         $response = $this->getJsonResponse();
 
-        // Filtered out by the per-post capability check — no mutation.
         $this->assertTrue($response['success']);
         $this->assertSame([], $response['data']);
         $this->assertEmpty(get_post_meta($ownPublishedPostId, 'beyondwords_generate_audio', true));
@@ -469,9 +445,8 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     }
 
     /**
-     * When the per-post filter removes every selected post, the delete branch
-     * must be a clean no-op (success, no IDs) — no API request, and not the
-     * empty-batch error the delete helper would otherwise throw.
+     * When the per-post filter removes every post, delete must be a clean no-op (success,
+     * no IDs) — no API request, and not the delete helper's empty-batch error.
      *
      * @test
      */

--- a/tests/phpunit/posts-list/test-bulk-edit.php
+++ b/tests/phpunit/posts-list/test-bulk-edit.php
@@ -12,24 +12,17 @@ final class BulkEditTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
         unset($_POST, $_REQUEST);
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         unset($_POST, $_REQUEST);
 
-        // The redirect handlers gate on current_user_can( 'edit_post', ... ), so
-        // several tests log a user in. Reset it so state cannot leak into sibling
-        // test classes.
+        // Several tests log a user in; reset so state cannot leak into sibling test classes.
         wp_set_current_user(0);
 
-        // Then...
         parent::tearDown();
     }
 
@@ -45,12 +38,10 @@ final class BulkEditTest extends TestCase
         $this->assertEquals(10, has_action('bulk_edit_custom_box', array(BulkEdit::class, 'bulk_edit_custom_box')));
         $this->assertEquals(10, has_action('wp_ajax_save_bulk_edit_beyondwords', array(BulkEdit::class, 'save_bulk_edit')));
 
-        // Post type: post
         $this->assertEquals(10, has_filter('bulk_actions-edit-post', array(BulkEdit::class, 'bulk_actions_edit')));
         $this->assertEquals(10, has_filter('handle_bulk_actions-edit-post', array(BulkEdit::class, 'handle_bulk_delete_action')));
         $this->assertEquals(10, has_filter('handle_bulk_actions-edit-post', array(BulkEdit::class, 'handle_bulk_generate_action')));
 
-        // Post type: page
         $this->assertEquals(10, has_filter('bulk_actions-edit-page', array(BulkEdit::class, 'bulk_actions_edit')));
         $this->assertEquals(10, has_filter('handle_bulk_actions-edit-page', array(BulkEdit::class, 'handle_bulk_delete_action')));
         $this->assertEquals(10, has_filter('handle_bulk_actions-edit-page', array(BulkEdit::class, 'handle_bulk_generate_action')));
@@ -154,11 +145,9 @@ final class BulkEditTest extends TestCase
      */
     public function handle_bulk_generate_action()
     {
-        // The handler now filters $object_ids by current_user_can( 'edit_post' ),
-        // so run as an administrator who can edit every selected post.
+        // The handler filters $object_ids by current_user_can('edit_post'), so run as an admin.
         wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
 
-        // Set up API credentials for integration test
         update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
         update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
 
@@ -168,22 +157,18 @@ final class BulkEditTest extends TestCase
                 'post_title' => 'BulkEditTest::handle_bulk_generate_action::skip-1',
                 'post_content' => 'Test content for skip-1.',
             ]),
-            // Create
             self::factory()->post->create([
                 'post_title' => 'BulkEditTest::handle_bulk_generate_action::create-1',
                 'post_content' => 'Test content for create-1.',
             ]),
-            // Create
             self::factory()->post->create([
                 'post_title' => 'BulkEditTest::handle_bulk_generate_action::create-2',
                 'post_content' => 'Test content for create-2.',
             ]),
-            // Create
             self::factory()->post->create([
                 'post_title' => 'BulkEditTest::handle_bulk_generate_action::create-3',
                 'post_content' => 'Test content for create-3.',
             ]),
-            // Create
             self::factory()->post->create([
                 'post_title' => 'BulkEditTest::handle_bulk_generate_action::create-4',
                 'post_content' => 'Test content for create-4.',
@@ -203,7 +188,6 @@ final class BulkEditTest extends TestCase
         // beyondwords_bulk_generated should be updated with the no. of posts processed (so 99 becomes 4)
         $redirect = 'https://example.com/wp-admin/posts?beyondwords_bulk_generated=99';
 
-        // Add nonce into redirect
         $redirect = add_query_arg('beyondwords_bulk_edit_result_nonce', $nonce, $redirect);
 
         $redirect = BulkEdit::handle_bulk_generate_action($redirect, 'beyondwords_generate_audio', $selectedPostIds);
@@ -215,16 +199,13 @@ final class BulkEditTest extends TestCase
         $this->assertArrayHasKey('beyondwords_bulk_generated', $args);
         $this->assertArrayHasKey('beyondwords_bulk_failed', $args);
 
-        // Verify that generated + failed equals the number of selected posts
         $total = (int)$args['beyondwords_bulk_generated'] + (int)$args['beyondwords_bulk_failed'];
         $this->assertEquals(count($selectedPostIds), $total);
 
-        // Verify all selected posts have the generate_audio flag set
         foreach ($selectedPostIds as $postId) {
             $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
         }
 
-        // Clean up
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);
         }
@@ -241,12 +222,8 @@ final class BulkEditTest extends TestCase
      */
     public function handle_bulk_generate_action_with_no_api_credentials()
     {
-        // The handler now filters $object_ids by current_user_can( 'edit_post' ),
-        // so run as an administrator who can edit every selected post.
+        // The handler filters $object_ids by current_user_can('edit_post'), so run as an admin.
         wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
-
-        // Test error handling when API credentials are missing
-        // This tests the failure path where posts cannot be generated
 
         $postIds = [
             self::factory()->post->create([
@@ -259,7 +236,6 @@ final class BulkEditTest extends TestCase
             ]),
         ];
 
-        // Ensure no API credentials are set
         delete_option('beyondwords_api_key');
         delete_option('beyondwords_project_id');
 
@@ -276,27 +252,22 @@ final class BulkEditTest extends TestCase
         $this->assertArrayHasKey('beyondwords_bulk_generated', $args);
         $this->assertArrayHasKey('beyondwords_bulk_failed', $args);
 
-        // When API credentials are missing, all posts should fail
         $this->assertEquals(0, $args['beyondwords_bulk_generated']);
         $this->assertEquals(count($postIds), $args['beyondwords_bulk_failed']);
 
-        // Verify all posts have the generate_audio flag set (even though they failed)
+        // The generate_audio flag is set even though generation failed.
         foreach ($postIds as $postId) {
             $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
         }
 
-        // Clean up
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);
         }
     }
 
     /**
-     * A user with `edit_posts` may still lack `edit_post` for an individual post
-     * they do not own. Core routes custom bulk actions through this filter after
-     * only the coarse edit_posts gate, so the redirect-based generate handler must
-     * itself drop posts the user cannot edit — only the editable post is flagged
-     * for generation and counted. Mirrors the AJAX coverage in test-bulk-edit-ajax.php.
+     * Core runs custom bulk actions after only the coarse edit_posts gate, so the handler
+     * itself must drop posts the user cannot edit. Mirrors test-bulk-edit-ajax.php.
      *
      * @test
      *
@@ -321,8 +292,7 @@ final class BulkEditTest extends TestCase
             'post_title'  => 'BulkEditTest::generate-skip::other',
         ]);
 
-        // Intercept the create-audio request with a benign success so generation
-        // completes hermetically, without a real network call.
+        // Benign success stub so generation completes without a real network call.
         $mockHttp = function () {
             return [
                 'response' => ['code' => 200, 'message' => 'OK'],
@@ -341,7 +311,6 @@ final class BulkEditTest extends TestCase
 
         remove_filter('pre_http_request', $mockHttp, 10);
 
-        // Only the editable post is flagged for generation.
         $this->assertSame('1', get_post_meta($ownPostId, 'beyondwords_generate_audio', true));
         $this->assertEmpty(get_post_meta($otherPostId, 'beyondwords_generate_audio', true));
 
@@ -406,9 +375,8 @@ final class BulkEditTest extends TestCase
     }
 
     /**
-     * On the delete branch the per-post `edit_post` filter must drop posts the
-     * user cannot edit, so the API batch-delete request only ever carries the
-     * editable post's content — and only that post's meta is cleared.
+     * On delete the per-post `edit_post` filter must drop uneditable posts, so the API
+     * batch-delete only carries the editable post's content — and only its meta clears.
      *
      * @test
      *
@@ -461,16 +429,13 @@ final class BulkEditTest extends TestCase
 
         remove_filter('pre_http_request', $mockHttp, 10);
 
-        // Exactly one batch-delete request, carrying only the editable post's content.
         $this->assertCount(1, $requests);
         $this->assertStringContainsString('own-content-aaa', $requests[0]);
         $this->assertStringNotContainsString('other-content-bbb', $requests[0]);
 
-        // Only the editable post's meta is cleared; the other post is untouched.
         $this->assertSame('', get_post_meta($ownPostId, 'beyondwords_content_id', true));
         $this->assertSame('other-content-bbb', get_post_meta($otherPostId, 'beyondwords_content_id', true));
 
-        // The redirect reports exactly one deleted post.
         $query = parse_url($redirect, PHP_URL_QUERY);
         parse_str($query, $args);
         $this->assertEquals(1, $args['beyondwords_bulk_deleted']);
@@ -480,9 +445,8 @@ final class BulkEditTest extends TestCase
     }
 
     /**
-     * When the per-post filter removes every selected post, the delete handler
-     * must be a clean no-op: a zero count, no API request, and — critically — no
-     * BULK-NO-RESPONSE error from handing an empty batch to the API.
+     * When the per-post filter removes every post, delete must be a clean no-op: zero
+     * count, no API request, and no BULK-NO-RESPONSE error from an empty batch.
      *
      * @test
      *
@@ -521,7 +485,6 @@ final class BulkEditTest extends TestCase
         $query = parse_url($redirect, PHP_URL_QUERY);
         parse_str($query, $args);
 
-        // Zero deleted, no error surfaced, and no API request attempted.
         $this->assertEquals(0, $args['beyondwords_bulk_deleted']);
         $this->assertArrayNotHasKey('beyondwords_bulk_error', $args);
         $this->assertFalse($httpAttempted, 'No API delete should be attempted when no editable posts remain.');

--- a/tests/phpunit/posts-list/test-column.php
+++ b/tests/phpunit/posts-list/test-column.php
@@ -11,17 +11,11 @@ class ColumnTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
-
-        // Your set up methods here.
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
-
-        // Then...
         parent::tearDown();
     }
 
@@ -34,12 +28,10 @@ class ColumnTest extends TestCase
 
         do_action('wp_loaded');
 
-        // Post type: post
         $this->assertEquals(10, has_filter('manage_post_posts_columns', array(Column::class, 'render_columns_head')));
         $this->assertEquals(10, has_action('manage_post_posts_custom_column', array(Column::class, 'render_columns_content')));
         $this->assertEquals(10, has_filter('manage_edit-post_sortable_columns', array(Column::class, 'make_column_sortable')));
 
-        // Post type: page
         $this->assertEquals(10, has_filter('manage_page_posts_columns', array(Column::class, 'render_columns_head')));
         $this->assertEquals(10, has_action('manage_page_posts_custom_column', array(Column::class, 'render_columns_content')));
         $this->assertEquals(10, has_filter('manage_edit-page_sortable_columns', array(Column::class, 'make_column_sortable')));

--- a/tests/phpunit/posts-list/test-notices.php
+++ b/tests/phpunit/posts-list/test-notices.php
@@ -12,19 +12,15 @@ final class NoticesTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         unset($_POST, $_GET);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         unset($_POST, $_GET);
 
-        // Then...
         parent::tearDown();
     }
 
@@ -161,9 +157,6 @@ final class NoticesTest extends TestCase
         $this->assertStringContainsString($expectMessage, $notice->filter('p:first-of-type')->text());
     }
 
-    /**
-     *
-     */
     public function generated_notice_provider() {
         return [
             '1 post' => [
@@ -203,9 +196,6 @@ final class NoticesTest extends TestCase
         $this->assertStringContainsString($expectMessage, $notice->filter('p:first-of-type')->text());
     }
 
-    /**
-     *
-     */
     public function deleted_notice_provider() {
         return [
             '1 post' => [
@@ -245,9 +235,6 @@ final class NoticesTest extends TestCase
         $this->assertStringContainsString($expectMessage, $notice->filter('p:first-of-type')->text());
     }
 
-    /**
-     *
-     */
     public function failed_notice_provider() {
         return [
             '1 post' => [
@@ -290,9 +277,6 @@ final class NoticesTest extends TestCase
         unset($_GET['beyondwords_bulk_error']);
     }
 
-    /**
-     *
-     */
     public function error_notice_provider() {
         return [
             'Unknown error' => [

--- a/tests/phpunit/settings/test-preselect.php
+++ b/tests/phpunit/settings/test-preselect.php
@@ -35,8 +35,7 @@ class PreselectTest extends TestCase
     }
 
     /**
-     * Register a hierarchical taxonomy attached to the given post type and
-     * remember it for teardown.
+     * Register a hierarchical taxonomy attached to the given post type; unregistered in tearDown.
      */
     private function register_hierarchical_taxonomy(string $taxonomy, string $post_type = 'post', bool $show_ui = true): void
     {
@@ -357,7 +356,6 @@ class PreselectTest extends TestCase
      */
     public function sanitize_stores_all_mode()
     {
-        // Post-type enabled + "All" ticked.
         $clean = Preselect::sanitize(['post' => ['enabled' => '1', 'all' => '1']]);
         $this->assertSame(['mode' => 'all'], $clean['post']);
     }
@@ -393,7 +391,6 @@ class PreselectTest extends TestCase
      */
     public function sanitize_all_checkbox_wins_over_ticked_terms()
     {
-        // Both "All" and some terms ticked → "All" wins.
         $clean = Preselect::sanitize([
             'post' => ['enabled' => '1', 'all' => '1', 'terms' => ['category' => [1]]],
         ]);
@@ -406,7 +403,6 @@ class PreselectTest extends TestCase
      */
     public function sanitize_enabled_without_all_or_terms_is_empty_terms_mode()
     {
-        // Enabled, "All" unticked, no terms picked → terms mode, no terms.
         $clean = Preselect::sanitize(['post' => ['enabled' => '1']]);
 
         $this->assertSame(['mode' => 'terms', 'terms' => []], $clean['post']);
@@ -454,7 +450,6 @@ class PreselectTest extends TestCase
             'post' => ['enabled' => '1', 'terms' => ['category' => [2]]],
         ]);
 
-        // genre is preserved; category is updated from the form.
         $this->assertSame([7], $clean['post']['terms']['genre']);
         $this->assertSame([2], $clean['post']['terms']['category']);
     }
@@ -464,7 +459,6 @@ class PreselectTest extends TestCase
      */
     public function sanitize_preserves_config_for_currently_incompatible_post_type()
     {
-        // A CPT that is not registered in this request must keep its config.
         update_option(Preselect::OPTION_NAME, [
             'post'    => ['mode' => 'all'],
             'cpt_gone' => ['mode' => 'all'],
@@ -571,7 +565,6 @@ class PreselectTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // 'post' is mode 'all' → enabled + All both checked.
         $enabled = $crawler->filter('input[type="checkbox"][name="' . Preselect::OPTION_NAME . '[post][enabled]"]');
         $this->assertCount(1, $enabled);
         $this->assertSame('checked', $enabled->attr('checked'));
@@ -580,7 +573,6 @@ class PreselectTest extends TestCase
         $this->assertCount(1, $all);
         $this->assertSame('checked', $all->attr('checked'));
 
-        // 'page' is not preselected → its post-type checkbox is unchecked.
         $pageEnabled = $crawler->filter('input[type="checkbox"][name="' . Preselect::OPTION_NAME . '[page][enabled]"]');
         $this->assertCount(1, $pageEnabled);
         $this->assertNull($pageEnabled->attr('checked'));
@@ -603,7 +595,6 @@ class PreselectTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // Terms mode → enabled checked, All unchecked.
         $enabled = $crawler->filter('input[type="checkbox"][name="' . Preselect::OPTION_NAME . '[post][enabled]"]');
         $this->assertSame('checked', $enabled->attr('checked'));
 

--- a/tests/phpunit/settings/test-settings.php
+++ b/tests/phpunit/settings/test-settings.php
@@ -16,25 +16,20 @@ class SettingsTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         delete_transient('beyondwords_settings_errors');
         delete_transient(Utils::CONNECTION_CHECK_TRANSIENT);
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         delete_transient('beyondwords_settings_errors');
         delete_transient(Utils::CONNECTION_CHECK_TRANSIENT);
-        // print_settings_errors() is now screen-gated; reset the screen so a
-        // test that sets it does not leak into the review-notice tests, which
-        // rely on no settings screen being active.
+        // print_settings_errors() is screen-gated; reset the screen so it cannot leak
+        // into the review-notice tests, which rely on no settings screen being active.
         unset($GLOBALS['current_screen']);
 
-        // Then...
         parent::tearDown();
     }
 
@@ -286,15 +281,10 @@ class SettingsTest extends TestCase
     }
 
     /**
-     * Regression: a sanitizer-queued error must reach the notice after the
-     * post-save redirect, even with no persistent object cache.
+     * Regression: a sanitizer-queued error must survive the post-save redirect with no persistent object cache.
      *
-     * Reproduces saving the Authentication tab with an empty API key: the
-     * Settings API runs `Fields::sanitize_api_key()` during the options.php
-     * POST, then `wp_redirect()`s to a fresh request that renders the notice.
-     * We model that request boundary with `wp_cache_flush()` — on a host with
-     * no persistent cache, the in-memory object cache is empty on the next
-     * request, which previously dropped the error. The transient survives it.
+     * wp_cache_flush() models the redirect's request boundary, which previously
+     * dropped the error; the transient survives it.
      *
      * @test
      */
@@ -314,16 +304,10 @@ class SettingsTest extends TestCase
     }
 
     /**
-     * Regression: queued errors are drained once rendered, so the same notice
-     * does not re-appear on the next admin page.
+     * Regression: queued errors are drained once rendered, so the notice does not re-appear.
      *
-     * `print_settings_errors()` is hooked to `admin_notices`, which fires on
-     * every admin screen, and the transient lives for 30s. The fix deletes the
-     * transient as soon as it has rendered, so the next request's
-     * `get_transient()` finds nothing and the notice shows exactly once instead
-     * of lingering on unrelated admin pages. Asserting the transient is gone
-     * after a render is the faithful model of that next request, and locks in
-     * the post-render delete so a future change cannot silently drop it.
+     * print_settings_errors() runs on every admin_notices; deleting the transient post-render
+     * makes the notice show exactly once instead of lingering for its 30s TTL.
      *
      * @test
      */
@@ -342,11 +326,8 @@ class SettingsTest extends TestCase
     }
 
     /**
-     * The notice handler is hooked to `admin_notices` (every admin screen) but
-     * must only act on the BeyondWords settings page — the only screen these
-     * errors are queued for. On any other screen it early-returns without even
-     * reading the transient, so a queued error never paints elsewhere and is
-     * left intact to render once the user reaches the settings page.
+     * The admin_notices handler must act only on the BeyondWords settings screen — elsewhere
+     * it early-returns without reading the transient, leaving it intact to render later.
      *
      * @test
      */
@@ -398,7 +379,6 @@ class SettingsTest extends TestCase
      */
     public function rest_api_init_callback()
     {
-        // Initiating the REST API.
         global $wp_rest_server;
         $server = $wp_rest_server = new \WP_REST_Server;
         do_action('rest_api_init');
@@ -474,15 +454,13 @@ class SettingsTest extends TestCase
         $this->assertArrayHasKey('current', $data['inspectMetaKeys']);
         $this->assertArrayHasKey('deprecated', $data['inspectMetaKeys']);
 
-        // Current keys are passed through verbatim from the canonical source.
         $this->assertSame(
             \BeyondWords\Core\Utils::get_post_meta_keys('current'),
             $data['inspectMetaKeys']['current']
         );
 
-        // Deprecated keys are the canonical deprecated set with the internal-only
-        // keys (player config, voice ids, hashes, timestamps) filtered out, so
-        // the Inspect panel keeps surfacing the same legacy fields it always has.
+        // The canonical deprecated set minus internal-only keys (player config, voice ids,
+        // hashes, timestamps) — the Inspect panel keeps surfacing the same legacy fields.
         $expectedDeprecated = [
             'beyondwords_podcast_id',
             'publish_post_to_speechkit',
@@ -502,8 +480,7 @@ class SettingsTest extends TestCase
         ];
         $this->assertSame($expectedDeprecated, $data['inspectMetaKeys']['deprecated']);
 
-        // …and every surfaced key must be a real deprecated key (guards drift if
-        // a key is ever renamed in the canonical list).
+        // Every surfaced key must be a real deprecated key (guards rename drift).
         $this->assertEmpty(
             array_diff(
                 $data['inspectMetaKeys']['deprecated'],
@@ -533,8 +510,7 @@ class SettingsTest extends TestCase
         $response = $server->dispatch(new \WP_REST_Request('GET', $path));
         $this->assertSame(401, $response->get_status());
 
-        // Editor sees the proxied video_settings payload, including the
-        // `sizes` array the editor uses for the "Video size" dropdown.
+        // Editor sees the proxied payload, including the `sizes` array for the Video size dropdown.
         $userId = self::factory()->user->create(['role' => 'editor']);
         wp_set_current_user($userId);
 

--- a/tests/phpunit/settings/test-utils.php
+++ b/tests/phpunit/settings/test-utils.php
@@ -35,7 +35,6 @@ class SettingsUtilsTest extends TestCase
         $this->assertContains('attachment', $postTypes);
         $this->assertContains('revision', $postTypes);
 
-        // Set the filter
         $filter = function($supportedPostTypes) {
             return [
                 $supportedPostTypes[1],
@@ -243,9 +242,8 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * A transient failure (5xx, timeout, DNS error) must NOT clear a
-     * previously-valid connection flag — otherwise a brief API blip hides the
-     * Integration and Preferences tabs and locks the operator out.
+     * A transient failure (5xx, timeout, DNS) must NOT clear a previously-valid flag —
+     * a brief API blip would hide the Integration and Preferences tabs.
      *
      * @test
      */
@@ -273,8 +271,7 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * A transport-level failure returns a WP_Error (no HTTP status). It is
-     * transient, so the connection flag must be preserved.
+     * A transport-level WP_Error (no HTTP status) is transient, so the flag must be preserved.
      *
      * @test
      */
@@ -296,8 +293,7 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * A 403 is a definitive auth failure (revoked key or wrong project), so it
-     * clears the connection flag just like a 401.
+     * A 403 is a definitive auth failure, so it clears the connection flag just like a 401.
      *
      * @test
      */
@@ -324,8 +320,7 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * Removing credentials clears the connection flag — no creds, no
-     * connection — without issuing an API request.
+     * Removing credentials clears the connection flag without issuing an API request.
      *
      * @test
      */
@@ -340,9 +335,7 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * Within the throttle window the check is served from the last result
-     * without issuing a second API request — this keeps the uncached remote
-     * call off every settings-page render.
+     * Within the throttle window the last result is reused — keeping the remote call off every settings-page render.
      *
      * @test
      */
@@ -372,8 +365,7 @@ class SettingsUtilsTest extends TestCase
     }
 
     /**
-     * Changing credentials busts the throttle so the new creds are validated
-     * immediately rather than waiting out the window.
+     * Changing credentials busts the throttle so the new creds are validated immediately.
      *
      * @test
      */
@@ -449,11 +441,8 @@ class SettingsUtilsTest extends TestCase
     /**
      * Regression: queued errors must survive a non-persistent object cache.
      *
-     * The default WordPress object cache is request-scoped, so the queue lives
-     * in a transient (which falls back to the options table), not `wp_cache_*`,
-     * to survive the redirect after a settings save. Flushing the object cache
-     * models the fresh request the redirect triggers on a host with no
-     * persistent cache drop-in; the error must still be readable afterwards.
+     * The queue lives in a transient (falls back to the options table), not `wp_cache_*`,
+     * to survive the fresh request after the settings-save redirect.
      *
      * @test
      */

--- a/tests/phpunit/site-health/test-site-health.php
+++ b/tests/phpunit/site-health/test-site-health.php
@@ -15,19 +15,15 @@ class SiteHealthTest extends TestCase
 
     public function setUp(): void
     {
-        // Before...
         parent::setUp();
 
-        // Your set up methods here.
         $this->info = [];
     }
 
     public function tearDown(): void
     {
-        // Your tear down methods here.
         $this->info = null;
 
-        // Then...
         parent::tearDown();
     }
 
@@ -120,8 +116,7 @@ class SiteHealthTest extends TestCase
     /**
      * @test
      *
-     * With credentials configured the probe runs and reports the API as
-     * reachable (the mock returns a non-error response for the API root).
+     * With credentials configured the probe reports the API reachable (mock returns non-error).
      */
     public function add_rest_api_connection_reports_reachable_when_configured()
     {
@@ -146,8 +141,7 @@ class SiteHealthTest extends TestCase
     /**
      * @test
      *
-     * On an unconfigured install the probe is skipped entirely — no blocking
-     * HTTP request is made when there are no API credentials.
+     * Unconfigured installs skip the probe — no blocking HTTP request without credentials.
      */
     public function add_rest_api_connection_skips_probe_without_credentials()
     {
@@ -176,11 +170,8 @@ class SiteHealthTest extends TestCase
     /**
      * @test
      *
-     * The probe is deliberately NOT cached. Site Health is a diagnostic, so
-     * every render must re-check — a cached result would keep reporting
-     * "unreachable" to an admin who just fixed the problem and hit refresh.
-     * This mirrors WordPress core's own dotorg_communication field, which
-     * probes wordpress.org on every Info-screen render.
+     * Deliberately NOT cached: a diagnostic must re-probe on every render, else it keeps
+     * reporting "unreachable" after a fix (mirrors core's dotorg_communication field).
      */
     public function add_rest_api_connection_is_not_cached()
     {
@@ -214,9 +205,7 @@ class SiteHealthTest extends TestCase
     /**
      * @test
      *
-     * The probe passes the client's shared default timeout, so a slow API
-     * cannot stall the Site Health render and the bound stays within VIP
-     * guidance.
+     * The probe passes the client's shared default timeout, keeping a slow API within VIP guidance.
      */
     public function add_rest_api_connection_uses_the_shared_default_timeout()
     {
@@ -248,8 +237,7 @@ class SiteHealthTest extends TestCase
     /**
      * @test
      *
-     * A transport-level failure is reported as unreachable, surfacing the
-     * error message returned by the request.
+     * A transport-level failure is reported as unreachable, surfacing the request's error message.
      */
     public function add_rest_api_connection_reports_unreachable_on_error()
     {

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,8 +9,6 @@ use BeyondWords\Core\Uninstaller;
 /**
  * Uninstall script for BeyondWords.
  *
- * Executed when BeyondWords is uninstalled via built-in WordPress commands.
- *
  * @since 3.7.0
  *
  * @SuppressWarnings(PHPMD.ExitExpression)


### PR DESCRIPTION
## What

Drastically reduces the volume of inline comments and docblock prose across the plugin — `src/`, root PHP files, `scripts/`, `tests/phpunit/` and `tests/cypress/` — per the "code explains what, comments explain why" rule:

- **PHPDoc / JSDoc**: 1-line summary; a secondary description (max 2 lines) only where behaviour is genuinely non-obvious. All `@since` / `@param` / `@return` / `@var` tags preserved with their existing values.
- **Inline comments**: what-comments removed; why-comments kept, trimmed to 1–2 lines.
- **Functional comments untouched**: `phpcs:ignore/disable/enable`, `/* translators: */`, eslint globals/disables, WordPress dependency section headers, the plugin header in `speechkit.php`, PHPUnit `@test`/`@covers`/`@group`/`@dataProvider` annotations, and Cypress `@group`/`@covers` spec-discovery headers.
- **WordPress hook docblocks** (above `apply_filters`/`do_action`) kept as public API docs, descriptions trimmed to 1 line.

Long-form rationale worth keeping has moved to `doc/` and is linked from the README documentation index:

- `doc/rest-meta-visibility.md` — how BeyondWords post meta is exposed/hidden over REST
- `doc/video-settings-payload.md` — why a full `video_settings` object is sent to the content endpoint
- `doc/preselect-generate-audio.md` — stored format, legacy shapes, no-dirty editor derivation, save-time decision
- `doc/settings-internals.md` — settings-error transport, API connection check contract
- `doc/wordpress-vip.md` — new object-cache notes section
- `doc/running-tests.md` — new PHPUnit/flaky-test lore sections
- README now also links the previously unlisted `async-rest-migration.md` and `legacy-meta-migration.md`

## No lines of code changed

**Every one of the 139 changed PHP/JS files is code-identical to `main`**: byte-identical `php -w` output (comments + whitespace stripped) for PHP, identical espree token streams (JSX-aware, comments excluded) for JS. Formatting around removals was also checked — no introduced trailing whitespace, double blank lines, or blank lines adjacent to braces (pattern counts compared per-file against `main`).

`phpcs` (WordPress-VIP-Go ruleset) and `wp-scripts lint-js` both pass.

## Includes latest `main`

`origin/main` is merged in (including the bulk-generate cap from #573). The verbose docblocks/inline comments that feature added to `Sync`, `BulkEdit`, `Notices` and their tests were trimmed to the same style during the merge; conflict resolution kept main's code (new const + `@param` tags) with this branch's trimmed prose.

**147 files changed, +1,027 / −2,694** (net −1,667; additions are almost entirely the new `doc/` pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)