### PR TITLE
fix(classic-editor): show Generating state while generation is queued

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -227,9 +227,7 @@ function setupNodeEvents( on, config ) {
 			return null;
 		},
 
-		// Queue the deferred generation job the async (VIP) path would create.
-		// Scheduled far enough ahead that WP-Cron can't run it mid-test — the
-		// metabox only needs wp_next_scheduled() to be truthy.
+		// An hour out, so WP-Cron can't actually run the job mid-test.
 		async scheduleAudioGeneration( postId ) {
 			await execWp(
 				`eval 'wp_schedule_single_event( time() + 3600, "beyondwords_generate_audio", [ ${ parseInt(

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -227,6 +227,19 @@ function setupNodeEvents( on, config ) {
 			return null;
 		},
 
+		// Queue the deferred generation job the async (VIP) path would create.
+		// Scheduled far enough ahead that WP-Cron can't run it mid-test — the
+		// metabox only needs wp_next_scheduled() to be truthy.
+		async scheduleAudioGeneration( postId ) {
+			await execWp(
+				`eval 'wp_schedule_single_event( time() + 3600, "beyondwords_generate_audio", [ ${ parseInt(
+					postId,
+					10
+				) } ] );'`
+			);
+			return null;
+		},
+
 		async getPostMeta( options ) {
 			const { postId, metaKey } = options;
 			try {

--- a/doc/async-rest-migration.md
+++ b/doc/async-rest-migration.md
@@ -38,6 +38,26 @@ returns immediately.
 - Error meta is written when the job runs (≈1 cron tick later) rather than
   inline, so the editor surfaces an API error on its next load.
 
+### Editor state while the job is queued
+
+Deferral means the post-publish page load has **no content ID at all**, so there
+is nothing for the content-status poll (`#566`) to query. Left alone the classic
+metabox rendered the "Player" heading and nothing else — no player, no spinner,
+no message — until the author reloaded.
+
+`Metabox::awaiting_generation_embed()` covers that window: when
+`wp_next_scheduled( Sync::GENERATE_AUDIO_CRON_HOOK, … )` is set but no content ID
+exists, it renders the loading container with `data-post-id` /
+`data-await-content`. `awaitContentId()` in `content-id/classic-metabox.js` then
+polls the post's own meta over `wp/v2` until the cron job writes an ID, sets the
+data attributes and hands off to `initMetaboxPlayer()` — so the player still
+waits for `processed` rather than embedding a 404 the CDN would cache.
+
+It reuses `pollContentStatus()` by reporting `queued` (already a non-terminal
+status) until the ID lands, inheriting the time budget, hidden-tab handling and
+supersede token. Gating on the scheduled job matters: a post with nothing queued
+has no audio coming, so a spinner there would never resolve.
+
 ## Deferred (follow-up)
 
 ### Classic-editor async reads

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Release date: tbc
 
 **Fixes**
 
+* [#603](https://github.com/beyondwords-io/wordpress-plugin/pull/603) Show a loading state in the classic editor while audio generation is still queued.
 * [#564](https://github.com/beyondwords-io/wordpress-plugin/pull/564) Send the full `video_settings` payload so videos generate.
     * Selecting "Video" or "Audio + video" output now sends the complete video settings (seeded from the project defaults), fixing posts that produced no video.
 * [#564](https://github.com/beyondwords-io/wordpress-plugin/pull/564) Sweep the paired `_transient_timeout_beyondwords_*` rows on uninstall, so no orphaned option rows are left behind.

--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -97,6 +97,8 @@ class Metabox {
 			} else {
 				self::player_embed( $post );
 			}
+		} else {
+			self::awaiting_generation_embed( $post );
 		}
 
 		// The Embed dropdown ("None" = no player) replaces the old Display player checkbox.
@@ -272,6 +274,66 @@ class Metabox {
 			</div>
 			<?php
 		endif;
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+
+	/**
+	 * Render a loading state while deferred audio generation is still queued.
+	 *
+	 * Async generation (Sync::is_async_generation_enabled()) writes no content ID
+	 * during the save, so the post-publish page load has nothing for the
+	 * content-status poll to query and the Player section would otherwise be
+	 * blank until the author reloads. classic-metabox.js polls the post's own
+	 * meta from here, then hands off to the content-status poll once the cron
+	 * job writes the ID.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int|\WP_Post|null $post (Optional) Post ID, or WP_Post object, or null.
+	 */
+	public static function awaiting_generation_embed( $post = null ) {
+		$post = get_post( $post );
+
+		if ( ! ( $post instanceof \WP_Post ) ) {
+			return;
+		}
+
+		// A post with no queued job has no audio coming, so stay silent rather
+		// than showing a spinner that would never resolve.
+		if ( ! wp_next_scheduled( \BeyondWords\Post\Sync::GENERATE_AUDIO_CRON_HOOK, [ $post->ID ] ) ) {
+			return;
+		}
+
+		$project_id = \BeyondWords\Post\Meta::get_project_id( $post->ID );
+
+		if ( ! $project_id ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		?>
+		<div
+			id="beyondwords-metabox-player"
+			role="status"
+			aria-live="polite"
+			style="margin: 13px 0;"
+			data-project-id="<?php echo esc_attr( $project_id ); ?>"
+			data-post-id="<?php echo esc_attr( $post->ID ); ?>"
+			data-await-content="1"
+		>
+			<span
+				class="spinner is-active"
+				style="float: none; margin: 0 8px 0 0;"
+			></span>
+			<span class="beyondwords-player-loading-text">
+				<?php esc_html_e( 'Generating…', 'speechkit' ); ?>
+			</span>
+		</div>
+		<script
+			defer
+			src='<?php echo esc_url( \BeyondWords\Core\Urls::get_js_sdk_url() ); ?>'
+		></script>
+		<?php
 		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 

--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -280,12 +280,7 @@ class Metabox {
 	/**
 	 * Render a loading state while deferred audio generation is still queued.
 	 *
-	 * Async generation (Sync::is_async_generation_enabled()) writes no content ID
-	 * during the save, so the post-publish page load has nothing for the
-	 * content-status poll to query and the Player section would otherwise be
-	 * blank until the author reloads. classic-metabox.js polls the post's own
-	 * meta from here, then hands off to the content-status poll once the cron
-	 * job writes the ID.
+	 * See doc/async-rest-migration.md.
 	 *
 	 * @since 7.0.0
 	 *
@@ -298,8 +293,7 @@ class Metabox {
 			return;
 		}
 
-		// A post with no queued job has no audio coming, so stay silent rather
-		// than showing a spinner that would never resolve.
+		// No queued job means no audio is coming, so a spinner would never resolve.
 		if ( ! wp_next_scheduled( \BeyondWords\Post\Sync::GENERATE_AUDIO_CRON_HOOK, [ $post->ID ] ) ) {
 			return;
 		}

--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -305,10 +305,7 @@
 	/**
 	 * Poll the post's own meta until deferred generation writes a content ID.
 	 *
-	 * Async generation queues a cron job instead of calling the API during the
-	 * save, so right after publish there is no content ID for initMetaboxPlayer()
-	 * to query. Poll `wp/v2` until the job writes one, then hand off so the
-	 * player still waits for `processed` rather than embedding immediately.
+	 * See doc/async-rest-migration.md.
 	 *
 	 * @param {HTMLElement} container The #beyondwords-metabox-player element.
 	 */
@@ -363,8 +360,7 @@
 					.then( function ( data ) {
 						meta = ( data && data.meta ) || {};
 
-						// 'queued' is non-terminal, so the poll keeps running
-						// until the job lands an ID or the budget runs out.
+						// 'queued' is non-terminal, so polling continues.
 						return {
 							status: meta.beyondwords_content_id
 								? 'found'
@@ -402,8 +398,7 @@
 			}
 			container.removeAttribute( 'data-await-content' );
 
-			// Generation has only just started, so poll for `processed` rather
-			// than embedding a 404 the CDN would cache.
+			// Poll for `processed`, else the player 404s and the CDN caches it.
 			initMetaboxPlayer( container );
 		} );
 	}

--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -303,6 +303,112 @@
 	}
 
 	/**
+	 * Poll the post's own meta until deferred generation writes a content ID.
+	 *
+	 * Async generation queues a cron job instead of calling the API during the
+	 * save, so right after publish there is no content ID for initMetaboxPlayer()
+	 * to query. Poll `wp/v2` until the job writes one, then hand off so the
+	 * player still waits for `processed` rather than embedding immediately.
+	 *
+	 * @param {HTMLElement} container The #beyondwords-metabox-player element.
+	 */
+	function awaitContentId( container ) {
+		if (
+			typeof beyondwordsData === 'undefined' ||
+			! beyondwordsData.root
+		) {
+			return;
+		}
+
+		const postId = container.getAttribute( 'data-post-id' );
+
+		if ( ! postId ) {
+			return;
+		}
+
+		// A newer init for this container supersedes any in-flight poll.
+		const token = {};
+		container.beyondwordsPollToken = token;
+		const isCancelled = function () {
+			return container.beyondwordsPollToken !== token;
+		};
+
+		const restBase = getRestBase();
+		let meta = {};
+
+		showMetaboxLoading( container );
+
+		pollContentStatus( {
+			fetchStatus() {
+				return fetch(
+					beyondwordsData.root +
+						'wp/v2/' +
+						restBase +
+						'/' +
+						encodeURIComponent( postId ) +
+						'?context=edit',
+					{
+						credentials: 'same-origin',
+						headers: {
+							'X-WP-Nonce': beyondwordsData.nonce,
+						},
+					}
+				)
+					.then( function ( response ) {
+						if ( ! response.ok ) {
+							throw new Error( response.statusText );
+						}
+						return response.json();
+					} )
+					.then( function ( data ) {
+						meta = ( data && data.meta ) || {};
+
+						// 'queued' is non-terminal, so the poll keeps running
+						// until the job lands an ID or the budget runs out.
+						return {
+							status: meta.beyondwords_content_id
+								? 'found'
+								: 'queued',
+						};
+					} );
+			},
+			isHidden() {
+				return document.hidden;
+			},
+			isCancelled,
+		} ).then( function ( result ) {
+			if ( isCancelled() ) {
+				return;
+			}
+
+			if ( result.timedOut || result.status !== 'found' ) {
+				showMetaboxMessage( container, result );
+				return;
+			}
+
+			container.setAttribute(
+				'data-content-id',
+				meta.beyondwords_content_id
+			);
+			container.setAttribute(
+				'data-preview-token',
+				meta.beyondwords_preview_token || ''
+			);
+			if ( meta.beyondwords_project_id ) {
+				container.setAttribute(
+					'data-project-id',
+					meta.beyondwords_project_id
+				);
+			}
+			container.removeAttribute( 'data-await-content' );
+
+			// Generation has only just started, so poll for `processed` rather
+			// than embedding a 404 the CDN would cache.
+			initMetaboxPlayer( container );
+		} );
+	}
+
+	/**
 	 * Remove any existing notice from the metabox.
 	 */
 	function clearNotice() {
@@ -358,7 +464,7 @@
 	 * @return {string} The REST base slug.
 	 */
 	function getRestBase( button ) {
-		const base = button.getAttribute( 'data-rest-base' );
+		const base = button && button.getAttribute( 'data-rest-base' );
 		if ( base ) {
 			return base;
 		}
@@ -638,11 +744,12 @@
 		const playerContainer = document.getElementById(
 			'beyondwords-metabox-player'
 		);
-		if (
-			playerContainer &&
-			playerContainer.getAttribute( 'data-content-id' )
-		) {
-			initMetaboxPlayer( playerContainer );
+		if ( playerContainer ) {
+			if ( playerContainer.getAttribute( 'data-content-id' ) ) {
+				initMetaboxPlayer( playerContainer );
+			} else if ( playerContainer.getAttribute( 'data-await-content' ) ) {
+				awaitContentId( playerContainer );
+			}
 		}
 	}
 

--- a/tests/cypress/e2e/classic-editor/content-id.cy.js
+++ b/tests/cypress/e2e/classic-editor/content-id.cy.js
@@ -174,9 +174,7 @@ context( 'Classic Editor: Content ID', () => {
 	} );
 
 	it( 'shows a Generating state while deferred generation is still queued', () => {
-		// Async generation writes no content ID during the save, so the metabox
-		// polls the post meta instead. Keep it empty: the spinner must stay up
-		// rather than the Player section rendering blank until a manual reload.
+		// Empty meta = job still queued: the spinner must stay up, not go blank.
 		cy.intercept( 'GET', '**/wp/v2/posts/*', {
 			statusCode: 200,
 			body: { meta: { beyondwords_content_id: '' } },

--- a/tests/cypress/e2e/classic-editor/content-id.cy.js
+++ b/tests/cypress/e2e/classic-editor/content-id.cy.js
@@ -173,6 +173,80 @@ context( 'Classic Editor: Content ID', () => {
 		} );
 	} );
 
+	it( 'shows a Generating state while deferred generation is still queued', () => {
+		// Async generation writes no content ID during the save, so the metabox
+		// polls the post meta instead. Keep it empty: the spinner must stay up
+		// rather than the Player section rendering blank until a manual reload.
+		cy.intercept( 'GET', '**/wp/v2/posts/*', {
+			statusCode: 200,
+			body: { meta: { beyondwords_content_id: '' } },
+		} ).as( 'pollMeta' );
+
+		cy.createTestPost( {
+			title: 'Cypress Test: classic queued generation spinner',
+			postStatus: 'publish',
+			postType: 'post',
+		} ).then( ( postId ) => {
+			cy.task( 'scheduleAudioGeneration', postId );
+
+			cy.visit( `/wp-admin/post.php?post=${ postId }&action=edit` );
+
+			cy.wait( '@pollMeta' );
+
+			cy.get( '#beyondwords-metabox-player' ).should(
+				'have.attr',
+				'data-await-content',
+				'1'
+			);
+			cy.get( '#beyondwords-metabox-player .spinner.is-active' ).should(
+				'exist'
+			);
+			cy.get( '#beyondwords-metabox-player' ).should(
+				'contain',
+				'Generating'
+			);
+		} );
+	} );
+
+	it( 'hands off to the content-status poll once the queued job writes an ID', () => {
+		cy.intercept( 'GET', '**/wp/v2/posts/*', {
+			statusCode: 200,
+			body: {
+				meta: {
+					beyondwords_content_id: Cypress.expose( 'contentId' ),
+					beyondwords_project_id: Cypress.expose( 'projectId' ),
+				},
+			},
+		} ).as( 'pollMeta' );
+
+		// Terminal status, so reaching this route at all proves the handoff.
+		cy.intercept( 'GET', '**/beyondwords/v1/projects/*/content/*', {
+			statusCode: 200,
+			body: { status: 'error' },
+		} ).as( 'pollContent' );
+
+		cy.createTestPost( {
+			title: 'Cypress Test: classic queued generation handoff',
+			postStatus: 'publish',
+			postType: 'post',
+		} ).then( ( postId ) => {
+			cy.task( 'scheduleAudioGeneration', postId );
+
+			cy.visit( `/wp-admin/post.php?post=${ postId }&action=edit` );
+
+			cy.wait( '@pollMeta' );
+			cy.wait( '@pollContent' );
+
+			cy.get( '#beyondwords-metabox-player' ).should(
+				'contain',
+				'Generation failed.'
+			);
+			cy.get( '#beyondwords-metabox-player .spinner.is-active' ).should(
+				'not.exist'
+			);
+		} );
+	} );
+
 	it( 'shows a failure message and no spinner when generation errored', () => {
 		cy.intercept(
 			'GET',

--- a/tests/phpunit/editor/classic/test-metabox.php
+++ b/tests/phpunit/editor/classic/test-metabox.php
@@ -257,6 +257,72 @@ class MetaboxTest extends TestCase
     }
 
     /**
+     * Deferred generation writes no Content ID during the save, so the Player
+     * section must still show a status instead of rendering empty until reload.
+     *
+     * @test
+     */
+    public function awaiting_generation_embed_renders_a_loading_state_when_queued()
+    {
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+            'post_title'  => 'MetaboxTest::awaiting_generation_embed_renders_a_loading_state_when_queued',
+        ]);
+
+        update_post_meta($postId, 'beyondwords_project_id', 12345);
+
+        wp_schedule_single_event(time(), \BeyondWords\Post\Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]);
+
+        $html = $this->capture_output(function () use ($postId) {
+            Metabox::awaiting_generation_embed($postId);
+        });
+
+        $crawler = new Crawler($html);
+
+        $container = $crawler->filter('#beyondwords-metabox-player');
+        $this->assertCount(1, $container);
+
+        // No Content ID yet, so the JS must poll the post's own meta instead of
+        // the content-status route.
+        $this->assertSame('1', $container->attr('data-await-content'));
+        $this->assertSame((string) $postId, $container->attr('data-post-id'));
+        $this->assertNull($container->attr('data-content-id'));
+
+        $this->assertCount(1, $container->filter('.spinner.is-active'));
+        $this->assertStringContainsString('Generating', $container->text());
+
+        wp_unschedule_event(
+            wp_next_scheduled(\BeyondWords\Post\Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]),
+            \BeyondWords\Post\Sync::GENERATE_AUDIO_CRON_HOOK,
+            [$postId]
+        );
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * A post with nothing queued has no audio coming, so a spinner would hang forever.
+     *
+     * @test
+     */
+    public function awaiting_generation_embed_renders_nothing_when_no_job_is_queued()
+    {
+        $postId = self::factory()->post->create([
+            'post_status' => 'publish',
+            'post_title'  => 'MetaboxTest::awaiting_generation_embed_renders_nothing_when_no_job_is_queued',
+        ]);
+
+        update_post_meta($postId, 'beyondwords_project_id', 12345);
+
+        $html = $this->capture_output(function () use ($postId) {
+            Metabox::awaiting_generation_embed($postId);
+        });
+
+        $this->assertSame('', trim($html));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
      * Write a Content ID straight into post meta, bypassing Meta::sanitize_content_id().
      */
     private function store_raw_content_id($post_id, $value)

--- a/tests/phpunit/editor/classic/test-metabox.php
+++ b/tests/phpunit/editor/classic/test-metabox.php
@@ -257,8 +257,7 @@ class MetaboxTest extends TestCase
     }
 
     /**
-     * Deferred generation writes no Content ID during the save, so the Player
-     * section must still show a status instead of rendering empty until reload.
+     * A queued job must still show a status, not render the Player section empty.
      *
      * @test
      */
@@ -282,8 +281,7 @@ class MetaboxTest extends TestCase
         $container = $crawler->filter('#beyondwords-metabox-player');
         $this->assertCount(1, $container);
 
-        // No Content ID yet, so the JS must poll the post's own meta instead of
-        // the content-status route.
+        // No Content ID yet, so the JS must poll post meta, not the content route.
         $this->assertSame('1', $container->attr('data-await-content'));
         $this->assertSame((string) $postId, $container->attr('data-post-id'));
         $this->assertNull($container->attr('data-content-id'));


### PR DESCRIPTION
## Problem

Publishing in the classic editor could leave the Player section **completely empty** until the author reloaded the page — no player, no spinner, no message. The metabox looks like generation failed when it is simply still running, which misleads testing and support.

The polling delivered under [S-8779](https://linear.app/beyondwords/issue/S-8779/poll-rest-api-from-wordpress-plugin-to-ensure-player-is-ready) (#566) already covers part of this, but there are **two** distinct waits after a publish and only the second was handled:

| Wait | Before | After |
|---|---|---|
| WordPress has no content ID yet (job queued) | Player section renders **empty** | "Generating…" + poll |
| Content ID exists, BeyondWords still processing | "Generating…" + poll | unchanged |

`render_meta_box_content()` gated the entire player area on `has_content()`, so during the first wait it emitted the "Player" heading and nothing else. The existing poll could not help: `initMetaboxPlayer()` bails without a `data-content-id`, and that container was never rendered in the first place.

The tell-tale symptom is that reloading shows the **finished player** directly — never the Generating state. If a content ID had existed at first render you would have seen the spinner.

This happens whenever generation is deferred to cron — `Sync::is_async_generation_enabled()`, i.e. WordPress VIP or the `beyondwords_async_generate_audio` filter. It is pinned by the existing `on_add_or_update_post_defers_to_cron_when_async_enabled` test, which asserts `beyondwords_content_id` is `''` immediately after the save.

## Changes

- **`src/editor/classic/class-metabox.php`** — new `awaiting_generation_embed()` renders the loading container with `data-post-id` / `data-await-content` when a generation job is queued but no content ID exists. Gated on `wp_next_scheduled( Sync::GENERATE_AUDIO_CRON_HOOK, … )` so posts with no audio coming stay blank rather than showing a spinner that would never resolve.
- **`src/editor/components/content-id/classic-metabox.js`** — new `awaitContentId()` polls the post's own meta over `wp/v2` until the cron job writes an ID, then sets the data attributes and hands off to `initMetaboxPlayer()`.

`awaitContentId()` reuses the existing `pollContentStatus()` by reporting `'queued'` (already a non-terminal status) until the ID lands, so it inherits the 120s budget, hidden-tab handling and supersede token rather than duplicating them.

The handoff matters: the player still waits for `processed` rather than embedding straight away, so a still-processing asset never 404s into the CDN cache.

No new REST route is needed — `beyondwords_content_id` is already `show_in_rest` and is not in `REST_PRIVATE_META_KEYS`, so the `wp/v2` request the Fetch button already makes can serve it.

## Testing

- **PHPUnit: 714/715 pass.** Full `MetaboxTest` green (15 tests), including two new cases — renders the loading state when a job is queued, and renders nothing when one is not.
- The single failure is `build/index.asset.php: No such file or directory` in `src/editor/block/`, a file this PR does not touch. Confirmed pre-existing by stashing the changes and re-running: it fails identically on a clean tree. It is the gitignored `build/` dir being absent without `npm run build`.
- ESLint and phpcs clean on all changed files.

### Reviewer note

✅ **The two new Cypress specs have now been run in CI and pass** on both PHP 8.0 and 8.5:

```
✓ shows a Generating state while deferred generation is still queued
✓ hands off to the content-status poll once the queued job writes an ID
```

This supersedes the earlier note on this PR, which said they were unrun — at the time they could only be run against an env that mounted `main`, so they would have passed without exercising this branch. CI runs them against the branch properly. To run locally:

```
npm run cypress:run -- --spec 'tests/cypress/e2e/classic-editor/content-id.cy.js'
```

They rely on a new `scheduleAudioGeneration` Cypress task (`cypress.config.js`) that queues the cron event the async path would create, scheduled an hour out so WP-Cron cannot fire it mid-test.

### Scope

This fixes the deferred-generation path. On a non-VIP site generation is a blocking call during the save, so the content ID is already present and the existing polling works. If the empty Player section is ever reproduced on a **non-VIP** site, that is a different fault — most likely the 3s `DEFAULT_REQUEST_TIMEOUT` in `src/api/class-client.php` failing the create call — and should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
