### PR TITLE
Prevent a fatal error when the plugin is replaced mid-request

### DIFF
--- a/doc/plugin-upgrades.md
+++ b/doc/plugin-upgrades.md
@@ -1,0 +1,43 @@
+# Autoloading during a plugin upgrade
+
+Why [src/api/class-client.php](../src/api/class-client.php) resolves the API URL
+in `init()` instead of inside `filter_http_request_args()`.
+
+## The problem
+
+`Plugin_Upgrader` deletes the installed `speechkit/` directory and writes the new
+copy **within a request that already loaded the old version**. Our hooks are
+still registered, and `upgrader_process_complete` runs `wp_update_plugins()`,
+which issues an HTTP request — so `http_request_args` fires after the files
+backing our classes have gone.
+
+Any class the callback autoloads at that point is a fatal error, because
+Composer's classmap still points at the deleted path:
+
+```
+Warning: include(.../speechkit/vendor/composer/../../src/core/class-urls.php): Failed to open stream: No such file or directory
+Fatal error: Uncaught Error: Class "BeyondWords\Core\Urls" not found in .../src/api/class-client.php:93
+```
+
+The install itself has already succeeded by then, so the site recovers on the
+next request — but the user sees a white screen and gets a fatal-error email.
+
+It bites hardest on a **downgrade** (7.x → 6.x), where the replacement payload
+has an entirely different file layout and none of the 7.x paths resolve. A
+same-branch update only survives by luck: the new copy happens to contain a file
+at the same path.
+
+## The rule
+
+**Anything reachable from a hook that can fire during an upgrade must already be
+in memory.** In practice that means `http_request_args` (every outbound request,
+including core's update checks) and `admin_notices` (rendered on `update.php`).
+
+`Client::init()` runs during bootstrap, while the files are guaranteed to exist,
+so resolving `Urls::get_api_url()` there loads `Urls` for the whole request. That
+also covers `Settings::maybe_print_missing_creds_warning()`, which reaches for
+`Urls::get_dashboard_url()` from `admin_notices`.
+
+A fix can only ever protect *later* downgrades: the code running during the
+upgrade is the version being replaced, so a release can't repair the one before
+it.

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,15 @@ Yes. The plugin normally connects WordPress to BeyondWords through our REST API.
 
 == Changelog ==
 
+= 7.0.1 =
+
+Release date: TBC
+
+**Fixes**
+
+* [#621](https://github.com/beyondwords-io/wordpress-plugin/pull/621) Fix the fatal error shown when the plugin is replaced with a different version from the Plugins screen.
+    * Switching away from an existing 7.0.0 install still shows it once; the version being replaced has to be 7.0.1 or later for the fix to apply.
+
 = 7.0.0 =
 
 Release date: 12th August 2026

--- a/src/api/class-client.php
+++ b/src/api/class-client.php
@@ -67,11 +67,24 @@ class Client {
 	const VOICES_REQUEST_TIMEOUT = 8;
 
 	/**
+	 * API base URL, resolved once at bootstrap.
+	 *
+	 * @since 7.0.1
+	 *
+	 * @var string|null Null until `init()` runs.
+	 */
+	private static ?string $api_url = null;
+
+	/**
 	 * Register WordPress hooks.
 	 *
 	 * Must run early in the bootstrap so the filter precedes any API call.
 	 */
 	public static function init(): void {
+		// WordPress fires http_request_args mid-upgrade, after the plugin files have
+		// been replaced, so resolve (and load) Urls now — see doc/plugin-upgrades.md.
+		self::$api_url = \BeyondWords\Core\Urls::get_api_url();
+
 		// The VIP warning targets raised timeouts; this filter only adds headers.
 		// phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 		add_filter( 'http_request_args', [ self::class, 'filter_http_request_args' ], 10, 2 );
@@ -90,7 +103,7 @@ class Client {
 			return $args;
 		}
 
-		$api_url = \BeyondWords\Core\Urls::get_api_url();
+		$api_url = (string) self::$api_url;
 
 		if ( '' === $api_url || ! str_starts_with( $url, $api_url ) ) {
 			return $args;

--- a/tests/phpunit/api/test-client.php
+++ b/tests/phpunit/api/test-client.php
@@ -42,6 +42,48 @@ class ClientTest extends TestCase
     /**
      * @test
      */
+    public function init_loads_the_urls_class()
+    {
+        Client::init();
+
+        // Autoload disabled: Urls must already be in memory, so the filter never
+        // hits the filesystem mid-upgrade — see doc/plugin-upgrades.md.
+        $this->assertTrue(class_exists(Urls::class, false));
+    }
+
+    /**
+     * @test
+     */
+    public function filter_http_request_args_uses_the_url_resolved_at_init()
+    {
+        update_option('beyondwords_api_key', 'SECRET-API-KEY');
+
+        $property = new ReflectionProperty(Client::class, 'api_url');
+        $property->setAccessible(true);
+        $property->setValue(null, 'https://api.example.test/v1');
+
+        $args = Client::filter_http_request_args(
+            ['method' => 'GET', 'headers' => []],
+            'https://api.example.test/v1/projects/1234'
+        );
+
+        $this->assertSame('SECRET-API-KEY', $args['headers']['X-Api-Key']);
+
+        $args = Client::filter_http_request_args(
+            ['method' => 'GET', 'headers' => []],
+            Urls::get_api_url() . '/projects/1234'
+        );
+
+        $this->assertArrayNotHasKey('X-Api-Key', $args['headers']);
+
+        Client::init();
+
+        delete_option('beyondwords_api_key');
+    }
+
+    /**
+     * @test
+     */
     public function filter_http_request_args_skips_non_beyondwords_urls()
     {
         update_option('beyondwords_api_key', 'SECRET-API-KEY');


### PR DESCRIPTION
## Why

Replacing 7.0.0 with 6.x from the Plugins screen produces a white screen and a fatal-error email, even though the install itself succeeds:

```
Warning: include(.../speechkit/vendor/composer/../../src/core/class-urls.php): Failed to open stream: No such file or directory
Fatal error: Uncaught Error: Class "BeyondWords\Core\Urls" not found in .../src/api/class-client.php:93
```

`Plugin_Upgrader` deletes the installed directory and writes the replacement **within a request that already loaded the old version**. Our hooks are still registered, and `upgrader_process_complete` runs `wp_update_plugins()` — so `http_request_args` fires after the files backing our classes have gone, and `Client::filter_http_request_args()` autoloads `Urls` from a path that no longer exists.

This is new in 7.0.0: v6.x registers no hooks from `ApiClient`, so a running 6.x never touches the autoloader mid-upgrade.

## What changed

`Client::init()` resolves `Urls::get_api_url()` once at bootstrap, while the files are guaranteed to exist, and the filter reads that cached value. Loading `Urls` early also covers `Settings::maybe_print_missing_creds_warning()`, which reaches for `Urls::get_dashboard_url()` from `admin_notices` — rendered on `update.php`.

Rationale and the general rule are in [doc/plugin-upgrades.md](doc/plugin-upgrades.md).

## Note

This can only protect *later* downgrades. The code running during an upgrade is the version being replaced, so a downgrade **from** an already-released 7.0.0 still crashes — nothing shipped afterwards can change that.

## Tests

* `init_loads_the_urls_class` — `Urls` is in memory with autoload disabled after `init()`.
* `filter_http_request_args_uses_the_url_resolved_at_init` — the filter matches the URL cached at init, not one resolved at call time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)