### PR TITLE
fix(tests): update two tests stale after the Script-only Source removal

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,7 @@ Release date: tbc
 
 **Codebase Enhancements**
 
+* [#607](https://github.com/beyondwords-io/wordpress-plugin/pull/607) Update two PHPUnit tests left stale by the Script-only Source removal.
 * [#602](https://github.com/beyondwords-io/wordpress-plugin/pull/602) Align the player-visibility docs and Cypress specs with the "Embed" setting.
 * [#600](https://github.com/beyondwords-io/wordpress-plugin/pull/600) Add must-follow documentation and changelog rules to `AGENTS.md`, with `CLAUDE.md` and Copilot pointer files.
 * [#533](https://github.com/beyondwords-io/wordpress-plugin/pull/533) Fix failing Cypress tests for v7.

--- a/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
+++ b/tests/phpunit/editor/components/settings-fields/test-settings-fields.php
@@ -496,7 +496,8 @@ class SettingsFieldsTest extends TestCase
             'meta_input' => ['beyondwords_source' => 'script'],
         ]);
 
-        $this->assertSame(SettingsFields::EMBED_AUDIO_SCRIPT, SettingsFields::get_effective_embed($postId));
+        // The post asset comes first even for a legacy script source.
+        $this->assertSame(SettingsFields::EMBED_AUDIO_POST, SettingsFields::get_effective_embed($postId));
 
         wp_delete_post($postId, true);
     }

--- a/tests/phpunit/player/test-config-builder.php
+++ b/tests/phpunit/player/test-config-builder.php
@@ -361,29 +361,29 @@ class ConfigBuilderTest extends TestCase
     }
 
     /**
-     * Script × Video only produces "video_script", so a regression fails positively
-     * here rather than passing on key absence.
+     * Source = Post produces no script asset, so honouring the stale "video_script"
+     * would set summary — a regression fails positively rather than on key absence.
      *
      * @test
      */
     public function merge_post_settings_embed_invalid_for_source_output_falls_back_to_default_asset()
     {
         $post = $this->createEmbedPost([
-            'beyondwords_source' => 'script',
+            'beyondwords_source' => 'post',
             'beyondwords_output' => 'video',
-            'beyondwords_embed'  => 'audio_post',
+            'beyondwords_embed'  => 'video_script',
         ]);
 
         $params = ConfigBuilder::merge_post_settings($post, []);
 
         $this->assertTrue($params['video']);
-        $this->assertTrue($params['summary']);
+        $this->assertArrayNotHasKey('summary', $params);
 
         wp_delete_post($post->ID, true);
     }
 
     /**
-     * Counterpart to the test above, where the default asset would have set both params.
+     * Counterpart to the test above, where the default asset would have set video.
      *
      * @test
      */


### PR DESCRIPTION
PHPUnit was failing on `main` with one failure and one error. Both are stale
tests, not broken code — the source behaves as intended.

[#601](https://github.com/beyondwords-io/wordpress-plugin/pull/601) removed the
Script-only Source: `script` survives only as `LEGACY_SOURCE_SCRIPT` and
normalizes to `post_and_script`, and `embed_options()` now pushes the post
assets unconditionally. So the **first derived asset is always the post one**.
That PR updated most of the affected tests but missed these two, which still
encoded "script means script-only".

## What changed

**`SettingsFieldsTest::get_effective_embed_defaults_an_unset_value_to_the_first_asset`**

A legacy `script` post with no stored Embed derives `audio_post`, not
`audio_script`. This is deliberate rather than a regression in reach:
`Updater::migrate_source_script_to_post_and_script()` pins the script asset onto
posts that predate the change, precisely because the derived default moved — so
no existing post silently switches which asset it embeds.

**`ConfigBuilderTest::merge_post_settings_embed_invalid_for_source_output_falls_back_to_default_asset`**

The old seed (Source = `script` × Output = Video, stale `audio_post`) asserted
the fallback sets both `video` and `summary`. No source/output pair can produce
that any more, since the fallback always lands on the post asset — the test
errored on `Undefined array key "summary"`.

Simply dropping the `summary` assertion would have degraded the test to passing
on key absence, which its docblock explicitly set out to avoid. Instead it is
reseeded with Source = Post × Output = Video and a stale `video_script`. Post
generates no script asset, so honouring the stale value would *add* `summary` —
the property survives, and the test now catches both failure modes:

| Regression | Caught by |
| --- | --- |
| Stale Embed honoured instead of falling back | `assertArrayNotHasKey( 'summary' )` |
| Fallback returns nothing / `none` | `assertTrue( $params['video'] )` on a missing key |

## Verification

- Full suite green in the tests container: **739 tests, 0 failures**, with the
  same single multisite skip CI shows.
- Both tests confirmed to fail positively by temporarily deleting the validity
  check in `SettingsFields::get_effective_embed()`; the source was reverted
  afterwards and is untouched by this PR.
- Test-only change plus the changelog line, so no `src/` diff to review.

## Note for the reviewer

The Cypress "PHP 8.0" failure on `main` (`can add a publish CPT Inactive without
audio`) is **not** related and not a PHP-version issue. The CI log's code frame
points at `tests/cypress/support/commands.js:88` — the block editor's canvas
iframe re-mounts during hydration and detaches the subject `cy.find()` is
querying. 45 tests using the same helper passed in that same PHP 8.0 job, and
there is no PHP-version-conditional code in `src/`. It is being fixed separately.
