### PR TITLE
Remove the Script-only Source option (v7)

### DIFF
--- a/doc/legacy-meta-migration.md
+++ b/doc/legacy-meta-migration.md
@@ -35,6 +35,21 @@ To carry existing opt-outs forward, the v7.0.0 migration in
 flag. `Player::is_enabled()` still honours `beyondwords_disabled` as a fallback
 for any post the migration hasn't reached (e.g. after a downgrade/re-upgrade).
 
+### `beyondwords_source = script` → `post_and_script`
+
+Source offered Post / Script / Post + script during the 7.0.0 betas, but
+script-only was never a real mode: the script is derived from the post body, so
+the platform generates the post assets either way (verified on staging — every
+Source = Script post produced article assets). The Embed dropdown then derived
+script assets only, hiding post assets that existed on the content item.
+
+Script was dropped from the option list. `SettingsFields::normalize_source()`
+and `normalizeSource()` (settings-panel/helpers.js) resolve `script`, unknown,
+and unset values to a source the dropdown offers, and the v7.0.0 migration
+`migrate_source_script_to_post_and_script()` rewrites the meta. Posts with no
+explicit Embed get one pinned to the script asset first, so the upgrade doesn't
+switch which asset the front-end player shows.
+
 ### Components removed
 
 - `src/editor/components/player-style/`

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,9 @@ Release date: tbc
 * [#542](https://github.com/beyondwords-io/wordpress-plugin/pull/542) Surface a `WP_Error` from `get_content()` instead of a fatal `TypeError`.
 * [#588](https://github.com/beyondwords-io/wordpress-plugin/pull/588) Ship `symfony/dom-crawler` 5.4.52 to fix CVE-2026-45071 (XXE / local file disclosure).
     * The composer constraint now floors at the patched release, so a vulnerable version can no longer be bundled.
+* [#601](https://github.com/beyondwords-io/wordpress-plugin/pull/601) Remove the "Script" option from the post Source setting, which offers "Post" or "Post + script".
+    * A script is written from the post, so the post's own audio and video were always generated (and billed) alongside it — while the Embed setting offered only the script assets, hiding the post assets that existed.
+    * Posts already saved as "Script" are migrated to "Post + script" on upgrade, and keep embedding their script asset.
 
 **Deprecations**
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,15 +128,14 @@ Release date: tbc
 * [#542](https://github.com/beyondwords-io/wordpress-plugin/pull/542) Surface a `WP_Error` from `get_content()` instead of a fatal `TypeError`.
 * [#588](https://github.com/beyondwords-io/wordpress-plugin/pull/588) Ship `symfony/dom-crawler` 5.4.52 to fix CVE-2026-45071 (XXE / local file disclosure).
     * The composer constraint now floors at the patched release, so a vulnerable version can no longer be bundled.
-* [#601](https://github.com/beyondwords-io/wordpress-plugin/pull/601) Remove the "Script" option from the post Source setting, which offers "Post" or "Post + script".
-    * A script is written from the post, so the post's own audio and video were always generated (and billed) alongside it — while the Embed setting offered only the script assets, hiding the post assets that existed.
-    * Posts already saved as "Script" are migrated to "Post + script" on upgrade, and keep embedding their script asset.
 
 **Deprecations**
 
 * Removed the `beyondwords_player_style`, `beyondwords_player_content`, `beyondwords_title_voice_id`, `beyondwords_summary_voice_id` and `beyondwords_disabled` post meta keys.
     * Existing values are preserved in the database and only removed on full uninstall; `beyondwords_disabled` is migrated to the new "Embed" setting on upgrade.
 * The `beyondwords-*` `<head>` meta tags are now only emitted for the client-side (Magic Embed) integration.
+* [#601](https://github.com/beyondwords-io/wordpress-plugin/pull/601) Removed the "Script" option from the post Source setting, which now offers "Post" or "Post + script".
+    * Posts saved as "Script" are migrated to "Post + script" on upgrade, and keep embedding their script asset.
 
 **Compatibility**
 

--- a/src/core/class-updater.php
+++ b/src/core/class-updater.php
@@ -45,6 +45,7 @@ class Updater {
 			self::migrate_preselect_format();
 			self::delete_deprecated_options();
 			self::migrate_disabled_to_embed_none();
+			self::migrate_source_script_to_post_and_script();
 		}
 
 		// Record the activation timestamp the first time we run.
@@ -150,6 +151,62 @@ class Updater {
 				}
 
 				delete_post_meta( $post_id, 'beyondwords_disabled' );
+			}
+
+			$found = count( $post_ids );
+		} while ( $found === $batch );
+	}
+
+	/**
+	 * v7.0.0: normalise the removed script-only Source to Post + script.
+	 *
+	 * See doc/legacy-meta-migration.md. Batched to keep memory bounded, and
+	 * idempotent because a migrated post no longer matches the query.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function migrate_source_script_to_post_and_script(): void {
+		$batch = 100;
+
+		do {
+			$post_ids = get_posts(
+				[
+					'post_type'   => 'any',
+					'post_status' => 'any',
+					'numberposts' => $batch,
+					'fields'      => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'meta_query'  => [
+						[
+							'key'   => 'beyondwords_source',
+							'value' => \BeyondWords\Editor\Components\SettingsFields::LEGACY_SOURCE_SCRIPT,
+						],
+					],
+				]
+			);
+
+			foreach ( $post_ids as $post_id ) {
+				// Pin the asset script-only was showing, so the player doesn't switch.
+				if ( '' === (string) get_post_meta( $post_id, 'beyondwords_embed', true ) ) {
+					$output = (string) get_post_meta( $post_id, 'beyondwords_output', true );
+
+					$audio = '' === $output
+						|| \BeyondWords\Editor\Components\SettingsFields::output_includes_audio( $output );
+
+					update_post_meta(
+						$post_id,
+						'beyondwords_embed',
+						$audio
+							? \BeyondWords\Editor\Components\SettingsFields::EMBED_AUDIO_SCRIPT
+							: \BeyondWords\Editor\Components\SettingsFields::EMBED_VIDEO_SCRIPT
+					);
+				}
+
+				update_post_meta(
+					$post_id,
+					'beyondwords_source',
+					\BeyondWords\Editor\Components\SettingsFields::SOURCE_POST_AND_SCRIPT
+				);
 			}
 
 			$found = count( $post_ids );

--- a/src/editor/components/settings-fields/class-settings-fields.php
+++ b/src/editor/components/settings-fields/class-settings-fields.php
@@ -25,8 +25,10 @@ defined( 'ABSPATH' ) || exit;
 class SettingsFields {
 
 	public const SOURCE_POST            = 'post';
-	public const SOURCE_SCRIPT          = 'script';
 	public const SOURCE_POST_AND_SCRIPT = 'post_and_script';
+
+	// Source removed in 7.0.0; see doc/legacy-meta-migration.md.
+	public const LEGACY_SOURCE_SCRIPT = 'script';
 
 	public const OUTPUT_AUDIO           = 'audio';
 	public const OUTPUT_VIDEO           = 'video';
@@ -103,10 +105,6 @@ class SettingsFields {
 				'value' => self::SOURCE_POST,
 			],
 			[
-				'label' => __( 'Script', 'speechkit' ),
-				'value' => self::SOURCE_SCRIPT,
-			],
-			[
 				'label' => __( 'Post + script', 'speechkit' ),
 				'value' => self::SOURCE_POST_AND_SCRIPT,
 			],
@@ -138,14 +136,23 @@ class SettingsFields {
 	}
 
 	/**
-	 * Whether the source includes the post body.
+	 * Resolve a stored source to SOURCE_POST or SOURCE_POST_AND_SCRIPT.
 	 *
 	 * @since 7.0.0
-	 *
-	 * @param string $source One of the SOURCE_* constants.
 	 */
-	public static function source_includes_post( string $source ): bool {
-		return in_array( $source, [ self::SOURCE_POST, self::SOURCE_POST_AND_SCRIPT ], true );
+	public static function normalize_source( string $source ): string {
+		return in_array( $source, [ self::SOURCE_POST_AND_SCRIPT, self::LEGACY_SOURCE_SCRIPT ], true )
+			? self::SOURCE_POST_AND_SCRIPT
+			: self::SOURCE_POST;
+	}
+
+	/**
+	 * The effective Source for a post.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function get_source( int $post_id ): string {
+		return self::normalize_source( self::get_meta( $post_id, 'beyondwords_source', self::SOURCE_POST ) );
 	}
 
 	/**
@@ -156,7 +163,7 @@ class SettingsFields {
 	 * @param string $source One of the SOURCE_* constants.
 	 */
 	public static function source_includes_script( string $source ): bool {
-		return in_array( $source, [ self::SOURCE_SCRIPT, self::SOURCE_POST_AND_SCRIPT ], true );
+		return self::SOURCE_POST_AND_SCRIPT === self::normalize_source( $source );
 	}
 
 	/**
@@ -185,7 +192,8 @@ class SettingsFields {
 	 * Derive the valid "Embed" dropdown options from the current Source × Output.
 	 *
 	 * Returns None plus one entry for each asset combination the current
-	 * source/output would produce.
+	 * source/output would produce. Post assets are unconditional — every source
+	 * generates the post.
 	 *
 	 * @since 7.0.0
 	 *
@@ -202,14 +210,14 @@ class SettingsFields {
 			],
 		];
 
+		$includes_script = self::source_includes_script( $source );
+
 		if ( self::output_includes_audio( $output ) ) {
-			if ( self::source_includes_post( $source ) ) {
-				$options[] = [
-					'label' => __( 'Audio (post)', 'speechkit' ),
-					'value' => self::EMBED_AUDIO_POST,
-				];
-			}
-			if ( self::source_includes_script( $source ) ) {
+			$options[] = [
+				'label' => __( 'Audio (post)', 'speechkit' ),
+				'value' => self::EMBED_AUDIO_POST,
+			];
+			if ( $includes_script ) {
 				$options[] = [
 					'label' => __( 'Audio (script)', 'speechkit' ),
 					'value' => self::EMBED_AUDIO_SCRIPT,
@@ -218,13 +226,11 @@ class SettingsFields {
 		}
 
 		if ( self::output_includes_video( $output ) ) {
-			if ( self::source_includes_post( $source ) ) {
-				$options[] = [
-					'label' => __( 'Video (post)', 'speechkit' ),
-					'value' => self::EMBED_VIDEO_POST,
-				];
-			}
-			if ( self::source_includes_script( $source ) ) {
+			$options[] = [
+				'label' => __( 'Video (post)', 'speechkit' ),
+				'value' => self::EMBED_VIDEO_POST,
+			];
+			if ( $includes_script ) {
 				$options[] = [
 					'label' => __( 'Video (script)', 'speechkit' ),
 					'value' => self::EMBED_VIDEO_SCRIPT,
@@ -290,7 +296,7 @@ class SettingsFields {
 	 * @return string One of the EMBED_* constants.
 	 */
 	public static function get_effective_embed( int $post_id ): string {
-		$source = self::get_meta( $post_id, 'beyondwords_source', self::SOURCE_POST );
+		$source = self::get_source( $post_id );
 		$output = self::get_meta( $post_id, 'beyondwords_output', self::OUTPUT_AUDIO );
 		$embed  = get_post_meta( $post_id, 'beyondwords_embed', true );
 
@@ -337,7 +343,7 @@ class SettingsFields {
 	 * @param \WP_Post $post The post object.
 	 */
 	public static function render_content_section( $post ): void {
-		$source             = self::get_meta( $post->ID, 'beyondwords_source', self::SOURCE_POST );
+		$source             = self::get_source( $post->ID );
 		$script_template_id = self::get_meta( $post->ID, 'beyondwords_script_template_id', '' );
 
 		$templates = \BeyondWords\Api\Client::get_summarization_settings_templates();
@@ -422,7 +428,7 @@ class SettingsFields {
 	 * @param \WP_Post $post The post object.
 	 */
 	public static function render_player_section( $post ): void {
-		$source = self::get_meta( $post->ID, 'beyondwords_source', self::SOURCE_POST );
+		$source = self::get_source( $post->ID );
 		$output = self::get_meta( $post->ID, 'beyondwords_output', self::OUTPUT_AUDIO );
 		$embed  = self::get_effective_embed( $post->ID );
 

--- a/src/editor/components/settings-fields/classic-metabox.js
+++ b/src/editor/components/settings-fields/classic-metabox.js
@@ -8,7 +8,6 @@
 	'use strict';
 
 	const SOURCE_POST = 'post';
-	const SOURCE_SCRIPT = 'script';
 	const SOURCE_POST_AND_SCRIPT = 'post_and_script';
 
 	const OUTPUT_AUDIO = 'audio';
@@ -22,11 +21,9 @@
 			beyondwordsSettingsFields.embedLabels ) ||
 		{};
 
-	const sourceIncludesPost = ( source ) =>
-		source === SOURCE_POST || source === SOURCE_POST_AND_SCRIPT;
-
+	// PHP normalises the rendered value, so the select only holds an offered source.
 	const sourceIncludesScript = ( source ) =>
-		source === SOURCE_SCRIPT || source === SOURCE_POST_AND_SCRIPT;
+		source === SOURCE_POST_AND_SCRIPT;
 
 	const outputIncludesAudio = ( output ) =>
 		output === OUTPUT_AUDIO || output === OUTPUT_AUDIO_AND_VIDEO;
@@ -57,15 +54,14 @@
 	 */
 	const getEmbedOptions = ( source, output ) => {
 		const options = [ { label: labels.none || 'None', value: EMBED_NONE } ];
+		const includesScript = sourceIncludesScript( source );
 
 		if ( outputIncludesAudio( output ) ) {
-			if ( sourceIncludesPost( source ) ) {
-				options.push( {
-					label: labels.audio_post || 'Audio (post)',
-					value: 'audio_post',
-				} );
-			}
-			if ( sourceIncludesScript( source ) ) {
+			options.push( {
+				label: labels.audio_post || 'Audio (post)',
+				value: 'audio_post',
+			} );
+			if ( includesScript ) {
 				options.push( {
 					label: labels.audio_script || 'Audio (script)',
 					value: 'audio_script',
@@ -74,13 +70,11 @@
 		}
 
 		if ( outputIncludesVideo( output ) ) {
-			if ( sourceIncludesPost( source ) ) {
-				options.push( {
-					label: labels.video_post || 'Video (post)',
-					value: 'video_post',
-				} );
-			}
-			if ( sourceIncludesScript( source ) ) {
+			options.push( {
+				label: labels.video_post || 'Video (post)',
+				value: 'video_post',
+			} );
+			if ( includesScript ) {
 				options.push( {
 					label: labels.video_script || 'Video (script)',
 					value: 'video_script',

--- a/src/editor/components/settings-panel/content-section.js
+++ b/src/editor/components/settings-panel/content-section.js
@@ -12,8 +12,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import {
 	getSourceOptions,
+	normalizeSource,
 	sourceIncludesScript,
-	SOURCE_POST,
 	projectDefaultOption,
 } from './helpers';
 import GenerateAudio from '../generate-audio';
@@ -34,7 +34,7 @@ export function ContentSection() {
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 
-	const source = meta.beyondwords_source || SOURCE_POST;
+	const source = normalizeSource( meta.beyondwords_source );
 	const scriptTemplateId = meta.beyondwords_script_template_id || '';
 
 	const setSource = ( value ) => {

--- a/src/editor/components/settings-panel/helpers.js
+++ b/src/editor/components/settings-panel/helpers.js
@@ -5,8 +5,10 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 export const SOURCE_POST = 'post';
-export const SOURCE_SCRIPT = 'script';
 export const SOURCE_POST_AND_SCRIPT = 'post_and_script';
+
+// Source removed in 7.0.0; see doc/legacy-meta-migration.md.
+export const LEGACY_SOURCE_SCRIPT = 'script';
 
 export const OUTPUT_AUDIO = 'audio';
 export const OUTPUT_VIDEO = 'video';
@@ -282,7 +284,6 @@ export function getLanguageModels( voices ) {
 export function getSourceOptions() {
 	return [
 		{ label: __( 'Post', 'speechkit' ), value: SOURCE_POST },
-		{ label: __( 'Script', 'speechkit' ), value: SOURCE_SCRIPT },
 		{
 			label: __( 'Post + script', 'speechkit' ),
 			value: SOURCE_POST_AND_SCRIPT,
@@ -301,12 +302,21 @@ export function getOutputOptions() {
 	];
 }
 
-export function sourceIncludesPost( source ) {
-	return source === SOURCE_POST || source === SOURCE_POST_AND_SCRIPT;
+/**
+ * Resolve a stored source to one the dropdown offers, so it never shows blank.
+ *
+ * @param {string} source The stored value.
+ *
+ * @return {string} SOURCE_POST or SOURCE_POST_AND_SCRIPT.
+ */
+export function normalizeSource( source ) {
+	return source === SOURCE_POST_AND_SCRIPT || source === LEGACY_SOURCE_SCRIPT
+		? SOURCE_POST_AND_SCRIPT
+		: SOURCE_POST;
 }
 
 export function sourceIncludesScript( source ) {
-	return source === SOURCE_SCRIPT || source === SOURCE_POST_AND_SCRIPT;
+	return normalizeSource( source ) === SOURCE_POST_AND_SCRIPT;
 }
 
 export function outputIncludesAudio( output ) {
@@ -321,6 +331,7 @@ export function outputIncludesVideo( output ) {
  * Derive the valid "Embed" dropdown options from the current Source × Output.
  *
  * Returns None plus one entry per asset the current source/output would produce.
+ * Post assets are unconditional — every source generates the post.
  *
  * @param {string} source One of SOURCE_*.
  * @param {string} output One of OUTPUT_*.
@@ -329,15 +340,14 @@ export function outputIncludesVideo( output ) {
  */
 export function getEmbedOptions( source, output ) {
 	const options = [ { label: __( 'None', 'speechkit' ), value: EMBED_NONE } ];
+	const includesScript = sourceIncludesScript( source );
 
 	if ( outputIncludesAudio( output ) ) {
-		if ( sourceIncludesPost( source ) ) {
-			options.push( {
-				label: __( 'Audio (post)', 'speechkit' ),
-				value: EMBED_AUDIO_POST,
-			} );
-		}
-		if ( sourceIncludesScript( source ) ) {
+		options.push( {
+			label: __( 'Audio (post)', 'speechkit' ),
+			value: EMBED_AUDIO_POST,
+		} );
+		if ( includesScript ) {
 			options.push( {
 				label: __( 'Audio (script)', 'speechkit' ),
 				value: EMBED_AUDIO_SCRIPT,
@@ -346,13 +356,11 @@ export function getEmbedOptions( source, output ) {
 	}
 
 	if ( outputIncludesVideo( output ) ) {
-		if ( sourceIncludesPost( source ) ) {
-			options.push( {
-				label: __( 'Video (post)', 'speechkit' ),
-				value: EMBED_VIDEO_POST,
-			} );
-		}
-		if ( sourceIncludesScript( source ) ) {
+		options.push( {
+			label: __( 'Video (post)', 'speechkit' ),
+			value: EMBED_VIDEO_POST,
+		} );
+		if ( includesScript ) {
 			options.push( {
 				label: __( 'Video (script)', 'speechkit' ),
 				value: EMBED_VIDEO_SCRIPT,

--- a/src/editor/components/settings-panel/helpers.test.js
+++ b/src/editor/components/settings-panel/helpers.test.js
@@ -5,8 +5,8 @@
  */
 import {
 	SOURCE_POST,
-	SOURCE_SCRIPT,
 	SOURCE_POST_AND_SCRIPT,
+	LEGACY_SOURCE_SCRIPT,
 	OUTPUT_AUDIO,
 	OUTPUT_VIDEO,
 	OUTPUT_AUDIO_AND_VIDEO,
@@ -23,7 +23,7 @@ import {
 	getLanguageModels,
 	getSourceOptions,
 	getOutputOptions,
-	sourceIncludesPost,
+	normalizeSource,
 	sourceIncludesScript,
 	outputIncludesAudio,
 	outputIncludesVideo,
@@ -149,15 +149,25 @@ describe( 'getLanguageModels', () => {
 } );
 
 describe( 'source/output predicates', () => {
-	it( 'sourceIncludesPost', () => {
-		expect( sourceIncludesPost( SOURCE_POST ) ).toBe( true );
-		expect( sourceIncludesPost( SOURCE_POST_AND_SCRIPT ) ).toBe( true );
-		expect( sourceIncludesPost( SOURCE_SCRIPT ) ).toBe( false );
+	it( 'normalizeSource maps the removed script-only value to Post + script', () => {
+		expect( normalizeSource( LEGACY_SOURCE_SCRIPT ) ).toBe(
+			SOURCE_POST_AND_SCRIPT
+		);
+		expect( normalizeSource( SOURCE_POST_AND_SCRIPT ) ).toBe(
+			SOURCE_POST_AND_SCRIPT
+		);
+	} );
+
+	it( 'normalizeSource falls back to Post for unset and unknown values', () => {
+		expect( normalizeSource( SOURCE_POST ) ).toBe( SOURCE_POST );
+		expect( normalizeSource( '' ) ).toBe( SOURCE_POST );
+		expect( normalizeSource( undefined ) ).toBe( SOURCE_POST );
+		expect( normalizeSource( 'not-a-real-source' ) ).toBe( SOURCE_POST );
 	} );
 
 	it( 'sourceIncludesScript', () => {
-		expect( sourceIncludesScript( SOURCE_SCRIPT ) ).toBe( true );
 		expect( sourceIncludesScript( SOURCE_POST_AND_SCRIPT ) ).toBe( true );
+		expect( sourceIncludesScript( LEGACY_SOURCE_SCRIPT ) ).toBe( true );
 		expect( sourceIncludesScript( SOURCE_POST ) ).toBe( false );
 	} );
 
@@ -176,7 +186,6 @@ describe( 'source/output predicates', () => {
 	it( 'getSourceOptions / getOutputOptions expose the expected values', () => {
 		expect( getSourceOptions().map( ( o ) => o.value ) ).toEqual( [
 			SOURCE_POST,
-			SOURCE_SCRIPT,
 			SOURCE_POST_AND_SCRIPT,
 		] );
 		expect( getOutputOptions().map( ( o ) => o.value ) ).toEqual( [
@@ -210,11 +219,19 @@ describe( 'getEmbedOptions', () => {
 		] );
 	} );
 
-	it( 'Script + Video → None / Video (script)', () => {
-		expect( values( SOURCE_SCRIPT, OUTPUT_VIDEO ) ).toEqual( [
+	it( 'Post + script + Video → None / Video (post) / Video (script)', () => {
+		expect( values( SOURCE_POST_AND_SCRIPT, OUTPUT_VIDEO ) ).toEqual( [
 			EMBED_NONE,
+			EMBED_VIDEO_POST,
 			EMBED_VIDEO_SCRIPT,
 		] );
+	} );
+
+	// Those posts have the post assets too, so hiding them was the v7 bug.
+	it( 'the removed script-only value derives the Post + script options', () => {
+		expect( values( LEGACY_SOURCE_SCRIPT, OUTPUT_AUDIO ) ).toEqual(
+			values( SOURCE_POST_AND_SCRIPT, OUTPUT_AUDIO )
+		);
 	} );
 
 	it( 'always includes None first', () => {
@@ -256,16 +273,14 @@ describe( 'getDefaultEmbed', () => {
 	} );
 
 	it( 'returns a non-None value for every source/output combination', () => {
-		[ SOURCE_POST, SOURCE_SCRIPT, SOURCE_POST_AND_SCRIPT ].forEach(
-			( source ) => {
-				[ OUTPUT_AUDIO, OUTPUT_VIDEO, OUTPUT_AUDIO_AND_VIDEO ].forEach(
-					( output ) => {
-						expect( getDefaultEmbed( source, output ) ).not.toBe(
-							EMBED_NONE
-						);
-					}
-				);
-			}
-		);
+		[ SOURCE_POST, SOURCE_POST_AND_SCRIPT ].forEach( ( source ) => {
+			[ OUTPUT_AUDIO, OUTPUT_VIDEO, OUTPUT_AUDIO_AND_VIDEO ].forEach(
+				( output ) => {
+					expect( getDefaultEmbed( source, output ) ).not.toBe(
+						EMBED_NONE
+					);
+				}
+			);
+		} );
 	} );
 } );

--- a/src/editor/components/settings-panel/player-section.js
+++ b/src/editor/components/settings-panel/player-section.js
@@ -15,8 +15,8 @@ import {
 	getDefaultEmbed,
 	getEmbedOptions,
 	isEmbedValid,
+	normalizeSource,
 	OUTPUT_AUDIO,
-	SOURCE_POST,
 } from './helpers';
 import Stack from '../stack';
 
@@ -30,7 +30,7 @@ export function PlayerSection( { withPanel = true } ) {
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = rawMeta ?? {};
 
-	const source = meta.beyondwords_source || SOURCE_POST;
+	const source = normalizeSource( meta.beyondwords_source );
 	const output = meta.beyondwords_output || OUTPUT_AUDIO;
 
 	const stored = meta.beyondwords_embed;

--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -280,11 +280,10 @@ class Content {
 			$body['body_voice_id'] = $body_voice_id;
 		}
 
-		// Source = Script or Post + script → enable summarization; omitted when
-		// Source is Post (or unset) so the project default applies.
-		$source = get_post_meta( $post_id, 'beyondwords_source', true );
+		// Omitted when Source is Post (or unset) so the project default applies.
+		$source = \BeyondWords\Editor\Components\SettingsFields::get_source( $post_id );
 
-		if ( in_array( $source, [ 'script', 'post_and_script' ], true ) ) {
+		if ( \BeyondWords\Editor\Components\SettingsFields::source_includes_script( $source ) ) {
 			$body['summarization_settings'] = [ 'enabled' => true ];
 
 			$script_template_id = intval(

--- a/tests/cypress/e2e/block-editor/settings-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/settings-panel.cy.js
@@ -41,7 +41,6 @@ context( 'Block Editor: Settings panel', () => {
 					.should( ( $els ) => {
 						expect( optionLabels( $els ) ).to.deep.eq( [
 							'Post',
-							'Script',
 							'Post + script',
 						] );
 					} );
@@ -49,7 +48,7 @@ context( 'Block Editor: Settings panel', () => {
 				// Script template hidden while Source = Post.
 				cy.get( '.beyondwords--script-template' ).should( 'not.exist' );
 
-				select( 'beyondwords--source' ).select( 'Script', {
+				select( 'beyondwords--source' ).select( 'Post + script', {
 					force: true,
 				} );
 				select( 'beyondwords--script-template' )

--- a/tests/cypress/e2e/classic-editor/settings-fields.cy.js
+++ b/tests/cypress/e2e/classic-editor/settings-fields.cy.js
@@ -41,7 +41,6 @@ context( 'Classic Editor: Settings fields', () => {
 					.should( ( $els ) => {
 						expect( optionLabels( $els ) ).to.deep.eq( [
 							'Post',
-							'Script',
 							'Post + script',
 						] );
 					} );
@@ -51,7 +50,7 @@ context( 'Classic Editor: Settings fields', () => {
 					'#beyondwords-metabox-settings--beyondwords-script-template-id'
 				).should( 'not.be.visible' );
 
-				cy.get( 'select#beyondwords_source' ).select( 'Script' );
+				cy.get( 'select#beyondwords_source' ).select( 'Post + script' );
 				cy.get(
 					'#beyondwords-metabox-settings--beyondwords-script-template-id'
 				).should( 'be.visible' );

--- a/tests/phpunit/core/test-updater.php
+++ b/tests/phpunit/core/test-updater.php
@@ -216,6 +216,49 @@ class UpdaterTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function migrate_source_script_to_post_and_script()
+    {
+        // Script-only with no Embed choice: was showing the script asset.
+        $audioPost = self::factory()->post->create();
+        update_post_meta($audioPost, 'beyondwords_source', 'script');
+
+        // Script-only, Video output, no Embed choice: was showing Video (script).
+        $videoPost = self::factory()->post->create();
+        update_post_meta($videoPost, 'beyondwords_source', 'script');
+        update_post_meta($videoPost, 'beyondwords_output', 'video');
+
+        // An explicit Embed choice must not be overwritten.
+        $embedPost = self::factory()->post->create();
+        update_post_meta($embedPost, 'beyondwords_source', 'script');
+        update_post_meta($embedPost, 'beyondwords_embed', 'none');
+
+        // A post on a supported source — must be left untouched.
+        $untouchedPost = self::factory()->post->create();
+        update_post_meta($untouchedPost, 'beyondwords_source', 'post');
+
+        Updater::migrate_source_script_to_post_and_script();
+
+        $this->assertSame('post_and_script', get_post_meta($audioPost, 'beyondwords_source', true));
+        $this->assertSame('audio_script', get_post_meta($audioPost, 'beyondwords_embed', true));
+
+        $this->assertSame('post_and_script', get_post_meta($videoPost, 'beyondwords_source', true));
+        $this->assertSame('video_script', get_post_meta($videoPost, 'beyondwords_embed', true));
+
+        $this->assertSame('post_and_script', get_post_meta($embedPost, 'beyondwords_source', true));
+        $this->assertSame('none', get_post_meta($embedPost, 'beyondwords_embed', true));
+
+        $this->assertSame('post', get_post_meta($untouchedPost, 'beyondwords_source', true));
+        $this->assertSame('', get_post_meta($untouchedPost, 'beyondwords_embed', true));
+
+        wp_delete_post($audioPost, true);
+        wp_delete_post($videoPost, true);
+        wp_delete_post($embedPost, true);
+        wp_delete_post($untouchedPost, true);
+    }
+
+    /**
      * The gate must close once the recorded version matches this build, else the pre-release `< 7.0.0` comparison re-fires v7 migrations every request.
      *
      * @test

--- a/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
+++ b/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
@@ -74,7 +74,7 @@ class SettingsFieldsTest extends TestCase
     public function source_and_output_options()
     {
         $this->assertSame(
-            ['post', 'script', 'post_and_script'],
+            ['post', 'post_and_script'],
             array_column(SettingsFields::source_options(), 'value')
         );
 
@@ -89,12 +89,8 @@ class SettingsFieldsTest extends TestCase
      */
     public function source_and_output_predicates()
     {
-        $this->assertTrue(SettingsFields::source_includes_post('post'));
-        $this->assertTrue(SettingsFields::source_includes_post('post_and_script'));
-        $this->assertFalse(SettingsFields::source_includes_post('script'));
-
-        $this->assertTrue(SettingsFields::source_includes_script('script'));
         $this->assertTrue(SettingsFields::source_includes_script('post_and_script'));
+        $this->assertTrue(SettingsFields::source_includes_script('script'));
         $this->assertFalse(SettingsFields::source_includes_script('post'));
 
         $this->assertTrue(SettingsFields::output_includes_audio('audio'));
@@ -104,6 +100,41 @@ class SettingsFieldsTest extends TestCase
         $this->assertTrue(SettingsFields::output_includes_video('video'));
         $this->assertTrue(SettingsFields::output_includes_video('audio_and_video'));
         $this->assertFalse(SettingsFields::output_includes_video('audio'));
+    }
+
+    /**
+     * @test
+     */
+    public function normalize_source_resolves_legacy_and_unknown_values()
+    {
+        $this->assertSame('post_and_script', SettingsFields::normalize_source('post_and_script'));
+
+        // Script-only was removed in 7.0.0 — it always generated the post too.
+        $this->assertSame('post_and_script', SettingsFields::normalize_source('script'));
+
+        $this->assertSame('post', SettingsFields::normalize_source('post'));
+        $this->assertSame('post', SettingsFields::normalize_source(''));
+        $this->assertSame('post', SettingsFields::normalize_source('not-a-real-source'));
+    }
+
+    /**
+     * @test
+     * @group integration
+     */
+    public function get_source_normalizes_the_stored_meta()
+    {
+        $postId = self::factory()->post->create(['post_title' => 'SettingsFieldsTest::get_source']);
+
+        // Unset → Post.
+        $this->assertSame('post', SettingsFields::get_source($postId));
+
+        update_post_meta($postId, 'beyondwords_source', 'script');
+        $this->assertSame('post_and_script', SettingsFields::get_source($postId));
+
+        update_post_meta($postId, 'beyondwords_source', 'post_and_script');
+        $this->assertSame('post_and_script', SettingsFields::get_source($postId));
+
+        wp_delete_post($postId, true);
     }
 
     /**
@@ -128,8 +159,9 @@ class SettingsFieldsTest extends TestCase
     {
         return [
             'Post + Audio'                => ['post', 'audio', ['none', 'audio_post']],
-            'Script + Audio'              => ['script', 'audio', ['none', 'audio_script']],
             'Post+script + Audio'         => ['post_and_script', 'audio', ['none', 'audio_post', 'audio_script']],
+            // Legacy script-only posts have the post assets too, so they are offered.
+            'Legacy script + Audio'       => ['script', 'audio', ['none', 'audio_post', 'audio_script']],
             'Post + Video'                => ['post', 'video', ['none', 'video_post']],
             'Post + Audio+video'          => ['post', 'audio_and_video', ['none', 'audio_post', 'video_post']],
             'Post+script + Audio+video'   => [
@@ -166,7 +198,10 @@ class SettingsFieldsTest extends TestCase
         }));
 
         $this->assertCount(1, $crawler->filter('select#beyondwords_source'));
-        $this->assertCount(3, $crawler->filter('select#beyondwords_source option'));
+        $this->assertSame(
+            ['Post', 'Post + script'],
+            $crawler->filter('select#beyondwords_source option')->each(fn ($node) => $node->text())
+        );
         $this->assertStringContainsString(
             'display: none',
             (string) $crawler->filter('#beyondwords-metabox-settings--beyondwords-script-template-id')->attr('style')
@@ -183,7 +218,7 @@ class SettingsFieldsTest extends TestCase
     {
         $post = self::factory()->post->create_and_get([
             'post_title' => 'SettingsFieldsTest::content::script',
-            'meta_input' => ['beyondwords_source' => 'script'],
+            'meta_input' => ['beyondwords_source' => 'post_and_script'],
         ]);
 
         $crawler = new Crawler($this->capture_output(function () use ($post) {
@@ -196,6 +231,34 @@ class SettingsFieldsTest extends TestCase
         $options = $crawler->filter('select#beyondwords_script_template_id option');
         $this->assertSame('Project default', $options->eq(0)->text());
         $this->assertGreaterThan(1, $options->count());
+
+        wp_delete_post($post->ID, true);
+    }
+
+    /**
+     * An un-normalised read would leave the select with nothing selected.
+     *
+     * @test
+     * @group integration
+     */
+    public function render_content_section_normalizes_legacy_script_source()
+    {
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'SettingsFieldsTest::content::legacy-script',
+            'meta_input' => ['beyondwords_source' => 'script'],
+        ]);
+
+        $crawler = new Crawler($this->capture_output(function () use ($post) {
+            SettingsFields::render_content_section($post);
+        }));
+
+        $this->assertSame(
+            'post_and_script',
+            $crawler->filter('select#beyondwords_source option[selected]')->attr('value')
+        );
+
+        $wrapper = $crawler->filter('#beyondwords-metabox-settings--beyondwords-script-template-id');
+        $this->assertStringNotContainsString('display: none', (string) $wrapper->attr('style'));
 
         wp_delete_post($post->ID, true);
     }
@@ -348,7 +411,7 @@ class SettingsFieldsTest extends TestCase
         $postId = self::factory()->post->create(['post_title' => 'SettingsFieldsTest::save']);
 
         // No nonce → nothing saved.
-        $_POST['beyondwords_source'] = 'script';
+        $_POST['beyondwords_source'] = 'post_and_script';
         SettingsFields::save($postId);
         $this->assertSame('', get_post_meta($postId, 'beyondwords_source', true));
 
@@ -382,6 +445,11 @@ class SettingsFieldsTest extends TestCase
         $this->assertSame('post_and_script', get_post_meta($postId, 'beyondwords_source', true));
         $this->assertSame('3', get_post_meta($postId, 'beyondwords_video_template_id', true));
 
+        // Not an option any more, so a stale form cannot write it back.
+        $_POST['beyondwords_source'] = 'script';
+        SettingsFields::save($postId);
+        $this->assertSame('post_and_script', get_post_meta($postId, 'beyondwords_source', true));
+
         wp_delete_post($postId, true);
     }
 
@@ -396,7 +464,7 @@ class SettingsFieldsTest extends TestCase
         wp_set_current_user(self::factory()->user->create(['role' => 'subscriber']));
 
         $_POST['beyondwords_settings_fields_nonce'] = wp_create_nonce('beyondwords_settings_fields');
-        $_POST['beyondwords_source']                = 'script';
+        $_POST['beyondwords_source']                = 'post_and_script';
 
         SettingsFields::save($postId);
 

--- a/tests/phpunit/player/test-config-builder.php
+++ b/tests/phpunit/player/test-config-builder.php
@@ -250,7 +250,7 @@ class ConfigBuilderTest extends TestCase
     public function merge_post_settings_embed_audio_script_sets_summary()
     {
         $post = $this->createEmbedPost([
-            'beyondwords_source' => 'script',
+            'beyondwords_source' => 'post_and_script',
             'beyondwords_output' => 'audio',
             'beyondwords_embed'  => 'audio_script',
         ]);
@@ -288,7 +288,7 @@ class ConfigBuilderTest extends TestCase
     public function merge_post_settings_embed_video_script_sets_video_and_summary()
     {
         $post = $this->createEmbedPost([
-            'beyondwords_source' => 'script',
+            'beyondwords_source' => 'post_and_script',
             'beyondwords_output' => 'video',
             'beyondwords_embed'  => 'video_script',
         ]);
@@ -391,7 +391,7 @@ class ConfigBuilderTest extends TestCase
         update_option(Fields::OPTION_PLAYER_UI, Fields::PLAYER_UI_HEADLESS);
 
         $post = $this->createEmbedPost([
-            'beyondwords_source' => 'script',
+            'beyondwords_source' => 'post_and_script',
             'beyondwords_output' => 'video',
             'beyondwords_embed'  => 'video_script',
         ]);
@@ -419,7 +419,7 @@ class ConfigBuilderTest extends TestCase
         $post = self::factory()->post->create_and_get([
             'meta_input' => [
                 'beyondwords_project_id' => BEYONDWORDS_TESTS_PROJECT_ID,
-                'beyondwords_source'     => 'script',
+                'beyondwords_source'     => 'post_and_script',
                 'beyondwords_output'     => 'audio',
                 'beyondwords_embed'      => 'audio_script',
             ],

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -441,7 +441,7 @@ class ContentTest extends TestCase
         $postId = self::factory()->post->create([
             'post_title' => 'ContentTest::summarizationEnabled',
             'meta_input' => [
-                'beyondwords_source'             => 'script',
+                'beyondwords_source'             => 'post_and_script',
                 'beyondwords_script_template_id' => '42',
             ],
         ]);
@@ -452,8 +452,8 @@ class ContentTest extends TestCase
         $this->assertTrue($body['summarization_settings']['enabled']);
         $this->assertSame(42, $body['summarization_settings']['template']['id']);
 
-        // Source = post_and_script enables it too.
-        update_post_meta($postId, 'beyondwords_source', 'post_and_script');
+        // The removed script-only value normalises to post_and_script.
+        update_post_meta($postId, 'beyondwords_source', 'script');
         $body = json_decode(Content::get_content_params($postId), true);
 
         $this->assertTrue($body['summarization_settings']['enabled']);


### PR DESCRIPTION
## Problem

The Source dropdown offered Post / Script / Post + script in both editors, but **script-only was never a real mode**. The script is derived from the post body, so the platform always generates the post assets — the plugin's own payload code confirmed it: `script` and `post_and_script` built an identical request in `src/post/class-content.php`, and nothing suppressed post generation.

Verified on staging (project 54024, 7.0.0-beta.1): every Source = Script post produced article assets. Post 3468 article audio; post 3446 article audio + article video; post 3442 article audio + script audio once the script generated.

Consequences of keeping the option:

- The UI promised script-only output while the account was billed for the post assets too.
- The Embed dropdown for Source = Script derived only None / Audio (script) / Video (script), hiding the post assets that actually existed on the content item.

## What changed

**Source offers Post / Post + script**, in `getSourceOptions()` ([helpers.js](src/editor/components/settings-panel/helpers.js), block), `source_options()` ([class-settings-fields.php](src/editor/components/settings-fields/class-settings-fields.php), classic), and the constants in [classic-metabox.js](src/editor/components/settings-fields/classic-metabox.js). `SOURCE_SCRIPT` became `LEGACY_SOURCE_SCRIPT` in both languages — the literal is still needed to normalise.

**Normalisation on read.** New `normalizeSource()` (JS) and `normalize_source()` + `get_source( $post_id )` (PHP) resolve `script`, unknown values, and unset to a source the dropdown offers. Wired into both block sections, both classic renderers, `get_effective_embed()`, and the payload builder — so a stale `script` in meta can never render a blank select.

**Payload.** `class-content.php` dropped its hard-coded `[ 'script', 'post_and_script' ]` for `SettingsFields::source_includes_script()`, so this logic no longer has a raw-literal fourth copy.

**`sourceIncludesPost()` deleted** (JS, PHP, classic JS). With script-only gone, every remaining source generates the post, so it was a tautology; `getEmbedOptions()` / `embed_options()` now push the post assets unconditionally — which is the reported bug, stated as code.

**Migration.** `migrate_source_script_to_post_and_script()` in the `< 7.0.0` block rewrites the meta, batched and idempotent like its sibling.

## Reviewer notes

**One judgement call worth a look:** the migration also pins `beyondwords_embed` to the script asset when the post had no explicit choice. Script-only derived script embeds alone, so the effective default was `audio_script`; under Post + script the default becomes `audio_post`. Without the pin, a beta post would silently switch which asset its player shows on upgrade.

**No "section 2.2 Source" exists in this repo** — no doc contains the Source option list or the Embed examples (closest is `readme.txt:92`, field names only). That amendment belongs wherever the project overview actually lives. The removal and migration are documented in [doc/legacy-meta-migration.md](doc/legacy-meta-migration.md) instead.

`languages/speechkit.pot` still carries the `"Script"` msgid; CI regenerates it via `composer wp:i18n:make-pot` at release build.

Comments and docblocks follow the § Documentation rules from `claude/agents-txt-docs-guidelines-dc763e` (one line per inline comment, one-line docblock summaries, long-form in `doc/`).

## Testing

- `npm run test:unit` (settings-panel helpers) — 28 pass, including new `normalizeSource` and legacy-value cases
- Full PHPUnit — **717 pass, 1 skipped** (the pre-existing multisite Uninstaller skip). New coverage: `normalize_source`, `get_source`, legacy-source rendering, stale-form rejection on save, and the migration.
- `phpcs` (WordPress-VIP-Go) clean, no new `phpcs:ignore`; `npm run lint:js` clean

**Cypress specs are updated but were not run** — `block-editor/settings-panel.cy.js` and `classic-editor/settings-fields.cy.js` need a dev env serving this branch:

```bash
npm run cypress:run -- --browser chrome --spec 'tests/cypress/e2e/block-editor/settings-panel.cy.js,tests/cypress/e2e/classic-editor/settings-fields.cy.js'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
