### PR TITLE
Poll content status before embedding the block-editor Preview panel player

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ Release date: 11th August 2026
 
 **Fixes**
 
+* [#618](https://github.com/beyondwords-io/wordpress-plugin/pull/618) Poll content status before embedding the block-editor Preview panel player, so a still-processing post (more likely with a customised voice/model) no longer shows a broken preview.
 * [#613](https://github.com/beyondwords-io/wordpress-plugin/pull/613) Fix author names with an ampersand showing as `Smith &amp; Sons` in the BeyondWords dashboard.
 * [#612](https://github.com/beyondwords-io/wordpress-plugin/pull/612) Fix tags with an ampersand showing as `r&amp;d` in the BeyondWords dashboard.
 * [#610](https://github.com/beyondwords-io/wordpress-plugin/pull/610) Stop the bulk "Generate audio" notice counting skipped posts as failures.

--- a/src/editor/components/play-audio/hooks.js
+++ b/src/editor/components/play-audio/hooks.js
@@ -5,7 +5,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -65,8 +65,12 @@ export function useBeyondWordsNamespace() {
 /**
  * Create a (preview) BeyondWords player once its content is ready.
  *
- * A contentId that appears during this session may still be processing, so it
- * polls until `processed` before embedding (see lib/poll-content-status.js).
+ * Always confirms `processed` before embedding a contentId, whether it just
+ * appeared this session or was already on the post when the editor opened —
+ * a just-published, still-processing post (e.g. a slower voice/model
+ * override) is otherwise indistinguishable from a long-finished one. Mirrors
+ * the classic editor metabox, which polls unconditionally for the same
+ * reason. See lib/poll-content-status.js.
  *
  * @param {Object}      options              Options.
  * @param {HTMLElement} options.target       Player mount node.
@@ -93,10 +97,6 @@ export function useBeyondWordsPlayer( {
 		isPolling: false,
 		timedOut: false,
 	} );
-
-	// Content that existed at mount finished processing long ago and embeds
-	// immediately; only a contentId appearing during this session polls first.
-	const mountContentIdRef = useRef( contentId );
 
 	useEffect( () => {
 		if ( ! BeyondWords?.Player || ! target ) {
@@ -145,9 +145,9 @@ export function useBeyondWordsPlayer( {
 			setPlayer( newPlayer );
 		};
 
-		if ( contentId && contentId !== mountContentIdRef.current ) {
-			// Session-fresh content: poll until processed, then embed, so a 404
-			// is never CDN-cached for still-processing content.
+		if ( contentId ) {
+			// Poll until processed, then embed, so a 404 is never CDN-cached
+			// for content that's still processing.
 			setPollState( {
 				status: undefined,
 				isPolling: true,
@@ -187,8 +187,8 @@ export function useBeyondWordsPlayer( {
 					// Aborted (unmount or dependency change) — nothing to do.
 				} );
 		} else {
-			// Already-processed content (present at mount) or client-side
-			// integration (keyed on sourceId): nothing to poll, embed now.
+			// Client-side integration, keyed on sourceId: nothing to poll,
+			// embed now.
 			setPollState( {
 				status: undefined,
 				isPolling: false,

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -1,18 +1,40 @@
 /**
  * @group block-editor
- * @covers src/editor/components/preview-panel/,src/editor/components/error-notice/
+ * @covers src/editor/components/preview-panel/,src/editor/components/error-notice/,src/editor/components/play-audio/
  */
 
-/* global cy, beforeEach, context, it */
+/* global Cypress, cy, beforeEach, context, it, expect */
+
+const PLAYER_SCRIPT_SRC =
+	'https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js';
+
+/**
+ * Stub the BeyondWords player SDK instead of loading the real CDN script.
+ *
+ * The real script's load time isn't deterministic in CI, which is why the
+ * poll-before-embed behaviour (src/editor/components/play-audio/hooks.js)
+ * wasn't covered here before; stubbing it removes that non-determinism so
+ * `window.BeyondWords.Player` calls can be asserted on directly.
+ */
+function stubPlayerScript() {
+	cy.intercept( 'GET', PLAYER_SCRIPT_SRC, {
+		headers: { 'content-type': 'application/javascript' },
+		body: `
+			window.__beyondwordsPlayerCalls = [];
+			window.BeyondWords = {
+				Player: function ( params ) {
+					window.__beyondwordsPlayerCalls.push( params );
+					this.destroy = function () {};
+				},
+			};
+		`,
+	} ).as( 'playerScript' );
+}
 
 context( 'Block Editor: Preview panel', () => {
 	beforeEach( () => {
 		cy.login();
 	} );
-
-	// Note: the block-editor player-preview poll is deliberately not covered
-	// here. It only starts once the CDN player SDK global is available, which
-	// isn't deterministic in CI, so a block spinner assertion is flaky.
 
 	it( 'shows a BeyondWords error message in the Preview panel', () => {
 		cy.createTestPost( {
@@ -34,6 +56,128 @@ context( 'Block Editor: Preview panel', () => {
 			cy.get( '.beyondwords-sidebar__preview' )
 				.find( '.beyondwords-sidebar__post-status-description--error' )
 				.should( 'contain', 'Cypress preview error' );
+		} );
+	} );
+
+	it( 'waits for a still-processing voice-customised preview instead of embedding it early', () => {
+		const projectId = Cypress.expose( 'projectId' );
+		const contentId = 'cypress-voice-preview-still-processing';
+
+		cy.createTestPost( {
+			title: 'Cypress Test: preview panel voice customised, still processing',
+			status: 'publish',
+			postType: 'post',
+		} ).then( ( postId ) => {
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_project_id',
+				metaValue: projectId,
+			} );
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_content_id',
+				metaValue: contentId,
+			} );
+			// Voice customisation: a non-default voice/model can take longer to
+			// process than the project default, widening the window where the
+			// content is still processing when the editor is opened.
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_language_code',
+				metaValue: 'en_US',
+			} );
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_body_voice_id',
+				metaValue: '9001',
+			} );
+
+			cy.intercept(
+				'GET',
+				// apiFetch appends `_locale`, hence the trailing wildcard.
+				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
+				{ statusCode: 200, body: { status: 'processing' } }
+			).as( 'statusCheck' );
+
+			stubPlayerScript();
+
+			cy.visitPostEditorById( postId );
+			cy.openBeyondwordsPluginSidebar();
+
+			cy.wait( '@statusCheck' );
+
+			cy.get( '.beyondwords-sidebar__preview' )
+				.find( '.beyondwords-player-loading' )
+				.should( 'contain', 'Generating' );
+
+			// The still-processing content must never reach the player SDK —
+			// embedding it would 404 (and the CDN would cache that 404).
+			cy.window()
+				.its( '__beyondwordsPlayerCalls' )
+				.should( 'have.length', 0 );
+		} );
+	} );
+
+	it( 'embeds a voice-customised preview once it has finished processing', () => {
+		const projectId = Cypress.expose( 'projectId' );
+		const contentId = 'cypress-voice-preview-processed';
+
+		cy.createTestPost( {
+			title: 'Cypress Test: preview panel voice customised, processed',
+			status: 'publish',
+			postType: 'post',
+		} ).then( ( postId ) => {
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_project_id',
+				metaValue: projectId,
+			} );
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_content_id',
+				metaValue: contentId,
+			} );
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_language_code',
+				metaValue: 'en_US',
+			} );
+			cy.task( 'setPostMeta', {
+				postId,
+				metaKey: 'beyondwords_body_voice_id',
+				metaValue: '9001',
+			} );
+
+			cy.intercept(
+				'GET',
+				// apiFetch appends `_locale`, hence the trailing wildcard.
+				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
+				{ statusCode: 200, body: { status: 'processed' } }
+			).as( 'statusCheck' );
+
+			stubPlayerScript();
+
+			cy.visitPostEditorById( postId );
+			cy.openBeyondwordsPluginSidebar();
+
+			cy.wait( '@statusCheck' );
+
+			// PlayAudio also mounts in the core "Post" tab's document-setting
+			// panel (src/editor/block/document-setting/index.js), so more than
+			// one instance can embed for the same post — assert every embed
+			// used the right content, not an exact count.
+			cy.window()
+				.its( '__beyondwordsPlayerCalls' )
+				.should( 'have.length.at.least', 1 )
+				.then( ( calls ) => {
+					calls.forEach( ( call ) => {
+						expect( call ).to.include( { contentId, projectId } );
+					} );
+				} );
+
+			cy.get( '.beyondwords-sidebar__preview' )
+				.find( '.beyondwords-player-loading' )
+				.should( 'not.exist' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

- The block-editor Preview panel skipped its "wait until processed" poll for any content ID that was already on the post when the editor mounted — it only polled a content ID that appeared later in the same browser session. Opening the editor on a just-published post whose audio was still processing embedded the player immediately, 404ing (and letting the CDN cache that 404). The classic editor never had this shortcut, which is why only the block editor showed the bug.
- Voice customisation makes this far more likely to hit: a non-default voice/model can take noticeably longer to process than the project default, widening the window where a post is still processing when the editor is opened — matching reports of the Preview panel failing to render for a voice-customised post despite the content eventually generating fine and playing on the frontend.
- `src/editor/components/play-audio/hooks.js` now always confirms `processed` before embedding, mirroring the classic editor.
- Added two Cypress tests to `preview-panel.cy.js` covering a voice-customised post: one confirms the panel shows "Generating…" and never calls the player SDK while status is `processing`, the other confirms it embeds once status is `processed`. Both stub the player SDK script for determinism (the poll path was previously left uncovered here due to real-CDN flakiness).

## Test plan

- [x] `npm run lint:js` / `wp-scripts format --check` on the changed files
- [x] `npm run test:unit` (Jest) — all suites pass, unaffected
- [x] Ran the new spec live against a local wp-env: `npx cypress run --spec 'tests/cypress/e2e/block-editor/preview-panel.cy.js'` — all 3 tests pass
- [x] Verified regression coverage: reverted `hooks.js` to the pre-fix version and reran the same spec — the new "still processing" test correctly fails (`cy.wait` for the status check times out, since the old code never checks status before embedding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)