### PR TITLE
fix: count skipped posts separately from failures in bulk generate audio

### DIFF
--- a/doc/async-rest-migration.md
+++ b/doc/async-rest-migration.md
@@ -110,6 +110,15 @@ It sets `beyondwords_generate_audio` meta on every selected post, then:
   ([src/posts-list/class-notices.php](../src/posts-list/class-notices.php));
   their generate flag is already set, so re-running the action completes them.
 
+Each inline generate is counted as `generated`, `skipped` or `failed`. Skipped
+means there was nothing to do, not that anything went wrong: an ineligible post
+status, an existing recording with `BEYONDWORDS_AUTOREGENERATE` off, or another
+request already creating the audio ([source-id-race.md](source-id-race.md)).
+`Sync::generate_audio_result()` carries that outcome alongside the API response,
+because a falsy response alone can't tell the two apart —
+`Sync::generate_audio_for_post()` still returns just the response, so the save
+and cron callers are unaffected. `Notices::skipped_notice()` surfaces the count.
+
 ## Known limitations
 
 ### Classic-editor server-side reads

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Release date: tbc
 
 **Fixes**
 
+* [#610](https://github.com/beyondwords-io/wordpress-plugin/pull/610) Stop the bulk "Generate audio" notice counting skipped posts as failures.
 * [#606](https://github.com/beyondwords-io/wordpress-plugin/pull/606) Fix posts published with no player when two saves race to create audio.
 * [#564](https://github.com/beyondwords-io/wordpress-plugin/pull/564) Sweep the paired `_transient_timeout_beyondwords_*` rows on uninstall, so no orphaned option rows are left behind.
 * [#540](https://github.com/beyondwords-io/wordpress-plugin/pull/540) Escape the player `onload` attribute to prevent stored XSS via the Content ID.

--- a/src/post/class-sync.php
+++ b/src/post/class-sync.php
@@ -48,6 +48,15 @@ class Sync {
 	const BULK_GENERATE_SYNC_LIMIT = 10;
 
 	/**
+	 * Outcome of one generate attempt: audio requested, nothing to do, or the API call failed.
+	 *
+	 * @since 7.0.0
+	 */
+	const OUTCOME_GENERATED = 'generated';
+	const OUTCOME_SKIPPED   = 'skipped';
+	const OUTCOME_FAILED    = 'failed';
+
+	/**
 	 * Post meta key for the per-post "a create is in flight" lock.
 	 *
 	 * Underscore-prefixed so core protects it: request bookkeeping, not post data.
@@ -216,13 +225,27 @@ class Sync {
 	 * @return array<mixed>|false|null Response from the API, or false when audio wasn't generated.
 	 */
 	public static function generate_audio_for_post( int $post_id ): array|false|null {
+		return self::generate_audio_result( $post_id )['response'];
+	}
+
+	/**
+	 * Generate audio for a post, reporting whether it ran, was skipped, or failed.
+	 *
+	 * A falsy response on its own can't tell a post that had nothing to do from
+	 * one whose API call failed. See doc/async-rest-migration.md.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array{outcome:string, response:array<mixed>|false|null}
+	 */
+	private static function generate_audio_result( int $post_id ): array {
 		if ( ! self::should_generate_audio_for_post( $post_id ) ) {
-			return false;
+			return self::skipped_result();
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return false;
+			return self::skipped_result();
 		}
 
 		$integration_method = \BeyondWords\Settings\Fields::get_integration_method( $post );
@@ -232,7 +255,7 @@ class Sync {
 			update_post_meta( $post_id, 'beyondwords_integration_method', \BeyondWords\Settings\Fields::INTEGRATION_CLIENT_SIDE );
 			update_post_meta( $post_id, 'beyondwords_project_id', get_option( 'beyondwords_project_id' ) );
 
-			return \BeyondWords\Api\Client::get_player_by_source_id( $post_id );
+			return self::attempted_result( \BeyondWords\Api\Client::get_player_by_source_id( $post_id ) );
 		}
 
 		update_post_meta( $post_id, 'beyondwords_integration_method', \BeyondWords\Settings\Fields::INTEGRATION_REST_API );
@@ -241,7 +264,7 @@ class Sync {
 
 		if ( $content_id ) {
 			if ( defined( 'BEYONDWORDS_AUTOREGENERATE' ) && ! BEYONDWORDS_AUTOREGENERATE ) {
-				return false;
+				return self::skipped_result();
 			}
 
 			$response = self::update_or_recreate_audio( $post_id );
@@ -253,7 +276,35 @@ class Sync {
 		$project_id = \BeyondWords\Post\Meta::get_project_id( $post_id );
 		self::process_response( $response, $project_id, $post_id );
 
-		return $response;
+		return self::attempted_result( $response );
+	}
+
+	/**
+	 * Result for a post that needed no work — never counted as a failure.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array{outcome:string, response:false}
+	 */
+	private static function skipped_result(): array {
+		return [
+			'outcome'  => self::OUTCOME_SKIPPED,
+			'response' => false,
+		];
+	}
+
+	/**
+	 * Result for an API call we actually made, where a falsy response is the failure signal.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array{outcome:string, response:array<mixed>|false|null}
+	 */
+	private static function attempted_result( array|false|null $response ): array {
+		return [
+			'outcome'  => $response ? self::OUTCOME_GENERATED : self::OUTCOME_FAILED,
+			'response' => $response,
+		];
 	}
 
 	/**
@@ -264,11 +315,11 @@ class Sync {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return array<mixed>|null|false False when another request has the create covered.
+	 * @return array{outcome:string, response:array<mixed>|false|null} Skipped when another request has the create covered.
 	 */
-	private static function create_audio_once( int $post_id ): array|null|false {
+	private static function create_audio_once( int $post_id ): array {
 		if ( ! self::acquire_create_lock( $post_id ) ) {
-			return false;
+			return self::skipped_result();
 		}
 
 		try {
@@ -276,14 +327,14 @@ class Sync {
 			wp_cache_delete( $post_id, 'post_meta' );
 
 			if ( \BeyondWords\Post\Meta::get_content_id( $post_id ) ) {
-				return false;
+				return self::skipped_result();
 			}
 
 			$response = \BeyondWords\Api\Client::create_audio( $post_id );
 
 			self::process_response( $response, \BeyondWords\Post\Meta::get_project_id( $post_id ), $post_id );
 
-			return $response;
+			return self::attempted_result( $response );
 		} finally {
 			delete_post_meta( $post_id, self::CREATE_LOCK_META_KEY );
 		}
@@ -368,7 +419,7 @@ class Sync {
 	 *
 	 * @param int[] $post_ids WordPress post IDs from the bulk selection.
 	 *
-	 * @return array{generated:int, failed:int, deferred:int} Per-outcome counts.
+	 * @return array{generated:int, failed:int, skipped:int, deferred:int} Per-outcome counts.
 	 */
 	public static function bulk_generate_audio_for_posts( array $post_ids ): array {
 		$post_ids = array_map( 'intval', $post_ids );
@@ -389,6 +440,7 @@ class Sync {
 			return [
 				'generated' => count( $post_ids ),
 				'failed'    => 0,
+				'skipped'   => 0,
 				'deferred'  => 0,
 			];
 		}
@@ -402,10 +454,15 @@ class Sync {
 
 		$generated = 0;
 		$failed    = 0;
+		$skipped   = 0;
 
 		foreach ( $to_process as $post_id ) {
-			if ( self::generate_audio_for_post( $post_id ) ) {
+			$outcome = self::generate_audio_result( $post_id )['outcome'];
+
+			if ( self::OUTCOME_GENERATED === $outcome ) {
 				++$generated;
+			} elseif ( self::OUTCOME_SKIPPED === $outcome ) {
+				++$skipped;
 			} else {
 				++$failed;
 			}
@@ -414,6 +471,7 @@ class Sync {
 		return [
 			'generated' => $generated,
 			'failed'    => $failed,
+			'skipped'   => $skipped,
 			'deferred'  => $deferred,
 		];
 	}

--- a/src/posts-list/class-bulk-edit.php
+++ b/src/posts-list/class-bulk-edit.php
@@ -239,6 +239,7 @@ class BulkEdit {
 				'beyondwords_bulk_deferred',
 				'beyondwords_bulk_deleted',
 				'beyondwords_bulk_failed',
+				'beyondwords_bulk_skipped',
 				'beyondwords_bulk_error',
 			],
 			$redirect
@@ -270,6 +271,10 @@ class BulkEdit {
 			$redirect = add_query_arg( 'beyondwords_bulk_generated', $counts['generated'], $redirect );
 			$redirect = add_query_arg( 'beyondwords_bulk_failed', $counts['failed'], $redirect );
 
+			if ( $counts['skipped'] > 0 ) {
+				$redirect = add_query_arg( 'beyondwords_bulk_skipped', $counts['skipped'], $redirect );
+			}
+
 			if ( $counts['deferred'] > 0 ) {
 				$redirect = add_query_arg( 'beyondwords_bulk_deferred', $counts['deferred'], $redirect );
 			}
@@ -300,6 +305,7 @@ class BulkEdit {
 				'beyondwords_bulk_deferred',
 				'beyondwords_bulk_deleted',
 				'beyondwords_bulk_failed',
+				'beyondwords_bulk_skipped',
 				'beyondwords_bulk_error',
 			],
 			$redirect

--- a/src/posts-list/class-notices.php
+++ b/src/posts-list/class-notices.php
@@ -25,6 +25,7 @@ class Notices {
 	 */
 	public static function init(): void {
 		add_action( 'admin_notices', [ self::class, 'generated_notice' ] );
+		add_action( 'admin_notices', [ self::class, 'skipped_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'deferred_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'deleted_notice' ] );
 		add_action( 'admin_notices', [ self::class, 'failed_notice' ] );
@@ -53,6 +54,36 @@ class Notices {
 		);
 		?>
 		<div id="beyondwords-bulk-edit-notice-generated" class="notice notice-info is-dismissible">
+			<p><?php echo esc_html( $message ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * "N posts were skipped" notice after a Generate Audio bulk action.
+	 *
+	 * Skipped posts had nothing to generate — an ineligible post status, an
+	 * existing recording with autoregeneration off, or a concurrent create.
+	 */
+	public static function skipped_notice(): void {
+		$count = self::get_query_count( 'beyondwords_bulk_skipped' );
+
+		if ( null === $count ) {
+			return;
+		}
+
+		$message = sprintf(
+			/* translators: %d is replaced with the number of posts that were skipped */
+			_n(
+				'%d post was skipped because no audio change was needed.',
+				'%d posts were skipped because no audio change was needed.',
+				$count,
+				'speechkit'
+			),
+			$count
+		);
+		?>
+		<div id="beyondwords-bulk-edit-notice-skipped" class="notice notice-info is-dismissible">
 			<p><?php echo esc_html( $message ); ?></p>
 		</div>
 		<?php
@@ -126,7 +157,7 @@ class Notices {
 		}
 
 		$message = sprintf(
-			/* translators: %d is replaced with the number of posts that were skipped */
+			/* translators: %d is replaced with the number of posts that failed */
 			_n(
 				'%d post failed, check for errors in the BeyondWords column below.',
 				'%d posts failed, check for errors in the BeyondWords column below.',

--- a/tests/cypress/e2e/bulk-actions.cy.js
+++ b/tests/cypress/e2e/bulk-actions.cy.js
@@ -284,5 +284,37 @@ context( 'Bulk Actions', () => {
 				);
 				cy.get( 'div.notice.notice-error' ).should( 'not.be.visible' );
 			} );
+
+			it( `reports skipped, not failed, for draft ${ postType.name }s`, () => {
+				// A draft is a post status BeyondWords does not process, so the
+				// bulk action has nothing to generate for it.
+				const title = `Bulk skip for ${ postType.name }s`;
+
+				cy.createTestPost( {
+					title,
+					postType: postType.slug,
+					status: 'draft',
+				} );
+
+				cy.visit(
+					`/wp-admin/edit.php?post_type=${ postType.slug }&post_status=draft`
+				);
+
+				cy.contains( 'tbody tr', title ).within( () => {
+					cy.get( 'input[type="checkbox"][name="post[]"]' ).check();
+				} );
+
+				cy.get( '#bulk-action-selector-top' ).select(
+					'Generate audio'
+				);
+				cy.get( '#doaction' ).click();
+
+				cy.get( '#beyondwords-bulk-edit-notice-skipped' ).contains(
+					'1 post was skipped because no audio change was needed.'
+				);
+				cy.get( '#beyondwords-bulk-edit-notice-failed' ).should(
+					'not.exist'
+				);
+			} );
 		} );
 } );

--- a/tests/phpunit/post/test-sync.php
+++ b/tests/phpunit/post/test-sync.php
@@ -1659,6 +1659,7 @@ class SyncTest extends TestCase
         // Every post is queued and reported as requested; nothing runs inline.
         $this->assertSame(count($postIds), $counts['generated']);
         $this->assertSame(0, $counts['failed']);
+        $this->assertSame(0, $counts['skipped']);
         $this->assertSame(0, $counts['deferred']);
 
         foreach ($postIds as $postId) {
@@ -1703,6 +1704,7 @@ class SyncTest extends TestCase
 
         $this->assertSame(Sync::BULK_GENERATE_SYNC_LIMIT, $counts['failed']);
         $this->assertSame(0, $counts['generated']);
+        $this->assertSame(0, $counts['skipped']);
         $this->assertSame($overflow, $counts['deferred']);
 
         // The already-generated post is ordered last, so it is one of the deferred
@@ -1728,6 +1730,87 @@ class SyncTest extends TestCase
     }
 
     /**
+     * A post BeyondWords doesn't process — here a draft — is nothing to do rather
+     * than a failure, so the notice can't report failures that never happened.
+     *
+     * @test
+     * @group generateAudio
+     */
+    public function bulk_generate_audio_for_posts_counts_ineligible_posts_as_skipped()
+    {
+        $postIds = [
+            self::factory()->post->create(['post_status' => 'draft']),
+            self::factory()->post->create(['post_status' => 'draft']),
+        ];
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $counts = Sync::bulk_generate_audio_for_posts($postIds);
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $this->assertSame(0, $counts['generated']);
+        $this->assertSame(0, $counts['failed']);
+        $this->assertSame(count($postIds), $counts['skipped']);
+        $this->assertSame(0, $counts['deferred']);
+        $this->assertFalse($httpAttempted, 'An ineligible post should not reach the API.');
+
+        // The single-post entry point still reports falsy, so on_add_or_update_post()
+        // and the cron callback are unaffected by the outcome split.
+        $this->assertFalse(Sync::generate_audio_for_post($postIds[0]));
+
+        foreach ($postIds as $postId) {
+            wp_delete_post($postId, true);
+        }
+    }
+
+    /**
+     * The request that loses the create lock did no work, so it must not inflate
+     * the failure count either.
+     *
+     * @test
+     * @group generateAudio
+     */
+    public function bulk_generate_audio_for_posts_counts_a_locked_create_as_skipped()
+    {
+        update_option('beyondwords_api_key', BEYONDWORDS_TESTS_API_KEY);
+        update_option('beyondwords_project_id', BEYONDWORDS_TESTS_PROJECT_ID);
+
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+
+        // Stand in for another request that is mid-create with a fresh lock.
+        add_post_meta($postId, Sync::CREATE_LOCK_META_KEY, (string) time(), true);
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $counts = Sync::bulk_generate_audio_for_posts([$postId]);
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $this->assertSame(0, $counts['generated']);
+        $this->assertSame(0, $counts['failed']);
+        $this->assertSame(1, $counts['skipped']);
+        $this->assertFalse($httpAttempted, 'The lock holder is creating the audio; this request should not.');
+
+        // The lock belongs to the other request, so this one leaves it in place.
+        $this->assertNotEmpty(get_post_meta($postId, Sync::CREATE_LOCK_META_KEY, true));
+
+        wp_delete_post($postId, true);
+        delete_option('beyondwords_api_key');
+        delete_option('beyondwords_project_id');
+    }
+
+    /**
      * @test
      * @group generateAudio
      */
@@ -1742,6 +1825,7 @@ class SyncTest extends TestCase
 
         $this->assertSame(1, $counts['generated']);
         $this->assertSame(0, $counts['failed']);
+        $this->assertSame(0, $counts['skipped']);
         $this->assertSame(0, $counts['deferred']);
         $this->assertNotFalse(wp_next_scheduled(Sync::GENERATE_AUDIO_CRON_HOOK, [$postId]));
 

--- a/tests/phpunit/posts-list/test-bulk-edit-ajax.php
+++ b/tests/phpunit/posts-list/test-bulk-edit-ajax.php
@@ -156,6 +156,44 @@ final class BulkEditAjaxTest extends WP_Ajax_UnitTestCase
     }
 
     /**
+     * The inline bulk edit only flags posts for the next save — it never generates,
+     * so the generate/skip/fail outcomes the bulk action counts don't apply here.
+     *
+     * @test
+     */
+    public function save_bulk_edit_generate_flags_posts_it_would_not_generate_for()
+    {
+        // A draft is not a status BeyondWords processes, so the bulk *action* would
+        // skip it; the inline edit still flags it for when it is published.
+        $postId = self::factory()->post->create([
+            'post_status' => 'draft',
+            'post_title'  => 'BulkEditAjaxTest::generate-draft',
+        ]);
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $_POST['beyondwords_bulk_edit_nonce'] = wp_create_nonce('beyondwords_bulk_edit');
+        $_POST['beyondwords_bulk_edit'] = 'generate';
+        $_POST['post_ids'] = [$postId];
+
+        $response = $this->getJsonResponse();
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        $this->assertTrue($response['success']);
+        $this->assertSame([$postId], $response['data']);
+        $this->assertSame('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
+        $this->assertFalse($httpAttempted, 'The inline bulk edit should not call the API.');
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
      * Regression test for the AJAX delete path.
      *
      * With no post carrying both project_id and content_id, Client::batch_delete_audio() throws

--- a/tests/phpunit/posts-list/test-bulk-edit.php
+++ b/tests/phpunit/posts-list/test-bulk-edit.php
@@ -241,7 +241,7 @@ final class BulkEditTest extends TestCase
         delete_option('beyondwords_project_id');
 
         $nonce = wp_create_nonce('beyondwords_bulk_edit_result');
-        $redirect = 'https://example.com/wp-admin/posts?beyondwords_bulk_generated=99';
+        $redirect = 'https://example.com/wp-admin/posts?beyondwords_bulk_generated=99&beyondwords_bulk_skipped=99';
         $redirect = add_query_arg('beyondwords_bulk_edit_result_nonce', $nonce, $redirect);
 
         $redirect = BulkEdit::handle_bulk_generate_action($redirect, 'beyondwords_generate_audio', $postIds);
@@ -255,6 +255,9 @@ final class BulkEditTest extends TestCase
 
         $this->assertEquals(0, $args['beyondwords_bulk_generated']);
         $this->assertEquals(count($postIds), $args['beyondwords_bulk_failed']);
+
+        // Nothing was skipped, so the stale count from the incoming URL is dropped.
+        $this->assertArrayNotHasKey('beyondwords_bulk_skipped', $args);
 
         // The generate_audio flag is set even though generation failed.
         foreach ($postIds as $postId) {
@@ -529,10 +532,56 @@ final class BulkEditTest extends TestCase
         $this->assertSame('0', $args['beyondwords_bulk_generated']);
         $this->assertSame((string) Sync::BULK_GENERATE_SYNC_LIMIT, $args['beyondwords_bulk_failed']);
         $this->assertSame((string) $overflow, $args['beyondwords_bulk_deferred']);
+        $this->assertArrayNotHasKey('beyondwords_bulk_skipped', $args);
 
         foreach ($postIds as $postId) {
             $this->assertEquals('1', get_post_meta($postId, 'beyondwords_generate_audio', true));
         }
+
+        foreach ($postIds as $postId) {
+            wp_delete_post($postId, true);
+        }
+    }
+
+    /**
+     * Posts with nothing to generate are reported separately from real failures,
+     * so the notice no longer claims a failure the user cannot act on.
+     *
+     * @test
+     *
+     * @backupGlobals disabled
+     */
+    public function handle_bulk_generate_action_reports_skipped_posts()
+    {
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+        // Drafts are not a status BeyondWords processes, so each one is skipped.
+        $postIds = [
+            self::factory()->post->create(['post_status' => 'draft']),
+            self::factory()->post->create(['post_status' => 'draft']),
+        ];
+
+        $httpAttempted = false;
+        $filter = function ($preempt) use (&$httpAttempted) {
+            $httpAttempted = true;
+            return new WP_Error('blocked', 'No HTTP expected in this test.');
+        };
+        add_filter('pre_http_request', $filter, 10, 1);
+
+        $nonce = wp_create_nonce('beyondwords_bulk_edit_result');
+        $redirect = add_query_arg('beyondwords_bulk_edit_result_nonce', $nonce, 'https://example.com/wp-admin/edit.php');
+
+        $redirect = BulkEdit::handle_bulk_generate_action($redirect, 'beyondwords_generate_audio', $postIds);
+
+        remove_filter('pre_http_request', $filter, 10);
+
+        parse_str((string) parse_url($redirect, PHP_URL_QUERY), $args);
+
+        $this->assertSame((string) count($postIds), $args['beyondwords_bulk_skipped']);
+        $this->assertSame('0', $args['beyondwords_bulk_failed']);
+        $this->assertSame('0', $args['beyondwords_bulk_generated']);
+        $this->assertArrayNotHasKey('beyondwords_bulk_deferred', $args);
+        $this->assertFalse($httpAttempted, 'A skipped post should not reach the API.');
 
         foreach ($postIds as $postId) {
             wp_delete_post($postId, true);

--- a/tests/phpunit/posts-list/test-notices.php
+++ b/tests/phpunit/posts-list/test-notices.php
@@ -34,6 +34,7 @@ final class NoticesTest extends TestCase
         do_action('wp_loaded');
 
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'generated_notice')));
+        $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'skipped_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'deferred_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'deleted_notice')));
         $this->assertEquals(10, has_action('admin_notices', array(Notices::class, 'failed_notice')));
@@ -115,6 +116,21 @@ final class NoticesTest extends TestCase
         $this->expectException(\WPDieException::class);
 
         Notices::deferred_notice();
+    }
+
+    /**
+     * @test
+     */
+    public function skipped_notice_with_invalid_nonce()
+    {
+        set_current_screen('edit-post');
+
+        $_GET['beyondwords_bulk_edit_result_nonce'] = 'foo';
+        $_GET['beyondwords_bulk_skipped'] = '42';
+
+        $this->expectException(\WPDieException::class);
+
+        Notices::skipped_notice();
     }
 
     /**
@@ -260,6 +276,45 @@ final class NoticesTest extends TestCase
             '42 posts' => [
                 'numDeferred' => 42,
                 'expectMessage' => '42 posts still need audio — run Generate audio again to continue.',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider skipped_notice_provider
+     */
+    public function skipped_notice($numSkipped, $expectMessage)
+    {
+        set_current_screen('edit-post');
+
+        $_GET['beyondwords_bulk_edit_result_nonce'] = wp_create_nonce('beyondwords_bulk_edit_result');
+        $_GET['beyondwords_bulk_skipped'] = $numSkipped;
+
+        $html = $this->capture_output(function () {
+            Notices::skipped_notice();
+        });
+
+        $crawler = new Crawler($html);
+
+        $notice = $crawler->filter('div');
+
+        $this->assertEquals('beyondwords-bulk-edit-notice-skipped', $notice->getNode(0)->getAttribute('id'));
+        $this->assertEquals('notice notice-info is-dismissible', $notice->getNode(0)->getAttribute('class'));
+
+        $this->assertStringContainsString($expectMessage, $notice->filter('p:first-of-type')->text());
+    }
+
+    public function skipped_notice_provider() {
+        return [
+            '1 post' => [
+                'numSkipped' => 1,
+                'expectMessage' => '1 post was skipped because no audio change was needed.',
+            ],
+            '42 posts' => [
+                'numSkipped' => 42,
+                'expectMessage' => '42 posts were skipped because no audio change was needed.',
             ],
         ];
     }


### PR DESCRIPTION
## The bug

`Sync::bulk_generate_audio_for_posts()` counted the outcome of each post like this:

```php
if ( self::generate_audio_for_post( $post_id ) ) {
    ++$generated;
} else {
    ++$failed;
}
```

Every falsy return was a failure — but several of `generate_audio_for_post()`'s falsy returns mean *nothing to do*:

- `BEYONDWORDS_AUTOREGENERATE` is defined false and the post already has a content ID.
- `should_generate_audio_for_post()` returns false (autosave, revision, ineligible post status).
- `create_audio_once()` returns false because another request holds the per-post create lock, or already stored a content ID — added in #606 and raised there as minor/non-blocking.

So bulk "Generate audio" over, say, a set of drafts reported *"3 posts failed, check for errors in the BeyondWords column below."* when nothing had gone wrong and there were no errors to find. Cosmetic — re-running the action is idempotent — but the count was wrong and pointed the user at a column with nothing in it.

## The fix

`generate_audio_for_post()`'s falsy return can't carry the distinction, and changing its return type would ripple into `on_add_or_update_post()` (which casts to bool) and the cron callback. So the pipeline moved into a new private `Sync::generate_audio_result()` that returns the outcome alongside the response:

```php
[ 'outcome' => self::OUTCOME_SKIPPED, 'response' => false ]
```

`generate_audio_for_post()` is now a one-line wrapper returning `['response']` — **its public contract is unchanged**, and no existing caller was touched. `create_audio_once()` returns the same shape, so both of #606's skip returns are covered. `bulk_generate_audio_for_posts()` returns a fourth `skipped` count.

`BulkEdit::handle_bulk_generate_action()` adds `beyondwords_bulk_skipped` to the redirect when non-zero (mirroring how `deferred` is handled), and both bulk handlers strip the arg on redirect. `Notices::skipped_notice()` renders it:

> 3 posts were skipped because no audio change was needed.

`notice-info`, since nothing needs acting on.

## Notes for review

- **The AJAX handler needed no functional change.** `BulkEdit::save_bulk_edit()` calls `BulkEdit::generate_audio_for_posts()`, which only flags posts for the next save and never produces counts. It gets one boundary test documenting that, rather than invented coverage.
- **The skipped message is deliberately one message for three causes** (ineligible status / autoregenerate off / concurrent create). Splitting it would mean three query args and three notices for a cosmetic count; happy to if you'd rather.
- Rationale for the outcome split lives in [doc/async-rest-migration.md](doc/async-rest-migration.md) next to the existing bulk-generation section; the code carries a one-line pointer.
- Also fixed a drifted translator comment on `failed_notice()` that read "number of posts that were skipped" — now genuinely confusing next to a real skipped notice.

## Testing

- `composer test` — 746 pass, 1 skipped (the pre-existing multisite skip). PHPCS `WordPress-VIP-Go` clean, no `phpcs:ignore` added.
- New PHPUnit coverage: drafts and a held create lock both count as `skipped` (both assert via `pre_http_request` that no API call is made); the redirect carries `beyondwords_bulk_skipped` and omits it when zero, including dropping a stale value from the incoming URL; the notice's markup and both plural forms.
- One test also asserts `generate_audio_for_post()` still returns falsy for a skipped post, pinning the unchanged contract that `on_add_or_update_post()` depends on.

**Two gaps to flag:**

1. **The Cypress case is unverified.** `bulk-actions.cy.js` gains a per-post-type test that bulk-generates over a draft and asserts the skipped notice appears and the failed notice does not — the exact user-visible bug, and the only skip cause reachable from the UI. I couldn't run it locally: wp-env serves the plugin from the main checkout, so a run from the worktree would exercise `main`'s code rather than this branch's. The existing assertions in that spec are unaffected (nothing in those flows skips). Worth a CI eye.
2. **The coverage gate didn't run locally** — no xdebug/pcov in the tests container, so `coverage-check` had no clover.xml. CI will compute it.
