### PR TITLE
fix: decode HTML entities in tag names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Release date: tbc
 
 **Fixes**
 
+* [#612](https://github.com/beyondwords-io/wordpress-plugin/pull/612) Fix tags with an ampersand showing as `r&amp;d` in the BeyondWords dashboard.
 * [#606](https://github.com/beyondwords-io/wordpress-plugin/pull/606) Fix posts published with no player when two saves race to create audio.
 * [#564](https://github.com/beyondwords-io/wordpress-plugin/pull/564) Sweep the paired `_transient_timeout_beyondwords_*` rows on uninstall, so no orphaned option rows are left behind.
 * [#540](https://github.com/beyondwords-io/wordpress-plugin/pull/540) Escape the player `onload` attribute to prevent stored XSS via the Content ID.

--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -406,6 +406,9 @@ class Content {
 			}
 		}
 
+		// Core stores term names HTML-encoded, so "R&D" would reach the API as "R&amp;D".
+		$tags = array_map( fn( $tag ) => wp_specialchars_decode( $tag, ENT_QUOTES ), $tags );
+
 		// Terms in different taxonomies can share a name, and the API wants each tag once.
 		return array_values( array_unique( $tags ) );
 	}

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -813,6 +813,64 @@ class ContentTest extends TestCase
      *
      * @group tags
      **/
+    public function get_tags_decodes_html_entities_in_term_names()
+    {
+        $taxonomy = 'ampersands';
+
+        register_taxonomy($taxonomy, 'post');
+
+        $term = wp_insert_term('R&D', $taxonomy);
+
+        // Core encodes term names on insert, which is what get_tags() undoes.
+        $this->assertSame('R&amp;D', get_term($term['term_id'])->name);
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'Testing Content::get_tags() with an ampersand',
+            'post_status' => 'publish'
+        ]);
+
+        wp_set_post_terms($postId, [$term['term_id']], $taxonomy);
+
+        $this->assertSame(['Uncategorized', 'R&D'], Content::get_tags($postId));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     *
+     * @group tags
+     **/
+    public function get_tags_preserves_utf8_accents_in_term_names()
+    {
+        $taxonomy = 'accents';
+
+        register_taxonomy($taxonomy, 'post');
+
+        $term = wp_insert_term('café culture', $taxonomy);
+
+        $postId = self::factory()->post->create([
+            'post_title' => 'Testing Content::get_tags() with an accent',
+            'post_status' => 'publish'
+        ]);
+
+        wp_set_post_terms($postId, [$term['term_id']], $taxonomy);
+
+        $tags = Content::get_tags($postId);
+
+        $this->assertSame(['Uncategorized', 'café culture'], $tags);
+
+        // wp_json_encode() escapes the accent, so check it survives the round trip.
+        $this->assertSame($tags, json_decode(wp_json_encode($tags), true));
+
+        wp_delete_post($postId, true);
+    }
+
+    /**
+     * @test
+     *
+     * @group tags
+     **/
     public function get_tags_returns_an_empty_array_when_a_post_has_no_terms()
     {
         $pageId = self::factory()->post->create([


### PR DESCRIPTION
Follow-up to #598. A term named `R&D` reached the dashboard as `r&amp;d`:


## It's our side, not a dashboard rendering bug

WordPress encodes term names **on insert** — `_wp_specialchars` is attached to the `pre_term_name` filter in core's `default-filters.php` — so `R&D` is *stored in the database* as `R&amp;D`. Verified against a real WP install:

```
$ wp eval 'wp_insert_term( "R&D", "post_tag" ); ...'
stored name:   R&amp;D
raw db value:  'R&amp;D'
```

`get_the_terms()` returns that stored value verbatim, so we were sending `R&amp;D` in the `tags` payload. The dashboard then HTML-escaped it for display (correctly — escaping untrusted input is right), which renders the literal text `r&amp;d`. Garbage in, garbage faithfully displayed.

This predates #598 — the old `metadata.taxonomy` payload had the same encoding — but the new `tags` chips make it visible.

## Fix

```php
// Core stores term names HTML-encoded, so "R&D" would reach the API as "R&amp;D".
$tags = array_map( fn( $tag ) => wp_specialchars_decode( $tag, ENT_QUOTES ), $tags );
```

`wp_specialchars_decode()` rather than `html_entity_decode()` because it is the exact inverse of what core applied. A term whose name genuinely contains `&copy;` is stored as `&amp;copy;` and decodes back to the literal `&copy;` the author typed — `html_entity_decode()` would wrongly turn it into `©`. Decoding happens before the dedup pass, so `R&D` and a stray pre-encoded `R&amp;D` collapse to one tag.

## Tests

Both requested cases, in the `@group tags` group:

- **`get_tags_decodes_html_entities_in_term_names`** — asserts the core behaviour being compensated for (`get_term()->name === 'R&amp;D'`), then that `get_tags()` returns `R&D`. The first assertion pins the premise, so if core ever stops encoding, the test says why the decode exists.
- **`get_tags_preserves_utf8_accents_in_term_names`** — `café culture` is stored as raw UTF-8 (`c3a9`) and was never affected, but is now pinned, including a `wp_json_encode()` round trip since the request body escapes the accent as `é`.

Full suite: 717 tests, 2306 assertions, 1 skipped (the pre-existing multisite-only test). `phpcs` clean.

## Not fixed here

`display_name` gets the same treatment from core (`pre_user_display_name` is on the same filter list), so an author called `Smith & Sons` is sent as `Smith &amp; Sons` in the `author` param. Confirmed on a real install, but it's a different payload field and out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
