### PR TITLE
fix: decode HTML entities in author display names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Release date: tbc
 
 **Fixes**
 
+* [#613](https://github.com/beyondwords-io/wordpress-plugin/pull/613) Fix author names with an ampersand showing as `Smith &amp; Sons` in the BeyondWords dashboard.
 * [#606](https://github.com/beyondwords-io/wordpress-plugin/pull/606) Fix posts published with no player when two saves race to create audio.
 * [#564](https://github.com/beyondwords-io/wordpress-plugin/pull/564) Sweep the paired `_transient_timeout_beyondwords_*` rows on uninstall, so no orphaned option rows are left behind.
 * [#540](https://github.com/beyondwords-io/wordpress-plugin/pull/540) Escape the player `onload` attribute to prevent stored XSS via the Content ID.

--- a/src/post/class-content.php
+++ b/src/post/class-content.php
@@ -421,6 +421,9 @@ class Content {
 	public static function get_author_name( int $post_id ): string {
 		$author_id = get_post_field( 'post_author', $post_id );
 
-		return get_the_author_meta( 'display_name', $author_id );
+		$name = get_the_author_meta( 'display_name', $author_id );
+
+		// Core stores display names HTML-encoded, so "Smith & Sons" would reach the API as "Smith &amp; Sons".
+		return wp_specialchars_decode( $name, ENT_QUOTES );
 	}
 }

--- a/tests/phpunit/post/test-content.php
+++ b/tests/phpunit/post/test-content.php
@@ -860,4 +860,33 @@ class ContentTest extends TestCase
 
         wp_delete_post($post->ID, true);
     }
+
+    /**
+     * @test
+     **/
+    public function get_author_name_decodes_html_entities_in_display_names()
+    {
+        $user = self::factory()->user->create_and_get([
+            'role' => 'editor',
+            'display_name' => 'Smith & Sons',
+        ]);
+
+        // Core encodes display names on insert, which is what get_author_name() undoes.
+        $this->assertSame('Smith &amp; Sons', get_userdata($user->ID)->display_name);
+
+        wp_set_current_user($user->ID);
+
+        $post = self::factory()->post->create_and_get([
+            'post_title' => 'Testing Content::get_author_name() with an ampersand',
+            'post_status' => 'publish',
+        ]);
+
+        $this->assertSame('Smith & Sons', Content::get_author_name($post->ID));
+
+        $body = json_decode(Content::get_content_params($post->ID), true);
+
+        $this->assertSame('Smith & Sons', $body['author']);
+
+        wp_delete_post($post->ID, true);
+    }
 }


### PR DESCRIPTION
Follow-up to #612, which fixed the same bug in `tags` and flagged this one as out of scope. An author whose display name is `Smith & Sons` reaches the dashboard as `Smith &amp; Sons`.

## Same cause as the tags bug

WordPress encodes display names **on insert** — `_wp_specialchars` is attached to the `pre_user_display_name` filter in core's `default-filters.php`, the same filter list that encodes term names. So `Smith & Sons` is *stored in the database* already encoded. Verified against a real WP install:

```
$ wp eval 'wp_insert_user( ["user_login" => "amp", "user_pass" => "x", "display_name" => "Smith & Sons"] );'
get_userdata( $id )->display_name === "Smith &amp; Sons"
```

`Content::get_author_name()` returned that value verbatim and `get_content_params()` sent it as the `author` param. The dashboard then HTML-escaped it for display (correctly), rendering the literal text `Smith &amp; Sons`.

## Fix

```php
$name = get_the_author_meta( 'display_name', $author_id );

// Core stores display names HTML-encoded, so "Smith & Sons" would reach the API as "Smith &amp; Sons".
return wp_specialchars_decode( $name, ENT_QUOTES );
```

`wp_specialchars_decode()` rather than `html_entity_decode()` for the same reason as #612 — it is the exact inverse of what core applied. A name genuinely containing `&copy;` is stored as `&amp;copy;` and decodes back to the literal `&copy;` the author typed; `html_entity_decode()` would wrongly turn it into `©`.

## Tests

One test alongside the existing `get_author_name` test in `tests/phpunit/post/test-content.php`:

- **`get_author_name_decodes_html_entities_in_display_names`** — asserts the core behaviour being compensated for (`get_userdata()->display_name === 'Smith &amp; Sons'`), then that both `get_author_name()` and the `author` key of the `get_content_params()` body come back as `Smith & Sons`. As in #612, the first assertion pins the premise, so if core ever stops encoding, the test says why the decode exists.

Full suite: **740 tests, 2393 assertions, 0 failures**, 1 skipped (the pre-existing multisite-only test). `phpcs` clean, no ignores.

Note on local verification: the container the suite ran in has no xdebug/pcov, so no `clover.xml` is produced and the 85% `coverage-check` step could not run locally. CI installs xdebug on the runner, so the gate runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
