### PR TITLE
fix: fall back to the default asset when a stored Embed is invalid

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,8 @@ Release date: tbc
 * [#542](https://github.com/beyondwords-io/wordpress-plugin/pull/542) Surface a `WP_Error` from `get_content()` instead of a fatal `TypeError`.
 * [#588](https://github.com/beyondwords-io/wordpress-plugin/pull/588) Ship `symfony/dom-crawler` 5.4.52 to fix CVE-2026-45071 (XXE / local file disclosure).
     * The composer constraint now floors at the patched release, so a vulnerable version can no longer be bundled.
+* [#599](https://github.com/beyondwords-io/wordpress-plugin/pull/599) Keep the player when a Source or Output change invalidates the stored "Embed".
+    * In the classic editor an "Embed" you never chose is no longer saved with the post, so those posts now follow later Source and Output changes.
 
 **Deprecations**
 

--- a/src/editor/components/settings-fields/class-settings-fields.php
+++ b/src/editor/components/settings-fields/class-settings-fields.php
@@ -280,10 +280,8 @@ class SettingsFields {
 	/**
 	 * Resolve the effective Embed value for a post.
 	 *
-	 * Centralised so the shown default and the rendered player (ConfigBuilder)
-	 * never diverge. Legacy opt-outs resolve to None; a value that no longer fits
-	 * the current Source × Output falls back to the default asset, because only an
-	 * explicit "None" — always a valid option — means "show no player".
+	 * Centralised so the shown default and the rendered player (ConfigBuilder) never
+	 * diverge; legacy opt-outs resolve to None, stale values to the default asset.
 	 *
 	 * @since 7.0.0
 	 *
@@ -419,9 +417,6 @@ class SettingsFields {
 	/**
 	 * Render the Player section fields: Embed.
 	 *
-	 * The select shows the effective value, which for an unset Embed is the derived
-	 * default — so the accompanying flag records whether the user actually chose one.
-	 *
 	 * @since 7.0.0
 	 *
 	 * @param \WP_Post $post The post object.
@@ -442,6 +437,7 @@ class SettingsFields {
 				'speechkit'
 			)
 		);
+		// Lets save() tell a real choice from the rendered default.
 		?>
 		<input type="hidden" id="beyondwords_embed_touched" name="beyondwords_embed_touched" value="" />
 		<?php
@@ -607,10 +603,7 @@ class SettingsFields {
 			'beyondwords_embed',
 		];
 
-		// The Embed is only persisted once the user picks one, because the select
-		// always submits a value — the derived default when untouched. Leaving it
-		// unset keeps classic posts in step with block posts and lets a later
-		// Source/Output change re-derive the default asset.
+		// Only a real choice is stored; an unset Embed is re-derived at render.
 		if ( empty( $_POST['beyondwords_embed_touched'] ) ) {
 			$keys = array_values( array_diff( $keys, [ 'beyondwords_embed' ] ) );
 		}

--- a/src/editor/components/settings-fields/class-settings-fields.php
+++ b/src/editor/components/settings-fields/class-settings-fields.php
@@ -281,7 +281,9 @@ class SettingsFields {
 	 * Resolve the effective Embed value for a post.
 	 *
 	 * Centralised so the shown default and the rendered player (ConfigBuilder)
-	 * never diverge; legacy opt-outs and no-longer-valid values resolve to None.
+	 * never diverge. Legacy opt-outs resolve to None; a value that no longer fits
+	 * the current Source × Output falls back to the default asset, because only an
+	 * explicit "None" — always a valid option — means "show no player".
 	 *
 	 * @since 7.0.0
 	 *
@@ -301,7 +303,7 @@ class SettingsFields {
 		}
 
 		if ( ! self::is_embed_valid( $embed, $source, $output ) ) {
-			$embed = self::EMBED_NONE;
+			$embed = self::default_embed( $source, $output );
 		}
 
 		return $embed;
@@ -417,6 +419,9 @@ class SettingsFields {
 	/**
 	 * Render the Player section fields: Embed.
 	 *
+	 * The select shows the effective value, which for an unset Embed is the derived
+	 * default — so the accompanying flag records whether the user actually chose one.
+	 *
 	 * @since 7.0.0
 	 *
 	 * @param \WP_Post $post The post object.
@@ -437,6 +442,9 @@ class SettingsFields {
 				'speechkit'
 			)
 		);
+		?>
+		<input type="hidden" id="beyondwords_embed_touched" name="beyondwords_embed_touched" value="" />
+		<?php
 	}
 
 	/**
@@ -598,6 +606,14 @@ class SettingsFields {
 			'beyondwords_video_size',
 			'beyondwords_embed',
 		];
+
+		// The Embed is only persisted once the user picks one, because the select
+		// always submits a value — the derived default when untouched. Leaving it
+		// unset keeps classic posts in step with block posts and lets a later
+		// Source/Output change re-derive the default asset.
+		if ( empty( $_POST['beyondwords_embed_touched'] ) ) {
+			$keys = array_values( array_diff( $keys, [ 'beyondwords_embed' ] ) );
+		}
 
 		foreach ( $keys as $key ) {
 			if ( ! isset( $_POST[ $key ] ) ) {

--- a/src/editor/components/settings-fields/classic-metabox.js
+++ b/src/editor/components/settings-fields/classic-metabox.js
@@ -91,11 +91,39 @@
 		return options;
 	};
 
+	/**
+	 * The default Embed for a post that hasn't chosen one: the first produced asset.
+	 *
+	 * Mirrors getDefaultEmbed() in settings-panel/helpers.js, but takes the options
+	 * the caller has already derived.
+	 *
+	 * @param {Array<{label: string, value: string}>} options The Embed options.
+	 *
+	 * @return {string} The default embed value.
+	 */
+	const getDefaultEmbed = ( options ) => {
+		const asset = options.find( ( option ) => option.value !== EMBED_NONE );
+
+		return asset ? asset.value : EMBED_NONE;
+	};
+
 	const settingsFields = {
 		init() {
 			this.source = document.getElementById( 'beyondwords_source' );
 			this.output = document.getElementById( 'beyondwords_output' );
 			this.embed = document.getElementById( 'beyondwords_embed' );
+			this.embedTouched = document.getElementById(
+				'beyondwords_embed_touched'
+			);
+
+			// Wired ahead of the guard below because this flag decides whether
+			// SettingsFields::save() persists the Embed at all — an untouched Embed
+			// stays unset in meta, matching the block editor.
+			if ( this.embed && this.embedTouched ) {
+				this.embed.addEventListener( 'change', () => {
+					this.embedTouched.value = '1';
+				} );
+			}
 
 			if ( ! this.source && ! this.output ) {
 				return;
@@ -154,7 +182,10 @@
 			const options = getEmbedOptions( source, output );
 			const previous = this.embed.value;
 			const stillValid = options.some( ( o ) => o.value === previous );
-			const selected = stillValid ? previous : EMBED_NONE;
+			// A value the new Source × Output cannot produce becomes the default
+			// asset, not None: None is always a valid option, so an explicit
+			// opt-out is never rebuilt away.
+			const selected = stillValid ? previous : getDefaultEmbed( options );
 
 			this.embed.replaceChildren(
 				...options.map( ( option ) => {

--- a/src/editor/components/settings-fields/classic-metabox.js
+++ b/src/editor/components/settings-fields/classic-metabox.js
@@ -92,10 +92,7 @@
 	};
 
 	/**
-	 * The default Embed for a post that hasn't chosen one: the first produced asset.
-	 *
-	 * Mirrors getDefaultEmbed() in settings-panel/helpers.js, but takes the options
-	 * the caller has already derived.
+	 * The first produced asset, or None when the options hold no asset.
 	 *
 	 * @param {Array<{label: string, value: string}>} options The Embed options.
 	 *
@@ -116,9 +113,7 @@
 				'beyondwords_embed_touched'
 			);
 
-			// Wired ahead of the guard below because this flag decides whether
-			// SettingsFields::save() persists the Embed at all — an untouched Embed
-			// stays unset in meta, matching the block editor.
+			// Set before the guard below: the flag gates the whole save() write.
 			if ( this.embed && this.embedTouched ) {
 				this.embed.addEventListener( 'change', () => {
 					this.embedTouched.value = '1';
@@ -182,9 +177,7 @@
 			const options = getEmbedOptions( source, output );
 			const previous = this.embed.value;
 			const stillValid = options.some( ( o ) => o.value === previous );
-			// A value the new Source × Output cannot produce becomes the default
-			// asset, not None: None is always a valid option, so an explicit
-			// opt-out is never rebuilt away.
+			// Only a stale value lands here — None is valid for every combination.
 			const selected = stillValid ? previous : getDefaultEmbed( options );
 
 			this.embed.replaceChildren(

--- a/src/editor/components/settings-fields/classic-metabox.test.js
+++ b/src/editor/components/settings-fields/classic-metabox.test.js
@@ -1,9 +1,8 @@
 /* global describe, it, expect, beforeEach, jest */
 
 /*
- * classic-metabox.js is a bare IIFE that wires itself to the rendered metabox, so
- * these tests build the markup PHP would emit, re-run the module against it, and
- * drive it through the same `change` events a user would.
+ * The module is a bare IIFE, so each test rebuilds the markup PHP emits, re-runs
+ * the module against it, and drives it with real `change` events.
  */
 
 const SOURCE_VALUES = [ 'post', 'script', 'post_and_script' ];
@@ -19,18 +18,6 @@ const renderSelect = ( id, values, selected ) =>
 		)
 		.join( '' ) }</select>`;
 
-/**
- * Render the metabox fields and boot the module against them.
- *
- * @param {Object}        options              Fixture options.
- * @param {string}        options.source       The selected Source.
- * @param {string}        options.output       The selected Output.
- * @param {Array<string>} options.embedOptions The Embed options PHP rendered.
- * @param {string}        options.embed        The selected Embed.
- * @param {boolean}       options.withTouched  Whether the touched flag is present.
- *
- * @return {Object} The wired elements.
- */
 const boot = ( {
 	source = 'post',
 	output = 'audio',
@@ -79,8 +66,7 @@ describe( 'classic-metabox recomputeEmbed', () => {
 
 		change( output, 'video' );
 
-		// audio_post cannot be produced by Post × Video, so the post keeps a
-		// player on the default asset rather than falling through to None.
+		// Post × Video cannot produce audio_post, so the post keeps a player.
 		expect( optionValues( embed ) ).toEqual( [ 'none', 'video_post' ] );
 		expect( embed.value ).toBe( 'video_post' );
 	} );
@@ -106,8 +92,7 @@ describe( 'classic-metabox recomputeEmbed', () => {
 	} );
 
 	it( 'falls back to None when no asset can be produced', () => {
-		// Defensive: the rendered option list always has at least one asset, but
-		// getDefaultEmbed must still yield a selectable value if it ever does not.
+		// Defensive: the rendered list always has an asset, but must not break if not.
 		const { output, embed } = boot( {
 			embedOptions: [ 'none' ],
 			embed: 'none',
@@ -139,8 +124,7 @@ describe( 'classic-metabox embed touched flag', () => {
 
 		change( output, 'video' );
 
-		// The rebuild picked video_post, but the user never chose it — so save()
-		// leaves the meta unset and re-derives it, matching the block editor.
+		// The rebuild picked video_post, but the user never chose it.
 		expect( embed.value ).toBe( 'video_post' );
 		expect( touched.value ).toBe( '' );
 	} );

--- a/src/editor/components/settings-fields/classic-metabox.test.js
+++ b/src/editor/components/settings-fields/classic-metabox.test.js
@@ -1,0 +1,167 @@
+/* global describe, it, expect, beforeEach, jest */
+
+/*
+ * classic-metabox.js is a bare IIFE that wires itself to the rendered metabox, so
+ * these tests build the markup PHP would emit, re-run the module against it, and
+ * drive it through the same `change` events a user would.
+ */
+
+const SOURCE_VALUES = [ 'post', 'script', 'post_and_script' ];
+const OUTPUT_VALUES = [ 'audio', 'video', 'audio_and_video' ];
+
+const renderSelect = ( id, values, selected ) =>
+	`<select id="${ id }" name="${ id }">${ values
+		.map(
+			( value ) =>
+				`<option value="${ value }"${
+					value === selected ? ' selected' : ''
+				}>${ value }</option>`
+		)
+		.join( '' ) }</select>`;
+
+/**
+ * Render the metabox fields and boot the module against them.
+ *
+ * @param {Object}        options              Fixture options.
+ * @param {string}        options.source       The selected Source.
+ * @param {string}        options.output       The selected Output.
+ * @param {Array<string>} options.embedOptions The Embed options PHP rendered.
+ * @param {string}        options.embed        The selected Embed.
+ * @param {boolean}       options.withTouched  Whether the touched flag is present.
+ *
+ * @return {Object} The wired elements.
+ */
+const boot = ( {
+	source = 'post',
+	output = 'audio',
+	embedOptions = [ 'none', 'audio_post' ],
+	embed = 'audio_post',
+	withTouched = true,
+} = {} ) => {
+	document.body.innerHTML = [
+		renderSelect( 'beyondwords_source', SOURCE_VALUES, source ),
+		renderSelect( 'beyondwords_output', OUTPUT_VALUES, output ),
+		renderSelect( 'beyondwords_embed', embedOptions, embed ),
+		withTouched
+			? '<input type="hidden" id="beyondwords_embed_touched" name="beyondwords_embed_touched" value="" />'
+			: '',
+		// The wrappers the Source/Output handlers show and hide.
+		'<div id="beyondwords-metabox-settings--beyondwords-script-template-id"></div>',
+		'<div id="beyondwords-metabox-settings--beyondwords-video-template-id"></div>',
+		'<div id="beyondwords-metabox-settings--beyondwords-video-size"></div>',
+	].join( '' );
+
+	require( './classic-metabox' );
+
+	return {
+		source: document.getElementById( 'beyondwords_source' ),
+		output: document.getElementById( 'beyondwords_output' ),
+		embed: document.getElementById( 'beyondwords_embed' ),
+		touched: document.getElementById( 'beyondwords_embed_touched' ),
+	};
+};
+
+const change = ( element, value ) => {
+	element.value = value;
+	element.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+};
+
+const optionValues = ( select ) =>
+	Array.from( select.options ).map( ( option ) => option.value );
+
+describe( 'classic-metabox recomputeEmbed', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
+
+	it( 'selects the first produced asset when the stored value is invalid', () => {
+		const { output, embed } = boot( { embed: 'audio_post' } );
+
+		change( output, 'video' );
+
+		// audio_post cannot be produced by Post × Video, so the post keeps a
+		// player on the default asset rather than falling through to None.
+		expect( optionValues( embed ) ).toEqual( [ 'none', 'video_post' ] );
+		expect( embed.value ).toBe( 'video_post' );
+	} );
+
+	it( 'keeps a value the new Source × Output can still produce', () => {
+		const { source, embed } = boot( {
+			output: 'audio_and_video',
+			embedOptions: [ 'none', 'audio_post', 'video_post' ],
+			embed: 'video_post',
+		} );
+
+		change( source, 'post_and_script' );
+
+		expect( embed.value ).toBe( 'video_post' );
+	} );
+
+	it( 'keeps an explicit None, which every Source × Output offers', () => {
+		const { output, embed } = boot( { embed: 'none' } );
+
+		change( output, 'video' );
+
+		expect( embed.value ).toBe( 'none' );
+	} );
+
+	it( 'falls back to None when no asset can be produced', () => {
+		// Defensive: the rendered option list always has at least one asset, but
+		// getDefaultEmbed must still yield a selectable value if it ever does not.
+		const { output, embed } = boot( {
+			embedOptions: [ 'none' ],
+			embed: 'none',
+		} );
+
+		change( output, 'audio' );
+
+		expect( embed.value ).toBe( 'none' );
+	} );
+} );
+
+describe( 'classic-metabox embed touched flag', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
+
+	it( 'is set when the user picks an Embed', () => {
+		const { embed, touched } = boot();
+
+		expect( touched.value ).toBe( '' );
+
+		change( embed, 'none' );
+
+		expect( touched.value ).toBe( '1' );
+	} );
+
+	it( 'stays empty when an Output change rebuilds the Embed', () => {
+		const { output, embed, touched } = boot( { embed: 'audio_post' } );
+
+		change( output, 'video' );
+
+		// The rebuild picked video_post, but the user never chose it — so save()
+		// leaves the meta unset and re-derives it, matching the block editor.
+		expect( embed.value ).toBe( 'video_post' );
+		expect( touched.value ).toBe( '' );
+	} );
+
+	it( 'stays empty when a Source change rebuilds the Embed', () => {
+		const { source, touched } = boot( {
+			source: 'post',
+			embedOptions: [ 'none', 'audio_post' ],
+			embed: 'audio_post',
+		} );
+
+		change( source, 'script' );
+
+		expect( touched.value ).toBe( '' );
+	} );
+
+	it( 'is not required for the Embed to be recomputed', () => {
+		const { output, embed } = boot( { withTouched: false } );
+
+		change( output, 'video' );
+
+		expect( embed.value ).toBe( 'video_post' );
+	} );
+} );

--- a/src/editor/components/settings-panel/player-section.js
+++ b/src/editor/components/settings-panel/player-section.js
@@ -45,8 +45,7 @@ export function PlayerSection( { withPanel = true } ) {
 
 	// Never write meta on mount: an unset value already means "show", and a
 	// mount-time write races the other panels' preselect writes (e.g. Generate audio).
-	// A stored value the new Source × Output cannot produce becomes the default
-	// asset, not None — None is always valid, so an explicit opt-out never lands here.
+	// Only a stale value lands here — None is valid for every combination.
 	useEffect( () => {
 		if ( stored && ! isEmbedValid( stored, source, output ) ) {
 			setEmbed( getDefaultEmbed( source, output ) );

--- a/src/editor/components/settings-panel/player-section.js
+++ b/src/editor/components/settings-panel/player-section.js
@@ -11,7 +11,6 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import {
-	EMBED_NONE,
 	getDefaultEmbed,
 	getEmbedOptions,
 	isEmbedValid,
@@ -46,9 +45,11 @@ export function PlayerSection( { withPanel = true } ) {
 
 	// Never write meta on mount: an unset value already means "show", and a
 	// mount-time write races the other panels' preselect writes (e.g. Generate audio).
+	// A stored value the new Source × Output cannot produce becomes the default
+	// asset, not None — None is always valid, so an explicit opt-out never lands here.
 	useEffect( () => {
 		if ( stored && ! isEmbedValid( stored, source, output ) ) {
-			setEmbed( EMBED_NONE );
+			setEmbed( getDefaultEmbed( source, output ) );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ source, output ] );

--- a/tests/cypress/e2e/block-editor/settings-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/settings-panel.cy.js
@@ -183,5 +183,45 @@ context( 'Block Editor: Settings panel', () => {
 						] );
 					} );
 			} );
+
+			it( `Player Embed keeps a player when Output invalidates it for a ${ postType.name }`, () => {
+				cy.createPost( { postType } );
+				cy.openBeyondwordsPluginSidebar();
+
+				// Store an explicit choice, which is what the cleanup effect acts on.
+				select( 'beyondwords--output' ).select( 'Audio + video', {
+					force: true,
+				} );
+				select( 'beyondwords--embed' ).select( 'Video (post)', {
+					force: true,
+				} );
+
+				// Video (post) cannot be produced by Post × Audio, so the effect
+				// rewrites it to the default asset rather than to None.
+				select( 'beyondwords--output' ).select( 'Audio', {
+					force: true,
+				} );
+
+				select( 'beyondwords--embed' )
+					.find( 'option:selected' )
+					.should( 'have.text', 'Audio (post)' );
+			} );
+
+			it( `Player Embed keeps an explicit None across an Output change for a ${ postType.name }`, () => {
+				cy.createPost( { postType } );
+				cy.openBeyondwordsPluginSidebar();
+
+				select( 'beyondwords--embed' ).select( 'None', {
+					force: true,
+				} );
+				select( 'beyondwords--output' ).select( 'Video', {
+					force: true,
+				} );
+
+				// None is valid for every Source × Output, so it is never rewritten.
+				select( 'beyondwords--embed' )
+					.find( 'option:selected' )
+					.should( 'have.text', 'None' );
+			} );
 		} );
 } );

--- a/tests/cypress/e2e/block-editor/settings-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/settings-panel.cy.js
@@ -196,8 +196,7 @@ context( 'Block Editor: Settings panel', () => {
 					force: true,
 				} );
 
-				// Video (post) cannot be produced by Post × Audio, so the effect
-				// rewrites it to the default asset rather than to None.
+				// Post × Audio cannot produce Video (post), so the effect rewrites it.
 				select( 'beyondwords--output' ).select( 'Audio', {
 					force: true,
 				} );

--- a/tests/cypress/e2e/classic-editor/settings-fields.cy.js
+++ b/tests/cypress/e2e/classic-editor/settings-fields.cy.js
@@ -140,6 +140,77 @@ context( 'Classic Editor: Settings fields', () => {
 					} );
 			} );
 
+			it( `Player Embed keeps a player when Output invalidates it for a ${ postType.name }`, () => {
+				cy.createPost( { postType } );
+
+				cy.get( 'select#beyondwords_embed' )
+					.find( 'option:selected' )
+					.should( 'have.text', 'Audio (post)' );
+
+				// Post × Video cannot produce Audio (post), so the rebuild lands on
+				// the default asset — publishing here must not silently drop the player.
+				cy.get( 'select#beyondwords_output' ).select( 'Video' );
+
+				cy.get( 'select#beyondwords_embed' )
+					.find( 'option:selected' )
+					.should( 'have.text', 'Video (post)' );
+			} );
+
+			it( `Player Embed keeps an explicit None across an Output change for a ${ postType.name }`, () => {
+				cy.createPost( { postType } );
+
+				// None is offered by every Source × Output, so it is never invalid
+				// and the deliberate opt-out survives the rebuild.
+				cy.get( 'select#beyondwords_embed' ).select( 'None' );
+				cy.get( 'select#beyondwords_output' ).select( 'Video' );
+
+				cy.get( 'select#beyondwords_embed' )
+					.find( 'option:selected' )
+					.should( 'have.text', 'None' );
+			} );
+
+			it( `only persists a chosen Embed for a ${ postType.name }`, () => {
+				cy.createTestPost( {
+					title: `Cypress Test: untouched Embed for a ${ postType.name }`,
+					status: 'draft',
+					postType: postType.slug,
+				} ).then( ( postId ) => {
+					cy.visit(
+						`/wp-admin/post.php?post=${ postId }&action=edit`
+					);
+
+					// Change Output only. The Embed select rebuilds to Video (post),
+					// but the user never picked it.
+					cy.get( 'select#beyondwords_output' ).select( 'Video' );
+					cy.get( 'select#beyondwords_embed' )
+						.find( 'option:selected' )
+						.should( 'have.text', 'Video (post)' );
+
+					cy.contains( 'input[type="submit"]', 'Publish' ).click();
+
+					cy.task( 'getPostMeta', {
+						postId,
+						metaKey: 'beyondwords_output',
+					} ).should( 'equal', 'video' );
+
+					// Left unset, matching the block editor, so a later Source/Output
+					// change re-derives the default rather than fighting a stored value.
+					cy.task( 'getPostMeta', {
+						postId,
+						metaKey: 'beyondwords_embed',
+					} ).should( 'equal', '' );
+
+					// An actual choice is persisted.
+					cy.get( 'select#beyondwords_embed' ).select( 'None' );
+					cy.contains( 'input[type="submit"]', 'Update' ).click();
+
+					cy.task( 'getPostMeta', {
+						postId,
+						metaKey: 'beyondwords_embed',
+					} ).should( 'equal', 'none' );
+				} );
+			} );
+
 			it( `persists Content/Format/Player selections for a ${ postType.name }`, () => {
 				cy.createPost( { postType } );
 

--- a/tests/cypress/e2e/classic-editor/settings-fields.cy.js
+++ b/tests/cypress/e2e/classic-editor/settings-fields.cy.js
@@ -147,8 +147,7 @@ context( 'Classic Editor: Settings fields', () => {
 					.find( 'option:selected' )
 					.should( 'have.text', 'Audio (post)' );
 
-				// Post × Video cannot produce Audio (post), so the rebuild lands on
-				// the default asset — publishing here must not silently drop the player.
+				// Publishing here must not silently drop the player.
 				cy.get( 'select#beyondwords_output' ).select( 'Video' );
 
 				cy.get( 'select#beyondwords_embed' )
@@ -159,8 +158,7 @@ context( 'Classic Editor: Settings fields', () => {
 			it( `Player Embed keeps an explicit None across an Output change for a ${ postType.name }`, () => {
 				cy.createPost( { postType } );
 
-				// None is offered by every Source × Output, so it is never invalid
-				// and the deliberate opt-out survives the rebuild.
+				// None is never invalid, so the deliberate opt-out survives.
 				cy.get( 'select#beyondwords_embed' ).select( 'None' );
 				cy.get( 'select#beyondwords_output' ).select( 'Video' );
 
@@ -179,8 +177,7 @@ context( 'Classic Editor: Settings fields', () => {
 						`/wp-admin/post.php?post=${ postId }&action=edit`
 					);
 
-					// Change Output only. The Embed select rebuilds to Video (post),
-					// but the user never picked it.
+					// The select rebuilds to Video (post), but the user never picked it.
 					cy.get( 'select#beyondwords_output' ).select( 'Video' );
 					cy.get( 'select#beyondwords_embed' )
 						.find( 'option:selected' )
@@ -193,8 +190,7 @@ context( 'Classic Editor: Settings fields', () => {
 						metaKey: 'beyondwords_output',
 					} ).should( 'equal', 'video' );
 
-					// Left unset, matching the block editor, so a later Source/Output
-					// change re-derives the default rather than fighting a stored value.
+					// Left unset, matching the block editor.
 					cy.task( 'getPostMeta', {
 						postId,
 						metaKey: 'beyondwords_embed',

--- a/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
+++ b/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
@@ -323,8 +323,7 @@ class SettingsFieldsTest extends TestCase
      */
     public function render_player_section_falls_back_to_default_asset_when_embed_invalid()
     {
-        // Embed = video_post is invalid for Post + Audio → falls back to the first
-        // produced asset, so the post keeps a player instead of silently losing one.
+        // video_post is invalid for Post + Audio, so the post keeps a player.
         $post = self::factory()->post->create_and_get([
             'post_title' => 'SettingsFieldsTest::player::invalid',
             'meta_input' => ['beyondwords_embed' => 'video_post'],
@@ -356,8 +355,7 @@ class SettingsFieldsTest extends TestCase
             SettingsFields::render_player_section($post);
         }));
 
-        // The select always submits a value, so save() reads this flag to tell a
-        // real choice from the rendered default. It ships empty; JS sets it on change.
+        // Ships empty; JS sets it on change.
         $flag = $crawler->filter('input#beyondwords_embed_touched');
         $this->assertCount(1, $flag);
         $this->assertSame('hidden', $flag->attr('type'));
@@ -391,8 +389,7 @@ class SettingsFieldsTest extends TestCase
      */
     public function get_effective_embed_keeps_an_explicit_none()
     {
-        // None is valid for every Source × Output, so the deliberate opt-out is never
-        // re-derived into an asset — this is what separates it from a stale value.
+        // None is valid everywhere, which is what separates it from a stale value.
         $postId = self::factory()->post->create([
             'post_title' => 'SettingsFieldsTest::effective::none',
             'meta_input' => [
@@ -497,8 +494,7 @@ class SettingsFieldsTest extends TestCase
         $_POST['beyondwords_settings_fields_nonce'] = wp_create_nonce('beyondwords_settings_fields');
         $_POST['beyondwords_output']                = 'video';
 
-        // Untouched: the select still submits the rendered default, but storing it
-        // would pin the post to a publish-time value the user never picked.
+        // Untouched: the select still submits the rendered default.
         $_POST['beyondwords_embed'] = 'video_post';
 
         SettingsFields::save($postId);
@@ -514,8 +510,7 @@ class SettingsFieldsTest extends TestCase
 
         $this->assertSame('none', get_post_meta($postId, 'beyondwords_embed', true));
 
-        // An untouched later save leaves the stored choice alone rather than
-        // overwriting it with the default asset.
+        // An untouched later save leaves the stored choice alone.
         unset($_POST['beyondwords_embed_touched']);
         $_POST['beyondwords_embed'] = 'video_post';
 

--- a/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
+++ b/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
@@ -35,7 +35,8 @@ class SettingsFieldsTest extends TestCase
             $_POST['beyondwords_output'],
             $_POST['beyondwords_video_template_id'],
             $_POST['beyondwords_video_size'],
-            $_POST['beyondwords_embed']
+            $_POST['beyondwords_embed'],
+            $_POST['beyondwords_embed_touched']
         );
 
         parent::tearDown();
@@ -320,9 +321,10 @@ class SettingsFieldsTest extends TestCase
      * @test
      * @group integration
      */
-    public function render_player_section_falls_back_to_none_when_embed_invalid()
+    public function render_player_section_falls_back_to_default_asset_when_embed_invalid()
     {
-        // Embed = video_post is invalid for Post + Audio → falls back to None.
+        // Embed = video_post is invalid for Post + Audio → falls back to the first
+        // produced asset, so the post keeps a player instead of silently losing one.
         $post = self::factory()->post->create_and_get([
             'post_title' => 'SettingsFieldsTest::player::invalid',
             'meta_input' => ['beyondwords_embed' => 'video_post'],
@@ -333,11 +335,110 @@ class SettingsFieldsTest extends TestCase
         }));
 
         $this->assertSame(
-            'none',
+            'audio_post',
             $crawler->filter('select#beyondwords_embed option[selected]')->attr('value')
         );
 
         wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     * @group integration
+     */
+    public function render_player_section_outputs_an_untouched_embed_flag()
+    {
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'SettingsFieldsTest::player::touched',
+        ]);
+
+        $crawler = new Crawler($this->capture_output(function () use ($post) {
+            SettingsFields::render_player_section($post);
+        }));
+
+        // The select always submits a value, so save() reads this flag to tell a
+        // real choice from the rendered default. It ships empty; JS sets it on change.
+        $flag = $crawler->filter('input#beyondwords_embed_touched');
+        $this->assertCount(1, $flag);
+        $this->assertSame('hidden', $flag->attr('type'));
+        $this->assertSame('beyondwords_embed_touched', $flag->attr('name'));
+        $this->assertSame('', $flag->attr('value'));
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * @test
+     */
+    public function get_effective_embed_falls_back_to_the_default_asset_when_invalid()
+    {
+        // Output was changed to Video after audio_post was stored.
+        $postId = self::factory()->post->create([
+            'post_title' => 'SettingsFieldsTest::effective::invalid',
+            'meta_input' => [
+                'beyondwords_output' => 'video',
+                'beyondwords_embed'  => 'audio_post',
+            ],
+        ]);
+
+        $this->assertSame(SettingsFields::EMBED_VIDEO_POST, SettingsFields::get_effective_embed($postId));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     */
+    public function get_effective_embed_keeps_an_explicit_none()
+    {
+        // None is valid for every Source × Output, so the deliberate opt-out is never
+        // re-derived into an asset — this is what separates it from a stale value.
+        $postId = self::factory()->post->create([
+            'post_title' => 'SettingsFieldsTest::effective::none',
+            'meta_input' => [
+                'beyondwords_output' => 'video',
+                'beyondwords_embed'  => 'none',
+            ],
+        ]);
+
+        $this->assertSame(SettingsFields::EMBED_NONE, SettingsFields::get_effective_embed($postId));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     */
+    public function get_effective_embed_resolves_an_unset_value_via_the_legacy_flag()
+    {
+        $postId = self::factory()->post->create([
+            'post_title' => 'SettingsFieldsTest::effective::legacy',
+            'meta_input' => ['beyondwords_disabled' => '1'],
+        ]);
+
+        // Pre-v7 opt-out with no Embed stored → None.
+        $this->assertSame(SettingsFields::EMBED_NONE, SettingsFields::get_effective_embed($postId));
+
+        // An explicit asset outranks the legacy flag.
+        update_post_meta($postId, 'beyondwords_embed', SettingsFields::EMBED_AUDIO_POST);
+        $this->assertSame(SettingsFields::EMBED_AUDIO_POST, SettingsFields::get_effective_embed($postId));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     */
+    public function get_effective_embed_defaults_an_unset_value_to_the_first_asset()
+    {
+        $postId = self::factory()->post->create([
+            'post_title' => 'SettingsFieldsTest::effective::unset',
+            'meta_input' => ['beyondwords_source' => 'script'],
+        ]);
+
+        $this->assertSame(SettingsFields::EMBED_AUDIO_SCRIPT, SettingsFields::get_effective_embed($postId));
+
+        wp_delete_post($postId, true);
     }
 
     /**
@@ -360,6 +461,7 @@ class SettingsFieldsTest extends TestCase
         $_POST['beyondwords_video_template_id']     = '3';
         $_POST['beyondwords_video_size']            = 'landscape';
         $_POST['beyondwords_embed']                 = 'audio_post';
+        $_POST['beyondwords_embed_touched']         = '1';
 
         SettingsFields::save($postId);
 
@@ -381,6 +483,45 @@ class SettingsFieldsTest extends TestCase
         SettingsFields::save($postId);
         $this->assertSame('post_and_script', get_post_meta($postId, 'beyondwords_source', true));
         $this->assertSame('3', get_post_meta($postId, 'beyondwords_video_template_id', true));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     */
+    public function save_only_persists_the_embed_the_user_chose()
+    {
+        $postId = self::factory()->post->create(['post_title' => 'SettingsFieldsTest::save_embed']);
+
+        $_POST['beyondwords_settings_fields_nonce'] = wp_create_nonce('beyondwords_settings_fields');
+        $_POST['beyondwords_output']                = 'video';
+
+        // Untouched: the select still submits the rendered default, but storing it
+        // would pin the post to a publish-time value the user never picked.
+        $_POST['beyondwords_embed'] = 'video_post';
+
+        SettingsFields::save($postId);
+
+        $this->assertSame('video', get_post_meta($postId, 'beyondwords_output', true));
+        $this->assertSame('', get_post_meta($postId, 'beyondwords_embed', true));
+
+        // Touched → persisted.
+        $_POST['beyondwords_embed_touched'] = '1';
+        $_POST['beyondwords_embed']         = 'none';
+
+        SettingsFields::save($postId);
+
+        $this->assertSame('none', get_post_meta($postId, 'beyondwords_embed', true));
+
+        // An untouched later save leaves the stored choice alone rather than
+        // overwriting it with the default asset.
+        unset($_POST['beyondwords_embed_touched']);
+        $_POST['beyondwords_embed'] = 'video_post';
+
+        SettingsFields::save($postId);
+
+        $this->assertSame('none', get_post_meta($postId, 'beyondwords_embed', true));
 
         wp_delete_post($postId, true);
     }

--- a/tests/phpunit/player/test-config-builder.php
+++ b/tests/phpunit/player/test-config-builder.php
@@ -361,12 +361,8 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * A stored Embed that no longer fits the current Source × Output falls back to the
-     * default asset, so the post keeps a player.
-     *
-     * Source=Script × Output=Video can only produce "video_script", which sets both
-     * params — a regression to None (or to any other asset) fails this assertion
-     * rather than passing on absence.
+     * Script × Video only produces "video_script", so a regression fails positively
+     * here rather than passing on key absence.
      *
      * @test
      */
@@ -387,10 +383,7 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * An explicit None is not an invalid value, so an Output change never re-derives it.
-     *
-     * The counterpart to the test above: same Source × Output, where the default asset
-     * would have set video/summary.
+     * Counterpart to the test above, where the default asset would have set both params.
      *
      * @test
      */

--- a/tests/phpunit/player/test-config-builder.php
+++ b/tests/phpunit/player/test-config-builder.php
@@ -361,16 +361,45 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * A stored Embed that no longer fits the current Source × Output falls back to None.
+     * A stored Embed that no longer fits the current Source × Output falls back to the
+     * default asset, so the post keeps a player.
+     *
+     * Source=Script × Output=Video can only produce "video_script", which sets both
+     * params — a regression to None (or to any other asset) fails this assertion
+     * rather than passing on absence.
      *
      * @test
      */
-    public function merge_post_settings_embed_invalid_for_source_output_falls_back_to_none()
+    public function merge_post_settings_embed_invalid_for_source_output_falls_back_to_default_asset()
     {
         $post = $this->createEmbedPost([
-            'beyondwords_source' => 'post',
-            'beyondwords_output' => 'audio',
-            'beyondwords_embed'  => 'video_script',
+            'beyondwords_source' => 'script',
+            'beyondwords_output' => 'video',
+            'beyondwords_embed'  => 'audio_post',
+        ]);
+
+        $params = ConfigBuilder::merge_post_settings($post, []);
+
+        $this->assertTrue($params['video']);
+        $this->assertTrue($params['summary']);
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * An explicit None is not an invalid value, so an Output change never re-derives it.
+     *
+     * The counterpart to the test above: same Source × Output, where the default asset
+     * would have set video/summary.
+     *
+     * @test
+     */
+    public function merge_post_settings_embed_none_survives_an_invalidating_output()
+    {
+        $post = $this->createEmbedPost([
+            'beyondwords_source' => 'script',
+            'beyondwords_output' => 'video',
+            'beyondwords_embed'  => 'none',
         ]);
 
         $params = ConfigBuilder::merge_post_settings($post, []);


### PR DESCRIPTION
## Problem

When a stored `beyondwords_embed` became invalid after a Source or Output change, all three layers resolved it to **None**, so the post published with no player and no warning:

- classic: `recomputeEmbed()` in `src/editor/components/settings-fields/classic-metabox.js`
- block: the `useEffect` in `src/editor/components/settings-panel/player-section.js`
- PHP: `get_effective_embed()` in `src/editor/components/settings-fields/class-settings-fields.php`

The rule was consistent, but the editors exposed it differently. Block keeps an untouched Embed unset in meta and live-derives the default, so the rule rarely fired. Classic rendered the derived default into the form and persisted it on publish, so a user who never touched Embed still hit the None fallback after changing Output — same action, different outcome per editor.

Reproduction (classic): new post → Embed shows Audio (post) → change Output to Video → Embed rebuilds and selects None → publish → no player.

## What changed

**1. Invalidation now resolves to the first produced asset, not None.**

| Layer | Location |
|---|---|
| PHP | `get_effective_embed()` — `class-settings-fields.php` |
| Block | the `useEffect` — `player-section.js` |
| Classic | `recomputeEmbed()` — `classic-metabox.js` |

An explicit **None** is unaffected: None is a valid option for every Source × Output, so it never reaches the invalidation branch. That is precisely what makes it the deliberate opt-out, and it is now covered by a test in each layer.

**2. Classic no longer persists an Embed the user did not choose.**

The Player section renders a `beyondwords_embed_touched` hidden input, `classic-metabox.js` sets it on a user `change` of the Embed select, and `save()` drops `beyondwords_embed` from its key list when the flag is empty.

A Source/Output rebuild deliberately does **not** set the flag — a rebuild is not a choice — so an untouched Embed stays unset in meta and is re-derived at render, matching the block editor. This also resolves the wider asymmetry where block posts followed later default changes while classic posts were pinned to publish-time values.

## Reviewer notes

- **Classic can no longer set Embed with JS disabled**, since the touched flag is set by JS. `classic-metabox.js` is already required for the Script template / Video field show-hide behaviour, so classic is already degraded without it — but this widens that. It is inherent to the unified-persistence approach, not an oversight.
- **The flag is wired before `init()`'s early return**, because it gates whether `save()` persists the Embed at all; it must be set even if Source/Output are somehow absent.
- **Two existing tests encoded the old rule and are corrected.** `merge_post_settings_embed_invalid_for_source_output_falls_back_to_none` asserted only *key absence*, so it would have passed either way — it moves to Script × Video, where the default asset sets both `video` and `summary`, so a regression now actually fails. A companion test proves an explicit None survives the same invalidation.
- The front end was never at risk regardless, because `get_effective_embed()` re-validates at render time.

## Testing

- **PHPUnit** — 720 tests pass, 1 skip (the known multisite-only case). Adds direct `get_effective_embed()` cases (including the previously untested unset + legacy `beyondwords_disabled` branch), `save()` cases for both sides of the flag, and a check that the hidden input renders.
- **Jest** — 50 tests pass, 8 new in `classic-metabox.test.js`. The classic module is a bare IIFE, so the suite boots it against jsdom and drives it with real `change` events rather than adding test hooks to production code.
- **Cypress** — `classic-editor/settings-fields` 24/24, `block-editor/settings-panel` 18/18, both `display-player` specs 6/6. New cases cover invalidation landing on the default asset, an explicit None surviving, and (classic) an untouched Embed staying out of meta while a chosen one persists, asserted via `getPostMeta`.
- **Lint** — `phpcs` clean on the changed PHP, `lint:js` clean across `./src`.

The invalidation fallback previously had no test in the block or classic layer at all; it does now in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
