### PR TITLE
chore: bump the plugin version to 7.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-beta.1",
+  "version": "7.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beyondwords-wordpress-plugin",
-      "version": "7.0.0-beta.1",
+      "version": "7.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/api-fetch": "^7.51.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beyondwords-wordpress-plugin",
-  "version": "7.0.0-beta.1",
+  "version": "7.0.0-rc.1",
   "private": true,
   "description": "BeyondWords WordPress Plugin",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: beyondwords, stuartmcalpine
 Donate link: https://beyondwords.io
 Tags: text-to-speech, tts, audio, AI, voice cloning
-Stable tag: 7.0.0-beta.1
+Stable tag: 7.0.0-rc.1
 Requires at least: 6.6
 Requires PHP: 8.0
 Tested up to: 7.0

--- a/speechkit.php
+++ b/speechkit.php
@@ -15,7 +15,7 @@ declare( strict_types = 1 );
  * Description:       The effortless way to make content listenable. Automatically create audio versions and embed via our customizable player.
  * Author:            BeyondWords
  * Author URI:        https://beyondwords.io
- * Version:           7.0.0-beta.1
+ * Version:           7.0.0-rc.1
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       speechkit
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 // phpcs:disable
-define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-beta.1');
+define('BEYONDWORDS__PLUGIN_VERSION', '7.0.0-rc.1');
 define('BEYONDWORDS__PLUGIN_DIR',     plugin_dir_path(__FILE__));
 define('BEYONDWORDS__PLUGIN_URI',     plugin_dir_url(__FILE__));
 // phpcs:enable


### PR DESCRIPTION
Bumps the plugin version from `7.0.0-beta.1` to `7.0.0-rc.1`, moving 7.0.0 from beta to its first release candidate.

## What changed

Ran `scripts/bump-version.sh 7.0.0-rc.1`, which sets and then verifies the version in all five places it lives:

- `speechkit.php` plugin header `Version:`
- `BEYONDWORDS__PLUGIN_VERSION` in the same file
- `version` in `package.json`
- root `version` and `packages[""].version` in `package-lock.json`
- `Stable tag:` in `readme.txt`

## Notes for reviewers

- `7.0.0-rc.1`, not `7.0-rc.1` — the bump script enforces strict three-part semver, and it matches the existing `7.0.0-beta.1` form.
- The `== Changelog ==` block stays headed `= 7.0.0 =` / "Release date: tbc". An rc is a pre-release of that same version, so the heading is still correct, and the script deliberately doesn't touch the changelog.
- No changelog entry for this PR — it's a release chore with no user-visible effect beyond the version string itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)