### PR TITLE
Tidy classic metabox divider spacing and Content ID layout

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Release date: tbc
     * Editor dropdown data is cached in 15-minute transients; on VIP, audio create/update is deferred to WP-Cron so the save request returns immediately.
 * [#598](https://github.com/beyondwords-io/wordpress-plugin/pull/598) Send taxonomy terms as `tags`.
     * Breaking: the `metadata` param is no longer sent. Code hooking `beyondwords_content_params` to write `$params['metadata']` must append to `$params['tags']` instead, or it will raise a fatal error.
+* [#611](https://github.com/beyondwords-io/wordpress-plugin/pull/611) Tidy the classic editor metabox spacing and Content ID layout.
 
 **Fixes**
 

--- a/src/editor/classic/class-metabox.php
+++ b/src/editor/classic/class-metabox.php
@@ -105,23 +105,23 @@ class Metabox {
 		\BeyondWords\Editor\Components\SettingsFields::render_player_section( $post );
 		( new \BeyondWords\Editor\Components\GenerateAudio() )::element( $post );
 
-		echo '<hr />';
+		echo '<hr class="beyondwords-metabox__divider" />';
 		self::heading( __( 'Content', 'speechkit' ) );
 		\BeyondWords\Editor\Components\SettingsFields::render_content_section( $post );
 
-		echo '<hr />';
+		echo '<hr class="beyondwords-metabox__divider" />';
 		self::heading( __( 'Format', 'speechkit' ) );
 		\BeyondWords\Editor\Components\SettingsFields::render_format_section( $post );
 
-		echo '<hr />';
+		echo '<hr class="beyondwords-metabox__divider" />';
 		self::heading( __( 'Voice', 'speechkit' ) );
 		( new \BeyondWords\Editor\Components\SelectVoice() )::element( $post );
 
-		echo '<hr />';
+		echo '<hr class="beyondwords-metabox__divider" />';
 		self::heading( __( 'Data', 'speechkit' ) );
 		\BeyondWords\Editor\Components\ContentId::element( $post );
 
-		echo '<hr />';
+		echo '<hr class="beyondwords-metabox__divider" />';
 		self::help();
 	}
 

--- a/src/editor/classic/classic.css
+++ b/src/editor/classic/classic.css
@@ -70,9 +70,9 @@ table tr th#speechkit_status {
 	text-align: right;
 }
 
-/* Keeps the button flush right while the floated core spinner is shown. */
+/* Core floats spinners right, which would displace the button. */
 .beyondwords-metabox-content-id__actions .spinner {
 	float: none;
-	margin: 0 0 0 4px;
+	margin: 0 4px 0 0;
 	vertical-align: middle;
 }

--- a/src/editor/classic/classic.css
+++ b/src/editor/classic/classic.css
@@ -1,52 +1,78 @@
 
 .sk-metabox-button {
-  width: 100%;
-  text-align: center;
+	width: 100%;
+	text-align: center;
 }
 
-table tr th#speechkit_status{
-  width: 110px;
+table tr th#speechkit_status {
+	width: 110px;
 }
 
 .beyondwords-hidden {
-  display: none;
+	display: none;
 }
 
 .beyondwords-error {
-  background: #fff;
-  border: 1px solid #c3c4c7;
-  border-left-width: 4px;
-  box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
-  margin: 5px 0 15px;
-  padding: 1px 12px;
-  border-left-color: #d63638;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-left-width: 4px;
+	box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+	margin: 5px 0 15px;
+	padding: 1px 12px;
+	border-left-color: #d63638;
 }
 
 .beyondwords-error p,
 .beyondwords-success p {
-  font-size: 13px;
-  line-height: 1.5;
-  margin: 0.5em 0;
-  padding: 2px;
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 0.5em 0;
+	padding: 2px;
 }
 
 .beyondwords-success {
-  background: #fff;
-  border: 1px solid #c3c4c7;
-  border-left-width: 4px;
-  box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
-  margin: 5px 0 15px;
-  padding: 1px 12px;
-  border-left-color: #00a32a;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-left-width: 4px;
+	box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+	margin: 5px 0 15px;
+	padding: 1px 12px;
+	border-left-color: #00a32a;
 }
 
 .beyondwords-metabox__heading {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 0 0 8px;
-  padding: 0;
+	font-size: 14px;
+	font-weight: 600;
+	margin: 0 0 8px;
+	padding: 0;
 }
 
 .beyondwords-metabox-settings__field {
-  margin: 0 0 8px;
+	margin: 0 0 8px;
+}
+
+.beyondwords-metabox__divider {
+	margin: 16px 0;
+}
+
+#beyondwords-metabox-content-id {
+	margin: 8px 0 13px;
+}
+
+/* Core's 1px input margin would overhang the edge the button aligns to. */
+.beyondwords-metabox-content-id__input {
+	width: 100%;
+	margin: 1px 0;
+}
+
+.beyondwords-metabox-content-id__actions {
+	margin-top: 8px;
+	text-align: right;
+}
+
+/* Keeps the button flush right while the floated core spinner is shown. */
+.beyondwords-metabox-content-id__actions .spinner {
+	float: none;
+	margin: 0 0 0 4px;
+	vertical-align: middle;
 }

--- a/src/editor/components/content-id/class-content-id.php
+++ b/src/editor/components/content-id/class-content-id.php
@@ -61,20 +61,20 @@ class ContentId {
 
 		wp_nonce_field( 'beyondwords_content_id', 'beyondwords_content_id_nonce' );
 		?>
-		<div id="beyondwords-metabox-content-id" style="margin: 8px 0 13px;">
+		<div id="beyondwords-metabox-content-id">
 			<p class="post-attributes-label-wrapper">
 				<label for="beyondwords_content_id" class="post-attributes-label">
 					<?php esc_html_e( 'Content ID', 'speechkit' ); ?>
 				</label>
 			</p>
-			<div style="display: flex; gap: 4px; align-items: center;">
-				<input
-					type="text"
-					id="beyondwords_content_id"
-					name="beyondwords_content_id"
-					value="<?php echo esc_attr( $content_id ); ?>"
-					style="flex: 1;"
-				/>
+			<input
+				type="text"
+				id="beyondwords_content_id"
+				name="beyondwords_content_id"
+				class="beyondwords-metabox-content-id__input"
+				value="<?php echo esc_attr( $content_id ); ?>"
+			/>
+			<div class="beyondwords-metabox-content-id__actions">
 				<button
 					type="button"
 					id="beyondwords__content-id--fetch"

--- a/src/editor/components/content-id/classic-metabox.js
+++ b/src/editor/components/content-id/classic-metabox.js
@@ -600,7 +600,8 @@
 		if ( loading && ! spinner ) {
 			const s = document.createElement( 'span' );
 			s.className = 'spinner is-active';
-			button.parentNode.insertBefore( s, button.nextSibling );
+			// Left of the button, so the right-aligned button doesn't shift.
+			button.parentNode.insertBefore( s, button );
 			return s;
 		}
 


### PR DESCRIPTION
Two CSS fixes to the classic editor metabox, from a review of the rendered sidebar.

## What changed

**Section dividers.** The `<hr />` rules between sections relied on the browser default margin, so they sat tighter than the 8–13px rhythm of the headings and fields around them. They now carry a `beyondwords-metabox__divider` class with a 16px symmetric margin — measured 16px above and below each rule in the rendered metabox.

**Content ID / Fetch.** The field and button shared a flex row, which squeezed the field on a narrow sidebar (the Content ID UUID was clipped mid-value). The field is now full width, with the button on its own right-aligned row 9px below it.

Two details worth knowing:

* Core gives inputs a 1px side margin, which would push a `width: 100%` field 1px past the edge the button aligns to — zeroed on the field so the two share a right edge.
* The fetch spinner now goes in *before* the button rather than after it, and is un-floated (core floats spinners right). The button therefore holds the same right edge whether idle or loading, instead of jumping 24px left when a fetch starts.

**`classic.css` reformatted from spaces to tabs.** The file failed `npm run lint:css` on every line before this change; `wp-scripts lint-style --fix` converted it, which is what the WordPress standard and the AGENTS.md "reformat surrounding code when you touch it" rule ask for. This inflates the diff — the only substantive additions are the four new rule blocks at the end. The one remaining lint error (`#speechkit_status`, line 7) is pre-existing and unfixable: it's a WordPress-generated column id.

## Testing

* `phpcs` (WordPress-VIP-Go) clean on both changed PHP files.
* `lint:css` clean apart from the pre-existing `#speechkit_status` error.
* `ContentIdTest` (13 tests) and `MetaboxTest` (15 tests) pass.
* Layout verified in a browser against the real `wp-admin` stylesheets, in both the idle and loading states, with computed geometry checked (field spans the full content box; field and button right edges align to 0px in both states).
* Jest suite passes (52 tests); `lint:js` clean on the changed JS.

`tests/cypress/e2e/classic-editor/content-id.cy.js` was not run locally — the dev wp-env serves the main checkout rather than this worktree, so it would have exercised the pre-change code. The spec targets only ids this change leaves intact (`#beyondwords-metabox-content-id`, `#beyondwords_content_id`, `#beyondwords__content-id--fetch`), so CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
