### PR TITLE
refactor: cut the inline commentary added with the polling change

### DIFF
--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -221,20 +221,8 @@ class Metabox {
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		if ( ! empty( $content_id ) ) :
-			/*
-			 * REST-API content may still be processing on the BeyondWords backend.
-			 * Embedding the player now would 404 — and the CDN would cache that
-			 * 404 — for content that isn't ready, so render a loading state and
-			 * let classic-metabox.js poll GET /content until the status is
-			 * `processed`, then construct the player.
-			 *
-			 * The Content ID is editable post meta and the preview token comes
-			 * from the REST API, so both are untrusted here. They are emitted as
-			 * esc_attr()'d data-* attributes and read back with getAttribute(),
-			 * so neither is ever interpolated into a JS execution context — the
-			 * stored-XSS vector that the inline `onload` handler has to
-			 * JSON-encode away simply does not exist on this path.
-			 */
+			// Content may still be processing, so classic-metabox.js polls before
+			// embedding; data-* keeps it out of any JS execution context.
 			?>
 			<div
 				id="beyondwords-metabox-player"
@@ -259,21 +247,8 @@ class Metabox {
 			></script>
 			<?php
 		else :
-			/*
-			 * Client-side integration is keyed on the source (post) ID — there is
-			 * nothing to poll, so embed immediately.
-			 *
-			 * Build the player SDK config as a PHP array, then JSON-encode it for
-			 * the inline `onload` handler instead of concatenating the values by
-			 * hand. The preview token is supplied by the REST API, so it is
-			 * untrusted in this output context. The HEX flags escape ' " < > &
-			 * inside every string value as \uXXXX, so a value cannot break out of
-			 * the JS string literal, the single-quoted attribute, or the
-			 * surrounding <script> markup; the structural JSON quotes are left
-			 * intact so the spread object literal stays valid JavaScript, and
-			 * esc_attr() below encodes those for the attribute. Mirrors
-			 * \BeyondWords\Player\Renderer\Javascript::render().
-			 */
+			// No Content ID to poll, so embed inline. The HEX flags stop an
+			// untrusted value breaking out of the JS string literal.
 			$config = [
 				'projectId'        => (int) $project_id,
 				'sourceId'         => (string) $post->ID,

--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -3,21 +3,13 @@
 ( function () {
 	'use strict';
 
-	/**
-	 * Content statuses that mean "still processing" — keep polling.
-	 *
-	 * @type {string[]}
-	 */
 	const NON_TERMINAL_STATUSES = [ 'draft', 'queued', 'processing' ];
 
 	/**
 	 * Poll `fetchStatus` until the content reaches a terminal status.
 	 *
-	 * Mirror of src/editor/lib/poll-content-status.js (which the block editor
-	 * imports and jest covers). Inlined here because this classic-editor script
-	 * is enqueued raw — it is not built, so it cannot `import`. Resolves
-	 * { status, timedOut }; a cancelled poll (superseded by a newer one) simply
-	 * stops without resolving.
+	 * Mirrors src/editor/lib/poll-content-status.js; inlined because this script
+	 * is served raw and cannot import a built module.
 	 *
 	 * @param {Object}   options               Options.
 	 * @param {Function} options.fetchStatus   () => Promise<{ status }>.
@@ -49,15 +41,12 @@
 					return;
 				}
 
-				// Budget measures visible time — a hidden tab resumes polling on
-				// return instead of timing out having never fetched.
+				// Hidden cycles never fetch, so they must not spend the budget.
 				if ( Date.now() - start - hiddenMs >= timeoutMs ) {
 					resolve( { status: lastStatus, timedOut: true } );
 					return;
 				}
 
-				// Skip the upstream call while the tab is hidden — each poll is
-				// an uncached upstream API call.
 				if ( isHidden && isHidden() ) {
 					const hiddenAt = Date.now();
 					setTimeout( function () {
@@ -104,10 +93,7 @@
 	/**
 	 * Resolve once the BeyondWords player SDK global is available.
 	 *
-	 * The SDK loads from a deferred <script>; by the time polling finishes it is
-	 * almost always ready, but guard with a short bounded wait just in case.
-	 *
-	 * @return {Promise<void>} Resolves when ready (or after the wait budget).
+	 * @return {Promise<void>} Resolves when ready, or after the wait budget.
 	 */
 	function whenBeyondWordsReady() {
 		return new Promise( function ( resolve ) {
@@ -156,8 +142,7 @@
 	}
 
 	/**
-	 * Replace the container contents with a terminal message (error / skipped /
-	 * timeout), or clear it when there is nothing to say.
+	 * Replace the container contents with a terminal message, if there is one.
 	 *
 	 * @param {HTMLElement} container The player container.
 	 * @param {Object}      result    The poll result { status, timedOut }.
@@ -188,12 +173,6 @@
 
 	/**
 	 * Poll the content status, then embed the player once it is `processed`.
-	 *
-	 * Reads projectId / contentId / previewToken from the container's data-*
-	 * attributes, shows a spinner while the content is still processing, and only
-	 * constructs the player on `processed` — so the player never requests (and
-	 * CDN-caches a 404 for) unprocessed content. A terminal error / skipped /
-	 * timeout shows a short message instead.
 	 *
 	 * @param {HTMLElement} container The #beyondwords-metabox-player element.
 	 */
@@ -235,19 +214,14 @@
 					typeof BeyondWords === 'undefined' ||
 					typeof BeyondWords.Player !== 'function'
 				) {
-					// SDK unavailable — either it was never emitted on this page
-					// (the post had no content at load, so player_embed() didn't
-					// run) or it failed to load within the bounded wait.
-					// Generation itself succeeded; clear the spinner so it isn't
-					// left stuck. A page refresh re-loads the SDK.
+					// The SDK is only emitted for posts that had content at load,
+					// so clear the spinner rather than leave it stuck forever.
 					container.innerHTML = '';
 					return;
 				}
 
 				container.innerHTML = '';
 
-				// The SDK constructor can throw; contain it so a preview-only
-				// error can't surface as a fatal.
 				try {
 					new BeyondWords.Player( {
 						target: container,
@@ -456,10 +430,7 @@
 			errorContainer.remove();
 		}
 
-		// Re-initialise the player preview with the fetched content. Route
-		// through initMetaboxPlayer so a just-fetched-but-still-processing
-		// content is polled until `processed` rather than embedded straight
-		// away (which would request — and CDN-cache a 404 for — unready content).
+		// Just-fetched content may still be processing, so poll before embedding.
 		if ( meta.beyondwords_content_id && meta.beyondwords_project_id ) {
 			let playerContainer = document.getElementById(
 				'beyondwords-metabox-player'

--- a/src/editor/components/play-audio/hooks.js
+++ b/src/editor/components/play-audio/hooks.js
@@ -68,19 +68,8 @@ export function useBeyondWordsNamespace() {
 /**
  * Create a (preview) BeyondWords player once its content is ready.
  *
- * When a `contentId` appears or changes *during* this session (REST-API
- * integration — e.g. the post was just generated/regenerated), the content may
- * still be processing on the BeyondWords backend. Embedding the player before it
- * is `processed` makes the player's first asset request 404, and that 404 gets
- * CDN-cached — so we poll the content object and only instantiate the player
- * once the backend reports `processed`. While polling, `isPolling` is true so
- * the caller can show a spinner + "Generating…" text; on a terminal
- * `error`/`skipped`/timeout the caller surfaces a short message instead.
- *
- * Content already present when the player mounted has long since finished
- * processing, so it is embedded immediately (no poll). Likewise when there is no
- * `contentId` (client-side integration, keyed on `sourceId`) there is nothing to
- * poll, so the player is created immediately as before.
+ * Content that appears or changes during the session may still be processing, so
+ * it is polled before embedding; anything else embeds immediately.
  *
  * @param {Object}      options              Options.
  * @param {HTMLElement} options.target       Player mount node.
@@ -108,11 +97,8 @@ export function useBeyondWordsPlayer( {
 		timedOut: false,
 	} );
 
-	// The contentId present when the player first mounted. Content that already
-	// existed at mount finished processing in an earlier session/save, so it can
-	// embed immediately — no poll, no spinner, no extra API call. Only a
-	// contentId that appears or changes *during* this session can still be
-	// processing and risk caching a 404, so only that case polls.
+	// Content already present at mount finished processing in an earlier session,
+	// so only a contentId that appears or changes now risks caching a 404.
 	const mountContentIdRef = useRef( contentId );
 
 	useEffect( () => {
@@ -163,9 +149,6 @@ export function useBeyondWordsPlayer( {
 		};
 
 		if ( contentId && contentId !== mountContentIdRef.current ) {
-			// Session-fresh (or regenerated) content: poll the content object
-			// until the backend finishes processing, then embed. Avoids caching
-			// a 404 for still-processing content.
 			setPollState( {
 				status: undefined,
 				isPolling: true,
@@ -202,11 +185,9 @@ export function useBeyondWordsPlayer( {
 					}
 				} )
 				.catch( () => {
-					// Aborted (unmount or dependency change) — nothing to do.
+					// Aborted on unmount or dependency change.
 				} );
 		} else {
-			// Already-processed content (present at mount) or client-side
-			// integration (keyed on sourceId): nothing to poll, embed now.
 			setPollState( {
 				status: undefined,
 				isPolling: false,

--- a/src/editor/components/play-audio/index.js
+++ b/src/editor/components/play-audio/index.js
@@ -56,8 +56,6 @@ function PlayAudio( {
 		previewToken,
 	} );
 
-	// Only speak up once polling has settled without a player (error/skipped/
-	// timeout). While polling, the spinner covers it.
 	const message =
 		! isPolling && ! player ? terminalMessage( status, timedOut ) : null;
 
@@ -65,8 +63,8 @@ function PlayAudio( {
 		<PlayAudioCheck>
 			<Wrapper>
 				<div className="beyondwords-player-box-wrapper">
-					{ /* Live region scoped to the status text only, so the
-					     player's own DOM isn't announced when it embeds. */ }
+					{ /* Scoped to the status text so the player's own DOM
+					     isn't announced when it embeds. */ }
 					{ ( isPolling || message ) && (
 						<div role="status" aria-live="polite">
 							{ isPolling && (

--- a/src/editor/lib/poll-content-status.js
+++ b/src/editor/lib/poll-content-status.js
@@ -1,52 +1,19 @@
 /**
  * Poll a BeyondWords content object until it reaches a terminal status.
  *
- * The editor embeds the audio/video player preview as soon as a content ID
- * exists on the post. If the BeyondWords backend is still processing, the
- * player's first asset request 404s and that 404 gets CDN-cached — leaving the
- * player broken even after the media is ready. To avoid that, callers poll the
- * content object (via the `beyondwords/v1/.../content/{id}` REST proxy) and only
- * instantiate the player once the backend reports `processed`.
+ * Embedding the player before the backend finishes processing 404s, and the CDN
+ * caches that 404 — so callers wait for `processed` before embedding.
  *
- * Framework-agnostic on purpose: no React and no `@wordpress/*` imports, so the
- * block editor bundle, the (non-built) classic-editor IIFE, and jest can all
- * share the same loop.
+ * No React or `@wordpress/*` imports: the classic editor script is served raw
+ * and cannot import a built module.
  */
 
-/**
- * Statuses that mean "not finished yet" — keep polling.
- *
- * Everything else (`processed`, `error`, `skipped`, or an unknown/absent value)
- * is terminal so the loop always ends.
- *
- * @type {string[]}
- */
 export const NON_TERMINAL_STATUSES = [ 'draft', 'queued', 'processing' ];
-
-/**
- * The success status — the only one for which a player should be embedded.
- *
- * @type {string}
- */
 export const PROCESSED_STATUS = 'processed';
-
-/**
- * Default poll interval, in milliseconds.
- *
- * @type {number}
- */
 export const DEFAULT_INTERVAL_MS = 3000;
-
-/**
- * Default overall time budget, in milliseconds, before giving up.
- *
- * @type {number}
- */
 export const DEFAULT_TIMEOUT_MS = 120000;
 
 /**
- * Build an `AbortError` that callers can recognise and swallow.
- *
  * @return {Error} An error whose `name` is `'AbortError'`.
  */
 function abortError() {
@@ -57,8 +24,6 @@ function abortError() {
 
 /**
  * Resolve after `ms`, or reject with an `AbortError` if `signal` aborts first.
- *
- * Abort-aware so unmount/cleanup doesn't have to wait out the interval.
  *
  * @param {number}       ms     Delay in milliseconds.
  * @param {AbortSignal=} signal Optional abort signal.
@@ -89,26 +54,10 @@ function sleep( ms, signal ) {
 /**
  * Poll `fetchStatus` until the content reaches a terminal status.
  *
- * Resolves `{ status, timedOut }`:
- * - `status` is the last-seen status (`processed`/`error`/`skipped`/unknown, or
- *   the last non-terminal status when the time budget elapses).
- * - `timedOut` is `true` only when the budget elapsed while still non-terminal.
- *
- * Rejects with an `AbortError` if `signal` aborts. Uses chained `setTimeout`
- * (not `setInterval`) so a slow request can never overlap the next tick, and a
- * transient fetch failure is treated as a non-terminal tick — one 5xx/network
- * blip must not abandon the wait.
- *
  * @param {Object}       options             Options.
  * @param {Function}     options.fetchStatus `() => Promise<{ status: string }>`.
- *                                           Fetches the content object.
- * @param {Function=}    options.onTick      Called with the current status on
- *                                           each non-terminal poll.
- * @param {Function=}    options.isHidden    `() => boolean`. When it returns
- *                                           true the upstream call is skipped
- *                                           for that cycle (throttle background
- *                                           tabs — each poll is an uncached
- *                                           upstream API call).
+ * @param {Function=}    options.onTick      Called on each non-terminal poll.
+ * @param {Function=}    options.isHidden    Skips the request while it returns true.
  * @param {AbortSignal=} options.signal      Abort signal to stop polling.
  * @param {number=}      options.intervalMs  Delay between polls.
  * @param {number=}      options.timeoutMs   Overall time budget.
@@ -127,22 +76,16 @@ export async function pollContentStatus( {
 	let lastStatus;
 	let hiddenMs = 0;
 
-	// Loop terminates via: terminal status (return), budget elapsed (return),
-	// or abort (throw). The `while ( true )` body always awaits, so it can't spin.
 	while ( true ) {
 		if ( signal?.aborted ) {
 			throw abortError();
 		}
 
-		// The budget measures *visible* time: hidden cycles don't fetch, so a
-		// backgrounded tab must resume polling on return rather than time out
-		// having never actually checked the status.
+		// Hidden cycles never fetch, so they must not spend the budget.
 		if ( Date.now() - start - hiddenMs >= timeoutMs ) {
 			return { status: lastStatus, timedOut: true };
 		}
 
-		// Skip the upstream call while the tab is hidden, but keep the loop
-		// alive so polling resumes when the tab becomes visible again.
 		if ( typeof isHidden === 'function' && isHidden() ) {
 			const hiddenAt = Date.now();
 			await sleep( intervalMs, signal );
@@ -155,16 +98,15 @@ export async function pollContentStatus( {
 			const response = await fetchStatus();
 			status = response?.status;
 		} catch {
-			// Transient failure — treat as a non-terminal tick and keep polling
-			// until the time budget is exhausted.
+			// One blip shouldn't abandon the wait; retry until the budget runs out.
 			await sleep( intervalMs, signal );
 			continue;
 		}
 
 		lastStatus = status;
 
+		// Unknown statuses count as terminal so the loop always ends.
 		if ( ! NON_TERMINAL_STATUSES.includes( status ) ) {
-			// processed / error / skipped / unknown — all terminal.
 			return { status, timedOut: false };
 		}
 

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -10,9 +10,8 @@ context( 'Block Editor: Preview panel', () => {
 		cy.login();
 	} );
 
-	// Note: the block-editor player-preview poll is deliberately not covered
-	// here. It only starts once the CDN player SDK global is available, which
-	// isn't deterministic in CI, so a block spinner assertion is flaky.
+	// The block poll only starts once the CDN player SDK global loads, which
+	// isn't deterministic in CI, so a spinner assertion here would be flaky.
 
 	it( 'shows a BeyondWords error message in the Preview panel', () => {
 		cy.createTestPost( {

--- a/tests/cypress/e2e/classic-editor/content-id.cy.js
+++ b/tests/cypress/e2e/classic-editor/content-id.cy.js
@@ -152,9 +152,7 @@ context( 'Classic Editor: Content ID', () => {
 	} );
 
 	it( 'shows a loading spinner while the content is still processing', () => {
-		// The metabox polls GET /content on page load for a post that has
-		// content. Stub it as still-processing so the spinner stays up and the
-		// player is not embedded (which would have 404-cached before this fix).
+		// Stub as still-processing so the spinner stays up for the assertion.
 		cy.intercept(
 			'GET',
 			'**/beyondwords/v1/projects/*/content/*',

--- a/tests/phpunit/editor/classic/test-metabox.php
+++ b/tests/phpunit/editor/classic/test-metabox.php
@@ -163,20 +163,9 @@ class MetaboxTest extends TestCase
     /**
      * A crafted Content ID must never reach a JS execution context.
      *
-     * Regression test for a stored XSS. The Content ID is editable post meta,
-     * saved with only sanitize_text_field() (which keeps double quotes), and was
-     * emitted into an inline `onload` JS string with esc_attr(). esc_attr()
-     * encodes `"` as `&quot;`, but the browser HTML-decodes the attribute before
-     * compiling the handler, so `&quot;` became a real `"` that closed the JS
-     * string literal and ran the rest of the value as code.
-     *
-     * REST-API content is now embedded by classic-metabox.js only after it polls
-     * the content status, so player_embed() emits no inline handler at all on
-     * this path. The Content ID travels in an esc_attr()'d `data-content-id`
-     * attribute and is read back with getAttribute(), so it is never interpolated
-     * into JavaScript source — removing the vector rather than escaping around
-     * it. The client-side path still embeds inline and is covered by
-     * player_embed_json_encodes_the_client_side_config() below.
+     * Regression test for a stored XSS: esc_attr()'s `&quot;` was HTML-decoded
+     * back to a real `"` that closed the inline onload's JS string literal. This
+     * path now emits no handler at all, so the ID stays an inert data attribute.
      *
      * @test
      */
@@ -192,11 +181,8 @@ class MetaboxTest extends TestCase
         // payload before we render — this keeps the assertions meaningful.
         update_post_meta($postId, 'beyondwords_project_id', 12345);
 
-        // Content IDs are charset-validated on save (Meta::sanitize_content_id), so
-        // update_post_meta() would blank this payload and nothing would render. Write
-        // it straight to the DB instead — a hostile value can now only reach the
-        // renderer via a raw row (legacy data, a direct DB write, or a future
-        // regression), which is exactly the case this escaping defence must survive.
+        // Content IDs are charset-validated on save, so a hostile value can only
+        // reach the renderer via a raw row — write one directly to reproduce that.
         $this->store_raw_content_id($postId, $payload);
 
         $html = $this->capture_output(function () use ($postId) {
@@ -205,38 +191,29 @@ class MetaboxTest extends TestCase
 
         $crawler = new Crawler($html);
 
-        // The injected markup must not spawn extra elements: exactly one player
-        // container and one (SDK) <script>.
+        // The injected markup must not spawn extra elements.
         $container = $crawler->filter('#beyondwords-metabox-player');
         $this->assertCount(1, $container);
 
         $script = $crawler->filter('script');
         $this->assertCount(1, $script);
 
-        // No inline handler on the polling path, so the payload has no JS
-        // execution context to break out of.
+        // No inline handler, so there is no JS context to break out of.
         $this->assertNull($script->attr('onload'));
 
-        // Crawler::attr() returns the HTML-decoded attribute — the exact string
-        // getAttribute() hands to the player SDK as a plain value.
         $this->assertSame($payload, $container->attr('data-content-id'));
 
-        // esc_attr() encoded the quotes, so the raw break-out sequence never
-        // appears in the emitted markup.
+        // esc_attr() encoded the quotes, so the break-out sequence never appears.
         $this->assertStringNotContainsString('"});alert(document.domain)', $html);
 
         wp_delete_post($postId, true);
     }
 
     /**
-     * The client-side (Magic Embed) path still embeds inline, so it must keep
-     * JSON-encoding its config.
+     * The client-side path still embeds inline, so it must keep JSON-encoding.
      *
-     * That integration is keyed on the source (post) ID and has no Content ID to
-     * poll, so player_embed() writes an inline `onload` handler. The preview
-     * token comes from the REST API and is untrusted in that output context, so
-     * the config is JSON-encoded with the HEX flags: an injected quote is
-     * hex-encoded and stays inside the JS string literal instead of closing it.
+     * It has no Content ID to poll, so the HEX flags are what stop an untrusted
+     * value closing the JS string literal.
      *
      * @test
      */
@@ -248,8 +225,7 @@ class MetaboxTest extends TestCase
             'post_title' => 'MetaboxTest::player_embed_json_encodes_the_client_side_config',
         ]);
 
-        // Client-side integration: a project ID but no Content ID, so the player
-        // embeds inline from the source (post) ID.
+        // A project ID but no Content ID, so the player embeds inline.
         update_post_meta($postId, 'beyondwords_project_id', 12345);
         update_post_meta(
             $postId,
@@ -267,13 +243,9 @@ class MetaboxTest extends TestCase
         $script = $crawler->filter('#beyondwords-metabox-player script');
         $this->assertCount(1, $script);
 
-        // Crawler::attr() returns the HTML-decoded attribute — exactly what the
-        // browser hands to the JS engine when the onload handler fires.
+        // attr() decodes the attribute, as the browser does before compiling it.
         $onload = $script->attr('onload');
 
-        // wp_json_encode() has hex-encoded the injected quotes so they stay
-        // inside the JS string literal. Assert the exact encoded value
-        // (structural quotes included) is present verbatim.
         $encoded = wp_json_encode(
             $payload,
             JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
@@ -283,7 +255,6 @@ class MetaboxTest extends TestCase
         // The raw break-out sequence (a bare " closing the string) must be absent.
         $this->assertStringNotContainsString('"});alert(document.domain)', $onload);
 
-        // The player is still initialised.
         $this->assertStringContainsString('new BeyondWords.Player(', $onload);
 
         wp_delete_post($postId, true);


### PR DESCRIPTION
Follow-up to #566 (already merged). Comment-only cleanup — **no behaviour change**.

Comments should say *why*, not *what*. #566 landed with a lot of narration and JSDoc prose that just restated the code; this drops it and keeps only the non-obvious rationale, at one or two lines each.

## What went

- **`src/editor/lib/poll-content-status.js`** — the worst offender (91 comment lines of 179). Dropped the per-constant docblocks, the "what it does" prose and the loop narration → 36 of 121.
- **`play-audio/hooks.js`** — 16-line hook docblock → a 2-line summary; the 5-line `mountContentIdRef` explainer → 2; deleted the block comments restating the `if`/`else`.
- **`content-id/classic-metabox.js`** — each helper's docblock trimmed to a one-liner + `@param`s; dropped the "skip while hidden" and "SDK constructor can throw" comments (the code already says both).
- **`classic/class-metabox.php`** — the two 14-line block comments → 2 lines each.
- **`tests/phpunit/.../test-metabox.php`** — both test docblocks → 3 lines; dropped the assertion narration and trimmed the `store_raw_content_id` note.

## What stayed (the non-obvious *why*)

- 404-caching is why we poll before embedding.
- Hidden cycles never fetch, so they must not spend the budget.
- One blip shouldn't abandon the wait.
- Unknown statuses count as terminal so the loop always ends.
- The SDK is only emitted for posts that had content at load (why we clear the spinner).
- The HEX flags stop an untrusted value closing the JS string literal.
- Why the block poll isn't Cypress-covered (SDK load isn't deterministic in CI).

## Deliberately untouched

The 5-line namespace comment in `hooks.js` and the best-effort-save comment in `classic-metabox.js` are both pre-existing in `main` — trimming them would drag unrelated code into this diff.

## Verification

`lint:js`, `webpack build` and `php -l` all pass. Diff is **-209/+44** and verifiably comment-only (no non-comment line changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)