### PR TITLE
Run the Cypress suite with pretty permalinks, fixing the Preview panel poll spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -636,13 +636,11 @@ jobs:
 
       - run: wp plugin list
 
-      - name: Set permalinks
-        run: |
-          wp rewrite structure '/%postname%/' --hard
-          wp rewrite flush --hard
-
+      # cypress.config.js `setupDatabase` owns the permalink structure: its
+      # wp-reset call would wipe anything set here. The router is what lets
+      # `php -S`, which cannot rewrite, serve those pretty URLs.
       - name: Start PHP web server
-        run: sudo php -S localhost:8889 -t /usr/share/nginx/html &
+        run: sudo php -S localhost:8889 -t /usr/share/nginx/html ${{ github.workspace }}/tests/cypress/scripts/router.php &
 
       - name: Cypress run
         uses: cypress-io/github-action@v7

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -109,6 +109,10 @@ function setupNodeEvents( on, config ) {
 				'plugin deactivate --all',
 				// eslint-disable-next-line max-len
 				'plugin activate speechkit Basic-Auth cpt-active cpt-inactive cpt-unsupported beyondwords-mock-rest-api-responses/mock-rest-api-responses.php',
+				// Match how real sites run: the reset above restores plain
+				// permalinks, which serve REST as `?rest_route=` instead of
+				// `/wp-json/`.
+				"rewrite structure '/%postname%/'",
 				// Configure plugin credentials for most tests
 				`option update beyondwords_api_key '${ apiKey }'`,
 				`option update beyondwords_project_id '${ projectId }'`,
@@ -139,6 +143,7 @@ function setupNodeEvents( on, config ) {
 				'plugin deactivate --all',
 				// eslint-disable-next-line max-len
 				'plugin activate speechkit Basic-Auth cpt-active cpt-inactive cpt-unsupported beyondwords-mock-rest-api-responses',
+				"rewrite structure '/%postname%/'",
 			] );
 
 			hasSetupDatabase = false;

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,7 @@ Release date: 11th August 2026
 
 **Codebase Enhancements**
 
+* [#619](https://github.com/beyondwords-io/wordpress-plugin/pull/619) Fix the block editor Preview panel Cypress spec failing on the content-status poll.
 * [#591](https://github.com/beyondwords-io/wordpress-plugin/pull/591) Refresh the developer documentation in `doc/` against the v7 codebase.
 * [#608](https://github.com/beyondwords-io/wordpress-plugin/pull/608) Fix the intermittent detached-DOM failures in the block editor Cypress specs.
 * [#607](https://github.com/beyondwords-io/wordpress-plugin/pull/607) Update two PHPUnit tests left stale by the Script-only Source removal.

--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,7 @@ Release date: 11th August 2026
 
 **Codebase Enhancements**
 
-* [#619](https://github.com/beyondwords-io/wordpress-plugin/pull/619) Fix the block editor Preview panel Cypress spec failing on the content-status poll.
+* [#619](https://github.com/beyondwords-io/wordpress-plugin/pull/619) Run the Cypress suite with pretty permalinks, fixing the block editor Preview panel content-status poll spec.
 * [#591](https://github.com/beyondwords-io/wordpress-plugin/pull/591) Refresh the developer documentation in `doc/` against the v7 codebase.
 * [#608](https://github.com/beyondwords-io/wordpress-plugin/pull/608) Fix the intermittent detached-DOM failures in the block editor Cypress specs.
 * [#607](https://github.com/beyondwords-io/wordpress-plugin/pull/607) Update two PHPUnit tests left stale by the Script-only Source removal.

--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ Yes. The plugin normally connects WordPress to BeyondWords through our REST API.
 
 = 7.0.0 =
 
-Release date: 11th August 2026
+Release date: 12th August 2026
 
 **Enhancements**
 

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -26,18 +26,18 @@ function stubPlayerSdk() {
 }
 
 /**
- * Match the content-status poll by its content ID.
+ * Match the content-status REST call for a content ID.
  *
- * `apiFetch` percent-encodes the REST path into `rest_route` under the test
- * site's plain permalinks, so a slash-separated glob never matches — the ID
- * is the one part of the URL that survives either form intact.
+ * The gaps are loose because `apiFetch` percent-encodes the path into
+ * `rest_route` under the test site's plain permalinks, so the slashes between
+ * `beyondwords`, `content` and the ID arrive as `%2F`.
  *
  * @param {string} contentId BeyondWords content ID.
  *
  * @return {RegExp} Matcher for the content-status request.
  */
 function contentStatusRoute( contentId ) {
-	return new RegExp( contentId );
+	return new RegExp( `beyondwords.+content.+${ contentId }` );
 }
 
 context( 'Block Editor: Preview panel', () => {

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -26,22 +26,18 @@ function stubPlayerSdk() {
 }
 
 /**
- * Match the plugin's content-status route under either permalink structure.
+ * Match the content-status poll by its content ID.
  *
- * `apiFetch` percent-encodes the path into `rest_route` when permalinks are
- * plain, so a slash-separated glob never matches.
+ * `apiFetch` percent-encodes the REST path into `rest_route` under the test
+ * site's plain permalinks, so a slash-separated glob never matches — the ID
+ * is the one part of the URL that survives either form intact.
  *
- * @param {string} projectId BeyondWords project ID.
  * @param {string} contentId BeyondWords content ID.
  *
- * @return {RegExp} Matcher for the content-status REST route.
+ * @return {RegExp} Matcher for the content-status request.
  */
-function contentStatusRoute( projectId, contentId ) {
-	const sep = '(?:/|%2F)';
-
-	return new RegExp(
-		`beyondwords${ sep }v1${ sep }projects${ sep }${ projectId }${ sep }content${ sep }${ contentId }`
-	);
+function contentStatusRoute( contentId ) {
+	return new RegExp( contentId );
 }
 
 context( 'Block Editor: Preview panel', () => {
@@ -105,7 +101,7 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept( 'GET', contentStatusRoute( projectId, contentId ), {
+			cy.intercept( 'GET', contentStatusRoute( contentId ), {
 				statusCode: 200,
 				body: { status: 'processing' },
 			} ).as( 'statusCheck' );
@@ -159,7 +155,7 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept( 'GET', contentStatusRoute( projectId, contentId ), {
+			cy.intercept( 'GET', contentStatusRoute( contentId ), {
 				statusCode: 200,
 				body: { status: 'processed' },
 			} ).as( 'statusCheck' );

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -25,21 +25,6 @@ function stubPlayerSdk() {
 	} );
 }
 
-/**
- * Match the content-status REST call for a content ID.
- *
- * The gaps are loose because `apiFetch` percent-encodes the path into
- * `rest_route` under the test site's plain permalinks, so the slashes between
- * `beyondwords`, `content` and the ID arrive as `%2F`.
- *
- * @param {string} contentId BeyondWords content ID.
- *
- * @return {RegExp} Matcher for the content-status request.
- */
-function contentStatusRoute( contentId ) {
-	return new RegExp( `beyondwords.+content.+${ contentId }` );
-}
-
 context( 'Block Editor: Preview panel', () => {
 	beforeEach( () => {
 		cy.login();
@@ -101,10 +86,12 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept( 'GET', contentStatusRoute( contentId ), {
-				statusCode: 200,
-				body: { status: 'processing' },
-			} ).as( 'statusCheck' );
+			// apiFetch appends `_locale`, hence the trailing wildcard.
+			cy.intercept(
+				'GET',
+				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
+				{ statusCode: 200, body: { status: 'processing' } }
+			).as( 'statusCheck' );
 
 			stubPlayerSdk();
 
@@ -155,10 +142,12 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept( 'GET', contentStatusRoute( contentId ), {
-				statusCode: 200,
-				body: { status: 'processed' },
-			} ).as( 'statusCheck' );
+			// apiFetch appends `_locale`, hence the trailing wildcard.
+			cy.intercept(
+				'GET',
+				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
+				{ statusCode: 200, body: { status: 'processed' } }
+			).as( 'statusCheck' );
 
 			stubPlayerSdk();
 

--- a/tests/cypress/e2e/block-editor/preview-panel.cy.js
+++ b/tests/cypress/e2e/block-editor/preview-panel.cy.js
@@ -5,30 +5,43 @@
 
 /* global Cypress, cy, beforeEach, context, it, expect */
 
-const PLAYER_SCRIPT_SRC =
-	'https://proxy.beyondwords.io/npm/@beyondwords/player@latest/dist/umd.js';
+/**
+ * Stub the BeyondWords player SDK before the editor boots.
+ *
+ * With the namespace already present the plugin never appends the CDN script,
+ * so `window.BeyondWords.Player` calls can be asserted on directly without
+ * depending on a cross-origin load — which cy.intercept cannot stub reliably
+ * once an earlier spec has left the script in the browser cache.
+ */
+function stubPlayerSdk() {
+	cy.on( 'window:before:load', ( win ) => {
+		win.__beyondwordsPlayerCalls = [];
+		win.BeyondWords = {
+			Player: function ( params ) {
+				win.__beyondwordsPlayerCalls.push( params );
+				this.destroy = function () {};
+			},
+		};
+	} );
+}
 
 /**
- * Stub the BeyondWords player SDK instead of loading the real CDN script.
+ * Match the plugin's content-status route under either permalink structure.
  *
- * The real script's load time isn't deterministic in CI, which is why the
- * poll-before-embed behaviour (src/editor/components/play-audio/hooks.js)
- * wasn't covered here before; stubbing it removes that non-determinism so
- * `window.BeyondWords.Player` calls can be asserted on directly.
+ * `apiFetch` percent-encodes the path into `rest_route` when permalinks are
+ * plain, so a slash-separated glob never matches.
+ *
+ * @param {string} projectId BeyondWords project ID.
+ * @param {string} contentId BeyondWords content ID.
+ *
+ * @return {RegExp} Matcher for the content-status REST route.
  */
-function stubPlayerScript() {
-	cy.intercept( 'GET', PLAYER_SCRIPT_SRC, {
-		headers: { 'content-type': 'application/javascript' },
-		body: `
-			window.__beyondwordsPlayerCalls = [];
-			window.BeyondWords = {
-				Player: function ( params ) {
-					window.__beyondwordsPlayerCalls.push( params );
-					this.destroy = function () {};
-				},
-			};
-		`,
-	} ).as( 'playerScript' );
+function contentStatusRoute( projectId, contentId ) {
+	const sep = '(?:/|%2F)';
+
+	return new RegExp(
+		`beyondwords${ sep }v1${ sep }projects${ sep }${ projectId }${ sep }content${ sep }${ contentId }`
+	);
 }
 
 context( 'Block Editor: Preview panel', () => {
@@ -92,14 +105,12 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept(
-				'GET',
-				// apiFetch appends `_locale`, hence the trailing wildcard.
-				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
-				{ statusCode: 200, body: { status: 'processing' } }
-			).as( 'statusCheck' );
+			cy.intercept( 'GET', contentStatusRoute( projectId, contentId ), {
+				statusCode: 200,
+				body: { status: 'processing' },
+			} ).as( 'statusCheck' );
 
-			stubPlayerScript();
+			stubPlayerSdk();
 
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsPluginSidebar();
@@ -148,14 +159,12 @@ context( 'Block Editor: Preview panel', () => {
 				metaValue: '9001',
 			} );
 
-			cy.intercept(
-				'GET',
-				// apiFetch appends `_locale`, hence the trailing wildcard.
-				`**/beyondwords/v1/projects/${ projectId }/content/${ contentId }*`,
-				{ statusCode: 200, body: { status: 'processed' } }
-			).as( 'statusCheck' );
+			cy.intercept( 'GET', contentStatusRoute( projectId, contentId ), {
+				statusCode: 200,
+				body: { status: 'processed' },
+			} ).as( 'statusCheck' );
 
-			stubPlayerScript();
+			stubPlayerSdk();
 
 			cy.visitPostEditorById( postId );
 			cy.openBeyondwordsPluginSidebar();

--- a/tests/cypress/e2e/plugins/amp.cy.js
+++ b/tests/cypress/e2e/plugins/amp.cy.js
@@ -3,7 +3,7 @@
  * @covers src/player/renderer/class-amp.php
  */
 
-/* global cy, before, beforeEach, after, context, it */
+/* global cy, before, beforeEach, after, context, it, URL */
 
 context( 'Plugins: AMP', () => {
 	before( () => {
@@ -37,8 +37,10 @@ context( 'Plugins: AMP', () => {
 				cy.hasPlayerInstances( 1 );
 
 				cy.url().then( ( url ) => {
-					// View post as AMP by appending &amp=1
-					cy.visit( `${ url }&amp=1` );
+					// Pretty permalinks carry no query string to append to.
+					const ampUrl = new URL( url );
+					ampUrl.searchParams.set( 'amp', '1' );
+					cy.visit( ampUrl.toString() );
 				} );
 
 				cy.get( 'amp-iframe' ).should( 'exist' );

--- a/tests/cypress/scripts/router.php
+++ b/tests/cypress/scripts/router.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Request router for the CI web server (`php -S`), which cannot rewrite.
+ *
+ * Pretty permalinks are set in cypress.config.js `setupDatabase`, so anything
+ * that isn't a real file has to reach WordPress the way Apache's .htaccess
+ * fallback does — otherwise `/wp-json/…` and post permalinks 404.
+ */
+
+$bw_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+
+// Let the server handle real files and directory indexes itself.
+if ( file_exists( $_SERVER['DOCUMENT_ROOT'] . $bw_path ) ) {
+	return false;
+}
+
+require $_SERVER['DOCUMENT_ROOT'] . '/index.php';


### PR DESCRIPTION
## Problem

`tests/cypress/e2e/block-editor/preview-panel.cy.js` fails on `main`:

```
1) Block Editor: Preview panel
     waits for a still-processing voice-customised preview instead of embedding it early:
   CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms`
   for the 1st request to the route: `statusCheck`. No request ever occurred.
```

## Cause

The test environment was running **plain permalinks**, which almost no real site does.

The workflow already sets a permalink structure before starting Cypress:

```yaml
- name: Set permalinks
  run: |
    wp rewrite structure '/%postname%/' --hard
```

…but the first spec's `setupDatabase` task runs `wp reset reset --yes` (wp-reset), which
restores WordPress defaults and wipes it. So from spec 1 onwards, every spec ran against
plain permalinks, and that step was dead configuration.

Under plain permalinks `get_rest_url()` returns the query-string form, so the poll in
`src/editor/components/play-audio/hooks.js` — `apiFetch( { path } )` — requests:

```
/index.php?rest_route=%2Fbeyondwords%2Fv1%2Fprojects%2F9969%2Fcontent%2F<id>&_locale=user
```

The spec's glob (`**/beyondwords/v1/projects/<id>/content/<id>*`) has no slashes to match
against, so the intercept never fired, `cy.wait( '@statusCheck' )` timed out, and the poll
hit the real endpoint instead of the stub. Classic-editor specs use the same glob shape and
pass because that code builds URLs as `restUrl + 'beyondwords/v1/…'`, keeping the slashes
literal.

## Fix

Test-only — no source change.

* **Set the permalink structure in `setupDatabase`**, after the reset that was wiping it, so
  the suite exercises the `/wp-json/…` routes real sites use. The dead workflow step is
  removed, with a comment recording what owns the structure now.
* **Add `tests/cypress/scripts/router.php`** for the CI web server. CI serves the site with
  `php -S`, which has no rewrite support, so pretty URLs would 404 wholesale; the router
  hands non-file requests to `index.php` the way Apache's `.htaccess` fallback does.
* **Match the poll with a plain path glob** again, now that the URL has literal slashes in
  it. No separator-encoding workaround in the spec.
* **Stub the player SDK via `window:before:load`** instead of intercepting the CDN script.
  With the namespace already defined the plugin never appends the script, so the assertions
  no longer depend on intercepting a cross-origin request that an earlier spec may have left
  in the browser cache — which is how the real player ended up running in the CI failure.

One other spec depended on the old structure: `plugins/amp.cy.js` built its AMP URL as
`` `${ url }&amp=1` ``, which only parsed while every post URL already carried a query string
(`/?p=123`). It now sets the query var through `URL`/`searchParams`, so it is correct under
either structure.

Note that `embeds a voice-customised preview once it has finished processing` had never
actually executed in CI: `cypress-fail-fast` skipped it behind the failing test. It runs and
passes here, so both sides of the poll-then-embed behaviour are now covered.

## Verification

```
npx cypress run --browser chrome --spec 'tests/cypress/e2e/block-editor/preview-panel.cy.js'
→ 3 passing
```

Because the permalink change is environment-wide, the full suite was also run locally with
fail-fast disabled (`--expose failFastEnabled=false`) so that every permalink-related failure
surfaced rather than being skipped behind the first one:

```
27 specs, 231 tests → 221 passing, 8 pending, 2 failing
✖ plugins/amp.cy.js   (both failures — the `&amp=1` URL above)
```

`plugins/amp.cy.js` passes with that spec fixed; no other spec was affected.

The router was verified standalone against a stub docroot: `/`, `/my-post/` and
`/wp-json/…?_locale=user` reach WordPress, while `/style.css` and `/wp-admin/` are served
directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
